### PR TITLE
set transport.kind to be strong type

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -101,7 +101,7 @@ func dial(ctx context.Context, insecure bool, opts ...ClientOption) (*grpc.Clien
 // UnaryClientInterceptor retruns a unary client interceptor.
 func UnaryClientInterceptor(m middleware.Middleware) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		ctx = transport.NewContext(ctx, transport.Transport{Kind: "gRPC"})
+		ctx = transport.NewContext(ctx, transport.Transport{Kind: transport.KindGRPC})
 		ctx = NewClientContext(ctx, ClientInfo{FullMethod: method})
 		h := func(ctx context.Context, req interface{}) (interface{}, error) {
 			return reply, invoker(ctx, method, req, reply, cc, opts...)

--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -146,7 +146,7 @@ func UnaryTimeoutInterceptor(timeout time.Duration) grpc.UnaryServerInterceptor 
 // UnaryServerInterceptor returns a unary server interceptor.
 func UnaryServerInterceptor(m middleware.Middleware) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		ctx = transport.NewContext(ctx, transport.Transport{Kind: "gRPC"})
+		ctx = transport.NewContext(ctx, transport.Transport{Kind: transport.KindGRPC})
 		ctx = NewServerContext(ctx, ServerInfo{Server: info.Server, FullMethod: info.FullMethod})
 		h := func(ctx context.Context, req interface{}) (interface{}, error) {
 			return handler(ctx, req)

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -90,7 +90,7 @@ func (t *baseTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.userAgent != "" && req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", t.userAgent)
 	}
-	ctx := transport.NewContext(req.Context(), transport.Transport{Kind: "HTTP"})
+	ctx := transport.NewContext(req.Context(), transport.Transport{Kind: transport.KindHTTP})
 	ctx = NewClientContext(ctx, ClientInfo{Request: req})
 	ctx, cancel := context.WithTimeout(ctx, t.timeout)
 	defer cancel()

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -134,7 +134,7 @@ func (s *Server) PrefixHanlde(prefix string, h http.Handler) {
 func (s *Server) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	ctx, cancel := context.WithTimeout(req.Context(), s.timeout)
 	defer cancel()
-	ctx = transport.NewContext(ctx, transport.Transport{Kind: "HTTP"})
+	ctx = transport.NewContext(ctx, transport.Transport{Kind: transport.KindHTTP})
 	ctx = NewServerContext(ctx, ServerInfo{Request: req, Response: res})
 
 	h := func(ctx context.Context, req interface{}) (interface{}, error) {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -17,8 +17,17 @@ type Server interface {
 
 // Transport is transport context value.
 type Transport struct {
-	Kind string
+	Kind Kind
 }
+
+// Kind defines the type of Transport
+type Kind string
+
+// Defines a set of transport kind
+const (
+	KindGRPC Kind = "gRPC"
+	KindHTTP Kind = "HTTP"
+)
 
 type transportKey struct{}
 


### PR DESCRIPTION
There are many reasons why strong type should be used here, but only one reason that is closest to the user is described here:

The user obtains the protocol information through `transport.FromContext`, but the definition of `Transport` is as follows:
```
type Transport struct {
	Kind string
}
```

If users don’t look at the source code, they don’t know how kratos assigns a value to `Kind`. It might be：
```
grpc, gRPC, GRPC, http, HTTP
```

This makes the `Kind` field difficult to use.

Signed-off-by: storyicon <storyicon@foxmail.com>