### PR TITLE
debug tracing opentracing.HTTPHeadersCarrier panic

### DIFF
--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -104,6 +104,8 @@ func Client(opts ...Option) middleware.Middleware {
 				if md, ok := metadata.FromOutgoingContext(ctx); ok {
 					carrier = opentracing.HTTPHeadersCarrier(md)
 					ctx = metadata.NewOutgoingContext(ctx, md)
+				} else {
+					carrier = make(opentracing.HTTPHeadersCarrier)
 				}
 			}
 			span := options.tracer.StartSpan(


### PR DESCRIPTION
修复grpc下未初始化opentracing.HTTPHeadersCarrier引起的panic