### PR TITLE
kratos: extract the interrupt logic

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -16,10 +16,11 @@ func TestApp(t *testing.T) {
 		Version("v1.0.0"),
 		Server(hs, gs),
 	)
+	ctx, done := OnInterrupt()
 	time.AfterFunc(time.Second, func() {
-		app.Stop()
+		done()
 	})
-	if err := app.Run(); err != nil {
+	if err := app.Run(ctx); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Go officially does not recommend storing context in struct. https://blog.golang.org/context-and-structs.
This is the original intention of this PR.
**notice!!!**
If merge this PR, at the same time, retest and merge the https://github.com/go-kratos/kratos-layout/pull/13.