### PR TITLE
Refine/error handling

### DIFF
--- a/pkg/ecode/status.go
+++ b/pkg/ecode/status.go
@@ -1,6 +1,7 @@
 package ecode
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
@@ -20,6 +21,14 @@ func Errorf(code Code, format string, args ...interface{}) *Status {
 	return Error(code, fmt.Sprintf(format, args...))
 }
 
+func Parse(errMsg string) *Status {
+	st := &types.Status{}
+	if err := json.Unmarshal([]byte(errMsg), st); err != nil {
+		st.Message = errMsg
+	}
+	return &Status{s: st}
+}
+
 var _ Codes = &Status{}
 
 // Status statusError is an alias of a status proto
@@ -30,7 +39,11 @@ type Status struct {
 
 // Error implement error
 func (s *Status) Error() string {
-	return s.Message()
+	if s == nil {
+		return ""
+	}
+	b, _ := json.Marshal(s.s)
+	return string(b)
 }
 
 // Code return error code

--- a/pkg/ecode/status_test.go
+++ b/pkg/ecode/status_test.go
@@ -55,3 +55,28 @@ func TestEmpty(t *testing.T) {
 	st = nil
 	assert.Len(t, st.Details(), 0)
 }
+
+func TestParse(t *testing.T) {
+	var (
+		err error
+		st  *Status
+	)
+	t.Run("parse ecode.Status", func(t *testing.T) {
+		err = FromCode(RequestErr)
+		st = Parse(err.Error())
+		assert.Equal(t, RequestErr.Code(), st.Code())
+
+		errMsg := "name is required"
+		err = Error(RequestErr, errMsg)
+		st = Parse(err.Error())
+		assert.Equal(t, RequestErr.Code(), st.Code())
+		assert.Equal(t, errMsg, st.Message())
+	})
+
+	t.Run("parse ecode.Code", func(t *testing.T) {
+		err = ServerErr
+		st = Parse(err.Error())
+
+		assert.Equal(t, ServerErr.Error(), st.Message())
+	})
+}

--- a/pkg/ecode/status_test.go
+++ b/pkg/ecode/status_test.go
@@ -1,10 +1,16 @@
 package ecode
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/golang/protobuf/ptypes/timestamp"
+	pkgerr "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/go-kratos/kratos/pkg/ecode/types"
@@ -58,25 +64,65 @@ func TestEmpty(t *testing.T) {
 
 func TestParse(t *testing.T) {
 	var (
-		err error
-		st  *Status
+		errMsg string
+		st     *Status
 	)
 	t.Run("parse ecode.Status", func(t *testing.T) {
-		err = FromCode(RequestErr)
-		st = Parse(err.Error())
+		st = Parse(FromCode(RequestErr))
 		assert.Equal(t, RequestErr.Code(), st.Code())
 
-		errMsg := "name is required"
-		err = Error(RequestErr, errMsg)
-		st = Parse(err.Error())
+		errMsg = "name is required"
+		st = Parse(Error(RequestErr, errMsg))
 		assert.Equal(t, RequestErr.Code(), st.Code())
 		assert.Equal(t, errMsg, st.Message())
 	})
 
 	t.Run("parse ecode.Code", func(t *testing.T) {
-		err = ServerErr
-		st = Parse(err.Error())
+		st = Parse(ServerErr)
 
 		assert.Equal(t, ServerErr.Error(), st.Message())
+	})
+
+	t.Run("parse wrap error", func(t *testing.T) {
+		st = Parse(pkgerr.Wrap(ServerErr, "db is unavailable"))
+
+		assert.Equal(t, ServerErr.Code(), st.Code())
+	})
+
+	t.Run("parse general error", func(t *testing.T) {
+		errMsg = "something is wrong!"
+
+		st = Parse(errors.New(errMsg))
+		assert.Equal(t, errMsg, st.Message())
+		assert.Equal(t, ServerErr.Code(), st.Code())
+	})
+
+	t.Run("parse raw Canceled", func(t *testing.T) {
+		st = Parse(context.Canceled)
+
+		assert.Equal(t, Canceled.Code(), st.Code())
+		assert.Equal(t, Canceled.Message(), st.Message())
+	})
+
+	t.Run("parse raw DeadlineExceeded", func(t *testing.T) {
+		st = Parse(context.DeadlineExceeded)
+
+		assert.Equal(t, Deadline.Code(), st.Code())
+		assert.Equal(t, Deadline.Message(), st.Message())
+	})
+
+	t.Run("parse google grpc status", func(t *testing.T) {
+		errMsg = "record not found"
+
+		st = Parse(status.Error(codes.NotFound, errMsg))
+
+		assert.Equal(t, int(codes.NotFound), st.Code())
+		assert.Equal(t, errMsg, st.Message())
+	})
+
+	t.Run("parse nil", func(t *testing.T) {
+		st = Parse(nil)
+
+		assert.Equal(t, OK.Code(), st.Code())
 	})
 }


### PR DESCRIPTION
- provide an easy way to handling error across service boundaries

before:

```go
// Server end
func (s *rpcServer) Call(ctx context.Context, req *pb.Request) (*pb.Response, error) {
	if len(req.Name) < 1 {
		return nil, ecode.Error(ecode.RequestErr, "name is required")
	}
	return &pb.Response{Status: 1}, nil
}
```

```go
import (
	...
	st "github.com/go-kratos/kratos/pkg/net/rpc/warden/internal/status"
	"github.com/go-kratos/kratos/pkg/ecode/types"
	...
)

...

// Client end
reply, err := rpcCli.Call(ctx, req)
// got grpc.Status
gst := st.FromError(err)
if len(gst.Details()) > 0 {
	if st, ok := gst.Details()[0].(*types.Status); ok {
		// Use kratos ecode.Status.Code
	}
}
//  convert grpc Status to kratos ecode.Codes
ec := st.ToMetaCode(gst)
// Use ec.Code(), ec.Message()
```

now:
```go
// Client end
reply, err := rpcCli.Call(ctx, req)
if err != nil {
	// convert error to ecode.Status directly
	st := ecode.Parse(err)
	if st.Code() == ecode.RequestErr.Code() {
		// deal with bad request
	}
}
```