### PR TITLE
proto/add:  rename to export && remove unnecessary type conversion

### DIFF
--- a/cmd/kratos/internal/proto/add/add.go
+++ b/cmd/kratos/internal/proto/add/add.go
@@ -59,7 +59,7 @@ func javaPackage(name string) string {
 }
 
 func serviceName(name string) string {
-	return unexport(strings.Split(name, ".")[0])
+	return export(strings.Split(name, ".")[0])
 }
 
-func unexport(s string) string { return strings.ToUpper(s[:1]) + s[1:] }
+func export(s string) string { return strings.ToUpper(s[:1]) + s[1:] }

--- a/cmd/kratos/internal/proto/add/proto.go
+++ b/cmd/kratos/internal/proto/add/proto.go
@@ -37,5 +37,5 @@ func (p *Proto) Generate() error {
 	if _, err := os.Stat(name); !os.IsNotExist(err) {
 		return fmt.Errorf("%s already exists", p.Name)
 	}
-	return ioutil.WriteFile(name, []byte(body), 0644)
+	return ioutil.WriteFile(name, body, 0644)
 }


### PR DESCRIPTION
1. The function name unexport is inconsistent with the actual behavior, it is more appropriate to name it as export here.
2. *Proto execute() return ([]byte, error), it is already of type []byte, so the conversion here is useless .