### PR TITLE
fix(cmd):  fix kratos cmd

### DIFF
--- a/cmd/kratos/internal/proto/client/client.go
+++ b/cmd/kratos/internal/proto/client/client.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/go-kratos/kratos/cmd/kratos/v2/internal/base"
@@ -88,7 +89,7 @@ func generate(proto string, args []string) error {
 	}
 	protoBytes, err := ioutil.ReadFile(proto)
 	if err == nil && len(protoBytes) > 0 {
-		if strings.Contains(string(protoBytes), "validate/validate.proto") {
+		if ok, _ := regexp.Match(`\n[^/]*(import)\s+"validate/validate.proto"`, protoBytes); ok {
 			input = append(input, "--validate_out=lang=go,paths=source_relative:.")
 		}
 	}


### PR DESCRIPTION
fix kratos proto client cmd when the validate.proto is annotated not to generate validate pb file

修复kratos命令，validate.proto 引入，注释未使用时，不生成 validate pb文件