### PR TITLE
fix(examples): rename config to cfg in blog #1117

### DIFF
--- a/examples/blog/cmd/blog/main.go
+++ b/examples/blog/cmd/blog/main.go
@@ -71,17 +71,17 @@ func main() {
 	flag.Parse()
 	logger := log.NewStdLogger(os.Stdout)
 
-	config := config.New(
+	cfg := config.New(
 		config.WithSource(
 			file.NewSource(flagconf),
 		),
 	)
-	if err := config.Load(); err != nil {
+	if err := cfg.Load(); err != nil {
 		panic(err)
 	}
 
 	var bc conf.Bootstrap
-	if err := config.Scan(&bc); err != nil {
+	if err := cfg.Scan(&bc); err != nil {
 		panic(err)
 	}
 	tp, err := tracerProvider(bc.Trace.Endpoint)


### PR DESCRIPTION
rename config to cfg in blog #1117 