### PR TITLE
fix: unable to get the correct port when registering the service #893

### DIFF
--- a/app.go
+++ b/app.go
@@ -64,6 +64,10 @@ func (a *App) Run() error {
 			return srv.Start()
 		})
 	}
+	
+	time.Sleep(1 * time.Second)
+	a.instance = buildInstance(a.opts)
+
 	if a.opts.registrar != nil {
 		if err := a.opts.registrar.Register(a.opts.ctx, a.instance); err != nil {
 			return err


### PR DESCRIPTION
fix: unable to get the correct port when registering the service #893