### PR TITLE
ci(github action): use golangci-lint to replace the deprecated golint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,10 +43,14 @@ jobs:
         go build ./...
         go test ./...
 
-    - name: Lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        version: v1.41
-        args: --disable-all --new-from-rev=HEAD~
-        skip-go-installation: true
-        skip-pkg-cache: true
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.41
+          args: --disable-all --new-from-rev=HEAD~
+          skip-go-installation: true
+          skip-pkg-cache: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,6 +52,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.41
-          args: --disable-all --new-from-rev=HEAD~
+          args: --disable-all
           skip-go-installation: true
           skip-pkg-cache: true
+          only-new-issues: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,6 +43,7 @@ jobs:
         go test ./...
 
     - name: Lint
-      run: |
-        go get golang.org/x/lint/golint
-        golint ./...
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.29
+        args: --disable-all

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,5 +46,5 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.29
+        version: v1.41
         args: --disable-all --new-from-rev=HEAD~

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,4 +46,4 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.29
-        args: --disable-all
+        args: --disable-all --new-from-rev=HEAD~

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,3 +48,5 @@ jobs:
       with:
         version: v1.41
         args: --disable-all --new-from-rev=HEAD~
+        skip-go-installation: true
+        skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,11 @@
+run:
+  timeout: 5m
+  modules-download-mode: readonly
+  skip-files:
+    - ".*_test\\.go$"
+
+linters:
+  enable:
+    - revive
+    - staticcheck
+    - govet

--- a/config/value.go
+++ b/config/value.go
@@ -68,7 +68,7 @@ func (v *atomicValue) Float() (float64, error) {
 	case int64:
 		return float64(val), nil
 	case string:
-		// todo: SA1030: 'bitSize' argument is invalid, must be either 32 or 64
+		//todo: SA1030: 'bitSize' argument is invalid, must be either 32 or 64
 		return strconv.ParseFloat(val, 10) //nolint: staticcheck
 	}
 	return 0.0, fmt.Errorf("type assert to %v failed", reflect.TypeOf(v.Load()))

--- a/config/value.go
+++ b/config/value.go
@@ -68,7 +68,8 @@ func (v *atomicValue) Float() (float64, error) {
 	case int64:
 		return float64(val), nil
 	case string:
-		return strconv.ParseFloat(val, 10)
+		// todo: SA1030: 'bitSize' argument is invalid, must be either 32 or 64
+		return strconv.ParseFloat(val, 10) //nolint: staticcheck
 	}
 	return 0.0, fmt.Errorf("type assert to %v failed", reflect.TypeOf(v.Load()))
 }

--- a/encoding/form/form.go
+++ b/encoding/form/form.go
@@ -67,10 +67,7 @@ func (c codec) Unmarshal(data []byte, v interface{}) error {
 		return MapProto(m, vs)
 	}
 
-	if err := c.decoder.Decode(v, vs); err != nil {
-		return err
-	}
-	return nil
+	return c.decoder.Decode(v, vs)
 }
 
 func (codec) Name() string {

--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -96,7 +96,8 @@ func dial(ctx context.Context, insecure bool, opts ...ClientOption) (*grpc.Clien
 		ints = append(ints, options.ints...)
 	}
 	var grpcOpts = []grpc.DialOption{
-		grpc.WithBalancerName(roundrobin.Name),
+		//todo: grpc.WithBalancerName is deprecated.
+		grpc.WithBalancerName(roundrobin.Name), //nolint:staticcheck
 		grpc.WithChainUnaryInterceptor(ints...),
 	}
 	if options.discovery != nil {

--- a/transport/http/context.go
+++ b/transport/http/context.go
@@ -97,18 +97,12 @@ func (c *wrapper) Returns(v interface{}, err error) error {
 	if err != nil {
 		return err
 	}
-	if err := c.router.srv.enc(&c.w, c.req, v); err != nil {
-		return err
-	}
-	return nil
+	return c.router.srv.enc(&c.w, c.req, v)
 }
 
 func (c *wrapper) Result(code int, v interface{}) error {
 	c.w.WriteHeader(code)
-	if err := c.router.srv.enc(&c.w, c.req, v); err != nil {
-		return err
-	}
-	return nil
+	return c.router.srv.enc(&c.w, c.req, v)
 }
 
 func (c *wrapper) JSON(code int, v interface{}) error {


### PR DESCRIPTION
使用 [golangci-lint](https://golangci-lint.run/) 来替代了 [golint](https://github.com/golang/lint) 检测，检测忽略了 `test` 文件，对于 `PR` 不主动检测旧的代码(非变更代码)，目前启用了以下[检测插件](https://golangci-lint.run/usage/linters)：
- revive
- staticcheck
- govet 


提交中包含了以下关联性改动：

- 对于新CI检测到的问题，本次PR**不对**问题进行修复，仅使用 `todo` 标记，标记问题。
- 提交对于 `冗余代码` 类型的问题，进行了更正。
- 根据 [golangci-lint-action/issues/23](https://github.com/golangci/golangci-lint-action/issues/23) 描述的内容，检测工具任务将会放在独立的 job 中进行。
- 添加了一个手动触发器用于手动触发 github action 任务

---

Merge 时请合并提交历史，closed #1173
