### PR TITLE
fix kratos new 时模板错误

### DIFF
--- a/tool/kratos-gen-project/templates/all/internal/dao/dao.go.tmpl
+++ b/tool/kratos-gen-project/templates/all/internal/dao/dao.go.tmpl
@@ -23,7 +23,7 @@ type Dao interface {
 	Close()
 	Ping(ctx context.Context) (err error)
 	// bts: -nullcache=&model.Article{ID:-1} -check_null_code=$!=nil&&$.ID==-1
-	Article(c context.Context, id int64) (*model.Article, error)
+	RawArticle(c context.Context, id int64) (*model.Article, error)
 }
 
 // dao dao.

--- a/tool/kratos-gen-project/templates/grpc/internal/dao/dao.go.tmpl
+++ b/tool/kratos-gen-project/templates/grpc/internal/dao/dao.go.tmpl
@@ -23,7 +23,7 @@ type Dao interface {
 	Close()
 	Ping(ctx context.Context) (err error)
 	// bts: -nullcache=&model.Article{ID:-1} -check_null_code=$!=nil&&$.ID==-1
-	Article(c context.Context, id int64) (*model.Article, error)
+	RawArticle(c context.Context, id int64) (*model.Article, error)
 }
 
 // dao dao.

--- a/tool/kratos-gen-project/templates/http/internal/dao/dao.go.tmpl
+++ b/tool/kratos-gen-project/templates/http/internal/dao/dao.go.tmpl
@@ -23,7 +23,7 @@ type Dao interface {
 	Close()
 	Ping(ctx context.Context) (err error)
 	// bts: -nullcache=&model.Article{ID:-1} -check_null_code=$!=nil&&$.ID==-1
-	Article(c context.Context, id int64) (*model.Article, error)
+	RawArticle(c context.Context, id int64) (*model.Article, error)
 }
 
 // dao dao.


### PR DESCRIPTION
在dao中执行 kratos tool wire
会出现  cannot use newDao(r, mc, db) (value of type *dao) as Dao value in return statement: missing method Article

原因是interface Dao
type Dao interface {
	Close()
	Ping(ctx context.Context) (err error)
	// bts: -nullcache=&model.Article{ID:-1} -check_null_code=$!=nil&&$.ID==-1
	Article(c context.Context, id int64) (*model.Article, error)
}
而dao 实现的方法是RawArticle