### PR TITLE
[FIX]the flag name, remove redundant hyphen

### DIFF
--- a/cmd/kratos/internal/project/project.go
+++ b/cmd/kratos/internal/project/project.go
@@ -25,8 +25,8 @@ func init() {
 	if repoURL = os.Getenv("KRATOS_LAYOUT_REPO"); repoURL == "" {
 		repoURL = "https://github.com/go-kratos/kratos-layout.git"
 	}
-	CmdNew.Flags().StringVarP(&repoURL, "-repo-url", "r", repoURL, "layout repo")
-	CmdNew.Flags().StringVarP(&branch, "-branch", "b", branch, "repo branch")
+	CmdNew.Flags().StringVarP(&repoURL, "repo-url", "r", repoURL, "layout repo")
+	CmdNew.Flags().StringVarP(&branch, "branch", "b", branch, "repo branch")
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/cmd/kratos/internal/proto/server/server.go
+++ b/cmd/kratos/internal/proto/server/server.go
@@ -22,7 +22,7 @@ var CmdServer = &cobra.Command{
 var targetDir string
 
 func init() {
-	CmdServer.Flags().StringVarP(&targetDir, "-target-dir", "t", "internal/service", "generate target directory")
+	CmdServer.Flags().StringVarP(&targetDir, "target-dir", "t", "internal/service", "generate target directory")
 }
 
 func run(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
cobra will add two hyphens before the flag name by default. If the flag itself has hyphens, three hyphens will appear in the actual output.