### PR TITLE
resolver/discovery: fix endpoint, scheme don't  match grpc

### DIFF
--- a/transport/grpc/resolver/discovery/resolver.go
+++ b/transport/grpc/resolver/discovery/resolver.go
@@ -46,6 +46,9 @@ func (r *discoveryResolver) update(ins []*registry.ServiceInstance) {
 			r.log.Errorf("Failed to parse discovery endpoint: %v", err)
 			continue
 		}
+		if endpoint == "" {
+			continue
+		}
 		addr := resolver.Address{
 			ServerName: in.Name,
 			Attributes: parseAttributes(in.Metadata),


### PR DESCRIPTION
when scheme don't  match grpc, endpoint is ""