### PR TITLE
fix:fix data race in rolling_counter

### DIFF
--- a/pkg/stat/metric/rolling_counter.go
+++ b/pkg/stat/metric/rolling_counter.go
@@ -69,5 +69,7 @@ func (r *rollingCounter) Value() int64 {
 }
 
 func (r *rollingCounter) Timespan() int {
+	r.policy.mu.RLock()
+	defer r.policy.mu.RUnlock()
 	return r.policy.timespan()
 }


### PR DESCRIPTION
执行bbr测试的时候，开启data race检测。发现存在并发数据竞争。经过排查是此处读取没有加读锁。

```
$ go test -run TestBBR -race
==================
WARNING: DATA RACE
Write at 0x00c00008ead8 by goroutine 72:
  github.com/go-kratos/kratos/pkg/stat/metric.(*RollingPolicy).add()
      /Users/zc/Desktop/companyWorkspace/bifrost/learn_proj/kratos/pkg/stat/metric/rolling_policy.go:51 +0x1eb
  github.com/go-kratos/kratos/pkg/stat/metric.(*RollingPolicy).Add()
      /Users/zc/Desktop/companyWorkspace/bifrost/learn_proj/kratos/pkg/stat/metric/rolling_policy.go:84 +0x84
  github.com/go-kratos/kratos/pkg/stat/metric.(*rollingCounter).Add()
      /Users/zc/Desktop/companyWorkspace/bifrost/learn_proj/kratos/pkg/stat/metric/rolling_counter.go:44 +0x6c
  github.com/go-kratos/kratos/pkg/ratelimit/bbr.(*BBR).Allow.func1()
      /Users/zc/Desktop/companyWorkspace/bifrost/learn_proj/kratos/pkg/ratelimit/bbr/bbr.go:200 +0xee
  github.com/go-kratos/kratos/pkg/ratelimit/bbr.TestBBR.func1()
      /Users/zc/Desktop/companyWorkspace/bifrost/learn_proj/kratos/pkg/ratelimit/bbr/bbr_test.go:66 +0x181
==================
drop:  10526
--- FAIL: TestBBR (15.88s)
    testing.go:1038: race detected during execution of test
FAIL
```