### PR TITLE
Import direct resovler for grpc client

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kratos/kratos/v2/registry"
 	"github.com/go-kratos/kratos/v2/transport"
 	"github.com/go-kratos/kratos/v2/transport/grpc/resolver/discovery"
+	_ "github.com/go-kratos/kratos/v2/transport/grpc/resolver/direct"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"


### PR DESCRIPTION
The direct resolver register itself during `init`.
Import the package so that the direct resolver can be initialized when using grpc client.