### PR TITLE
fix(config): strconv.ParseFloat use correct bitSize

### DIFF
--- a/config/value.go
+++ b/config/value.go
@@ -68,8 +68,7 @@ func (v *atomicValue) Float() (float64, error) {
 	case int64:
 		return float64(val), nil
 	case string:
-		//todo: SA1030: 'bitSize' argument is invalid, must be either 32 or 64
-		return strconv.ParseFloat(val, 10) //nolint: staticcheck
+		return strconv.ParseFloat(val, 64)
 	}
 	return 0.0, fmt.Errorf("type assert to %v failed", reflect.TypeOf(v.Load()))
 }


### PR DESCRIPTION
`strconv.ParseFloat` 方法无需填写 `base` 参数，需要直接填写 `bitSize` 参数