### PR TITLE
fix incorrect return type in service template

### DIFF
--- a/cmd/kratos/internal/proto/server/template.go
+++ b/cmd/kratos/internal/proto/server/template.go
@@ -18,7 +18,7 @@ type {{.Service}}Service struct {
 	pb.Unimplemented{{.Service}}Server
 }
 
-func New{{.Service}}Service() pb.{{.Service}}Server {
+func New{{.Service}}Service() *{{.Service}}Service {
 	return &{{.Service}}Service{}
 }
 {{ range .Methods }}


### PR DESCRIPTION
`
kratos proto server api/helloworld/helloworld.proto -t internal/service
`
生成出来的service文件中NewXxxxSerivce返回类型不正确