### PR TITLE
fix modPrefix error in windows

### DIFF
--- a/tool/kratos-gen-project/new.go
+++ b/tool/kratos-gen-project/new.go
@@ -26,7 +26,7 @@ func runNew(ctx *cli.Context) (err error) {
 		pwd, _ := os.Getwd()
 		p.path = filepath.Join(pwd, p.Name)
 	}
-	p.ModPrefix = modPath(p.path)
+	p.ModPrefix = strings.ReplaceAll(modPath(p.path), "\\", "/")
 	// creata a project
 	if err := create(); err != nil {
 		return err


### PR DESCRIPTION
windows 下 modPrefix 错误，以 \ 连接，导致 wndows 下创建服务时，-d 的参数只能是一层目录，不能成功创建如 app/admin 的多层目录