### PR TITLE
get remote ip by SplitHostPort

### DIFF
--- a/pkg/net/http/blademaster/metadata.go
+++ b/pkg/net/http/blademaster/metadata.go
@@ -2,6 +2,7 @@ package blademaster
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -110,7 +111,7 @@ func remoteIP(req *http.Request) (remote string) {
 	if remote = req.Header.Get("X-Real-IP"); remote != "" {
 		return
 	}
-	remote = req.RemoteAddr[:strings.Index(req.RemoteAddr, ":")]
+	remote, _, _ = net.SplitHostPort(req.RemoteAddr)
 	return
 }
 


### PR DESCRIPTION
go版本
```
go version go1.13.15 darwin/amd64
```
Mac本地环境下测试kratos-demo，日志打印ip为`ip=[`，原因是本地`RemoteAddr `为`[::1]:54905`，原写法无法支持IPv6地址解析，故此处使用`net.SplitHostPort`以正确解析ip