### PR TITLE
feat(config): support Resolver for config variable placeholders

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/encoding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFillTemplate(t *testing.T) {
+	var (
+		envString = "8080"
+		envInt    = 10
+		envBool   = true
+		envFloat  = 0.9
+	)
+
+	if err := os.Setenv("PORT", envString); err != nil {
+		t.Fatal("set env failed")
+	}
+	if err := os.Setenv("COUNT", strconv.Itoa(envInt)); err != nil {
+		t.Fatal("set env failed")
+	}
+	if err := os.Setenv("ENABLE", strconv.FormatBool(envBool)); err != nil {
+		t.Fatal("set env failed")
+	}
+	if err := os.Setenv("RATE", fmt.Sprintf("%v", envFloat)); err != nil {
+		t.Fatal("set env failed")
+	}
+
+	tests := []struct {
+		name   string
+		format string
+		data   string
+		path   string
+		expect interface{}
+	}{
+		{
+			name:   "json string",
+			format: "json",
+			data:   `{"http": {"server": {"port": {{ env "PORT" }}}}}`,
+			path:   "http.server.port",
+			expect: envString,
+		},
+		{
+			name:   "yaml string",
+			format: "yaml",
+			data: `
+http:
+  server:
+    port: {{ env "PORT" }}`,
+			path:   "http.server.port",
+			expect: envString,
+		},
+		{
+			name:   "json int",
+			format: "json",
+			data:   `{"a": {"b": {"c": {{ env "COUNT" }}}}}`,
+			path:   "a.b.c",
+			expect: envInt,
+		},
+		{
+			name:   "yaml int",
+			format: "yaml",
+			data: `
+a:
+  b:
+    c: {{ env "COUNT" }}`,
+			path:   "a.b.c",
+			expect: envInt,
+		},
+		{
+			name:   "json bool",
+			format: "json",
+			data:   `{"a": {"b": {"c": {{ env "ENABLE" }}}}}`,
+			path:   "a.b.c",
+			expect: envBool,
+		},
+		{
+			name:   "yaml bool",
+			format: "yaml",
+			data: `
+a:
+  b:
+    c: {{ env "ENABLE" }}`,
+			path:   "a.b.c",
+			expect: envBool,
+		},
+		{
+			name:   "json float",
+			format: "json",
+			data:   `{"a": {"b": {"c": {{ env "RATE" }}}}}`,
+			path:   "a.b.c",
+			expect: envFloat,
+		},
+		{
+			name:   "yaml float",
+			format: "yaml",
+			data: `
+a:
+  b:
+    c: {{ env "RATE" }}`,
+			path:   "a.b.c",
+			expect: envFloat,
+		},
+		// can not support xml config template because we can not unmarshal xml to map[string]interface{}
+		//{
+		//	name: "xml",
+		//	format: "xml",
+		//	data: `<http><server><port>{{ env "PORT" }}</port></server></http>`,
+		//	path: "http.server.port",
+		//	expect: envString,
+		//},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d, err := fillTemplate([]byte(test.data))
+			if err != nil {
+				t.Fatal(err)
+			}
+			v := make(map[string]interface{})
+			codec := encoding.GetCodec(test.format)
+			if codec == nil {
+				t.Fatalf("unsupported format: %s", test.format)
+			}
+			t.Log(string(d))
+			if err := codec.Unmarshal(d, &v); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+
+			rd := reader{
+				values: v,
+			}
+			if v, ok := rd.Value(test.path); ok {
+				var actual interface{}
+				switch test.expect.(type) {
+				case int:
+					if actual, err = v.Int(); err == nil {
+						assert.Equal(t, test.expect, int(actual.(int64)), "int value should be equal")
+					}
+				case string:
+					if actual, err = v.String(); err == nil {
+						assert.Equal(t, test.expect, actual, "string value should be equal")
+					}
+				case bool:
+					if actual, err = v.Bool(); err == nil {
+						assert.Equal(t, test.expect, actual, "bool value should be equal")
+					}
+				case float64:
+					if actual, err = v.Float(); err == nil {
+						assert.Equal(t, test.expect, actual, "float64 value should be equal")
+					}
+				default:
+					actual = v.Load()
+					assert.Equal(t, test.expect, actual, "interface{} value should be equal")
+				}
+				if err != nil {
+					t.Error(err)
+				}
+			} else {
+				t.Error("value path not found")
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,7 +25,13 @@ func TestDefaultResolver(t *testing.T) {
 				"rate":     "${RATE}",
 				"empty":    "${EMPTY:foobar}",
 				"array":    []interface{}{"${PORT}", "${NOTEXIST:8081}"},
+				"value1":   "${test.value}",
+				"value2":   "$PORT",
+				"value3":   "$PORT:default",
 			},
+		},
+		"test": map[string]interface{}{
+			"value": "foobar",
 		},
 		"PORT":   "8080",
 		"COUNT":  "10",
@@ -73,6 +79,21 @@ func TestDefaultResolver(t *testing.T) {
 			name:   "test array",
 			path:   "foo.bar.array",
 			expect: []interface{}{portString, "8081"},
+		},
+		{
+			name:   "test ${test.value}",
+			path:   "foo.bar.value1",
+			expect: "foobar",
+		},
+		{
+			name:   "test $value",
+			path:   "foo.bar.value2",
+			expect: portString,
+		},
+		{
+			name:   "test $value:default",
+			path:   "foo.bar.value3",
+			expect: portString + ":default",
 		},
 	}
 

--- a/config/options.go
+++ b/config/options.go
@@ -7,13 +7,17 @@ import (
 // Decoder is config decoder.
 type Decoder func(*KeyValue, map[string]interface{}) error
 
+// Resolver resolve placeholder in config.
+type Resolver func(map[string]interface{}) error
+
 // Option is config option.
 type Option func(*options)
 
 type options struct {
-	sources []Source
-	decoder Decoder
-	logger  log.Logger
+	sources  []Source
+	decoder  Decoder
+	resolver Resolver
+	logger   log.Logger
 }
 
 // WithSource with config source.
@@ -27,6 +31,13 @@ func WithSource(s ...Source) Option {
 func WithDecoder(d Decoder) Option {
 	return func(o *options) {
 		o.decoder = d
+	}
+}
+
+// WithResolver with config resolver.
+func WithResolver(r Resolver) Option {
+	return func(o *options) {
+		o.resolver = r
 	}
 }
 

--- a/config/reader.go
+++ b/config/reader.go
@@ -43,6 +43,9 @@ func (r *reader) Merge(kvs ...*KeyValue) error {
 			return err
 		}
 	}
+	if err := r.opts.resolver(merged); err != nil {
+		return err
+	}
 	r.values = merged
 	return nil
 }

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -20,6 +20,7 @@ func TestReader_Merge(t *testing.T) {
 			}
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
+		resolver: defaultResolver,
 	}
 	r := newReader(opts)
 	err = r.Merge(&KeyValue{

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -63,6 +63,7 @@ func TestReader_Value(t *testing.T) {
 			}
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
+		resolver: defaultResolver,
 	}
 
 	ymlval := `
@@ -142,6 +143,7 @@ func TestReader_Source(t *testing.T) {
 			}
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
+		resolver: defaultResolver,
 	}
 	r := newReader(opts)
 	err = r.Merge(&KeyValue{


### PR DESCRIPTION
using go template lib to replace placeholder to environment variable

like this:
```yaml
http:
  server:
    # replace with env var "PORT" with default value 8080 
    port: ${PORT:8080}
    # replace with env var "TIMEOUT" without default value
    timeout: "${TIMEOUT}"
```

please help for code reviewing @ymh199478

thanks in advance :-)