### PR TITLE
修复container/group在相同的key并发get时，可能会初始化多次的bug

### DIFF
--- a/pkg/container/group/group_test.go
+++ b/pkg/container/group/group_test.go
@@ -36,10 +36,10 @@ func TestGroupReset(t *testing.T) {
 	})
 
 	length := 0
-	g.objs.Range(func(_, _ interface{}) bool {
+	for _,_ = range g.objs {
 		length++
-		return true
-	})
+	}
+
 	assert.Equal(t, 0, length)
 
 	g.Get("/x/internal/dummy/user")
@@ -52,18 +52,16 @@ func TestGroupClear(t *testing.T) {
 	})
 	g.Get("/x/internal/dummy/user")
 	length := 0
-	g.objs.Range(func(_, _ interface{}) bool {
+	for _,_ = range g.objs {
 		length++
-		return true
-	})
+	}
 	assert.Equal(t, 1, length)
 
 	g.Clear()
 	length = 0
-	g.objs.Range(func(_, _ interface{}) bool {
+	for _,_ = range g.objs {
 		length++
-		return true
-	})
+	}
 	assert.Equal(t, 0, length)
 
 }


### PR DESCRIPTION
bug重现的代码示例：

type Apple struct {
	Color string
}

func main() {
	newFunc := func() interface{} {
		return &Apple{Color: strconv.FormatInt(time.Now().UnixNano(), 10)}
	}
	group := NewGroup(newFunc)
	for i := 1; i < 10; i++ {
		go func() {
			fmt.Println(group.Get("xx"))  // 相同的key，输出了不同的结果，证明被初始化了多次
		}()
	}
	time.Sleep(time.Second)
}