### PR TITLE
Update tool version

### DIFF
--- a/tool/kratos/version.go
+++ b/tool/kratos/version.go
@@ -8,9 +8,9 @@ import (
 
 var (
 	// Version is version
-	Version = "v0.5.0"
+	Version = "v0.6.0"
 	// BuildTime is BuildTime
-	BuildTime = "2020/4/30"
+	BuildTime = "2020/12/4"
 )
 
 // VersionOptions include version


### PR DESCRIPTION
由于v0.6.0已发布，因此需要更新kratos工具版本。BuildTime 采用的是 release 时间