### PR TITLE
proto/client: print correct err

### DIFF
--- a/cmd/kratos/internal/proto/client/client.go
+++ b/cmd/kratos/internal/proto/client/client.go
@@ -36,7 +36,7 @@ func run(cmd *cobra.Command, args []string) {
 		cmd := exec.Command("kratos", "upgrade")
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		if cmd.Run(); err != nil {
+		if err = cmd.Run(); err != nil {
 			fmt.Println(err)
 			return
 		}


### PR DESCRIPTION
Always print error here. 
```
go get -u github.com/go-kratos/kratos/cmd/kratos/v2
go: downloading github.com/go-kratos/kratos/cmd/kratos/v2 v2.0.0-20210412154310-d92c1edc2668
go get: added github.com/go-git/go-git/v5 v5.3.0
go get: added github.com/go-kratos/kratos/cmd/kratos/v2 v2.0.0-20210412154310-d92c1edc2668
go get: added github.com/kevinburke/ssh_config v1.1.0
go get: added github.com/sergi/go-diff v1.2.0
go get: added github.com/spf13/cobra v1.1.3
go get: upgraded golang.org/x/mod v0.3.0 => v0.4.2
go get -u github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2
go: downloading github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2 v2.0.0-20210412154310-d92c1edc2668
go get: added github.com/go-kratos/kratos/cmd/protoc-gen-go-http/v2 v2.0.0-20210412154310-d92c1edc2668
go get -u github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2
go: downloading github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2 v2.0.0-20210412154310-d92c1edc2668
go get: added github.com/go-kratos/kratos/cmd/protoc-gen-go-errors/v2 v2.0.0-20210412154310-d92c1edc2668
go get -u google.golang.org/protobuf/cmd/protoc-gen-go
go get -u google.golang.org/grpc/cmd/protoc-gen-go-grpc
go get: added google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0
exec: "protoc-gen-go": executable file not found in $PATH
```