### PR TITLE
fixed:修复了，在默认项目根目录为根路径的情况下跨文件引入proto 由于文件名不全，导致protobuf加载文件not found的bug

### DIFF
--- a/cmd/kratos/internal/proto/client/client.go
+++ b/cmd/kratos/internal/proto/client/client.go
@@ -77,7 +77,6 @@ func walk(dir string, args []string) error {
 
 // generate is used to execute the generate command for the specified proto file
 func generate(proto string, args []string) error {
-	path, name := filepath.Split(proto)
 	input := []string{
 		"--proto_path=.",
 		"--proto_path=" + base.KratosMod(),
@@ -93,7 +92,7 @@ func generate(proto string, args []string) error {
 			input = append(input, "--validate_out=lang=go,paths=source_relative:.")
 		}
 	}
-	input = append(input, name)
+	input = append(input, proto)
 	for _, a := range args {
 		if strings.HasPrefix(a, "-") {
 			input = append(input, a)
@@ -102,7 +101,7 @@ func generate(proto string, args []string) error {
 	fd := exec.Command("protoc", input...)
 	fd.Stdout = os.Stdout
 	fd.Stderr = os.Stderr
-	fd.Dir = path
+	fd.Dir = "."
 	if err := fd.Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
eg:
- api/basedata/tag/v1/tag.proto
- api/basedata/article/v1/article.proto
当 **api/basedata/article/v1/article.proto** import "api/basedata/tag/v1/tag.proto"
时 ，生成的依赖为api/basedata/tag/v1/tag.proto 但是 api/basedata/tag/v1/tag.proto 生成的文件source是tag.proto导致了依赖未找到
现在改成相对路径生成