### PR TITLE
display error messages

### DIFF
--- a/middleware/status/status.go
+++ b/middleware/status/status.go
@@ -72,6 +72,7 @@ func errorEncode(err error) error {
 	if !ok {
 		se = &errors.StatusError{
 			Code: 2,
+			Message: err.Error(),
 		}
 	}
 	gs := status.Newf(codes.Code(se.Code), "%s: %s", se.Reason, se.Message)


### PR DESCRIPTION
should not swallow the user's native error information.

Signed-off-by: storyicon <storyicon@foxmail.com>