### PR TITLE
feat(env): add config env source

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,10 +24,13 @@ func TestDefaultResolver(t *testing.T) {
 				"enable":   "${ENABLE:false}",
 				"rate":     "${RATE}",
 				"empty":    "${EMPTY:foobar}",
-				"array":    []interface{}{"${PORT}", "${NOTEXIST:8081}"},
-				"value1":   "${test.value}",
-				"value2":   "$PORT",
-				"value3":   "$PORT:default",
+				"array": []interface{}{
+					"${PORT}",
+					map[string]interface{}{"foobar": "${NOTEXIST:8081}"},
+				},
+				"value1": "${test.value}",
+				"value2": "$PORT",
+				"value3": "$PORT:default",
 			},
 		},
 		"test": map[string]interface{}{
@@ -78,7 +81,7 @@ func TestDefaultResolver(t *testing.T) {
 		{
 			name:   "test array",
 			path:   "foo.bar.array",
-			expect: []interface{}{portString, "8081"},
+			expect: []interface{}{portString, map[string]interface{}{"foobar": "8081"}},
 		},
 		{
 			name:   "test ${test.value}",

--- a/config/env/env.go
+++ b/config/env/env.go
@@ -1,0 +1,59 @@
+package env
+
+import (
+	"os"
+	"strings"
+
+	"github.com/go-kratos/kratos/v2/config"
+)
+
+type env struct {
+	prefixs []string
+}
+
+func NewSource(prefixs ...string) config.Source {
+	return &env{prefixs: prefixs}
+}
+
+func (e *env) Load() (kv []*config.KeyValue, err error) {
+	for _, envstr := range os.Environ() {
+		var k, v string
+		subs := strings.SplitN(envstr, "=", 2)
+		k = subs[0]
+		if len(subs) > 1 {
+			v = subs[1]
+		}
+
+		if len(e.prefixs) > 0 {
+			p, ok := matchPrefix(e.prefixs, envstr)
+			if !ok {
+				continue
+			}
+			// trim prefix
+			k = k[len(p):]
+			if k[0] == '_' {
+				k = k[1:]
+			}
+		}
+
+		kv = append(kv, &config.KeyValue{
+			Key:   k,
+			Value: []byte(v),
+		})
+	}
+	return
+}
+
+func (e *env) Watch() (config.Watcher, error) {
+	panic("watch env var not support")
+	return nil, nil
+}
+
+func matchPrefix(prefixs []string, s string) (string, bool) {
+	for _, p := range prefixs {
+		if strings.HasPrefix(s, p) {
+			return p, true
+		}
+	}
+	return "", false
+}

--- a/config/env/env.go
+++ b/config/env/env.go
@@ -45,8 +45,11 @@ func (e *env) Load() (kv []*config.KeyValue, err error) {
 }
 
 func (e *env) Watch() (config.Watcher, error) {
-	panic("watch env var not support")
-	return nil, nil
+	w, err := NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
 }
 
 func matchPrefix(prefixs []string, s string) (string, bool) {

--- a/config/env/env_test.go
+++ b/config/env/env_test.go
@@ -1,0 +1,130 @@
+package env
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/config"
+	"github.com/go-kratos/kratos/v2/config/file"
+	"github.com/stretchr/testify/assert"
+)
+
+const _testJSON = `
+{
+    "test":{
+        "server":{
+			"name":"$SERVICE_NAME",
+            "addr":"${ADDR:127.0.0.1}",
+            "port":"${PORT:8080}"
+        }
+    },
+    "foo":[
+        {
+            "name":"Tom",
+            "age":"${AGE}"
+        }
+    ]
+}`
+
+func TestEnv(t *testing.T) {
+	var (
+		path     = filepath.Join(os.TempDir(), "test_config")
+		filename = filepath.Join(path, "test.json")
+		data     = []byte(_testJSON)
+	)
+	defer os.Remove(path)
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Error(err)
+	}
+	if err := ioutil.WriteFile(filename, data, 0666); err != nil {
+		t.Error(err)
+	}
+
+	// set env
+	prefix := "KRATOS_"
+	envs := map[string]string{
+		prefix + "SERVICE_NAME": "kratos_app",
+		prefix + "ADDR":         "192.168.0.1",
+		prefix + "AGE":          "20",
+	}
+
+	for k, v := range envs {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := config.New(config.WithSource(
+		NewSource(prefix),
+		file.NewSource(path),
+	))
+
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		expect interface{}
+	}{
+		{
+			name:   "test $KEY",
+			path:   "test.server.name",
+			expect: "kratos_app",
+		},
+		{
+			name:   "test ${KEY:DEFAULT} without default",
+			path:   "test.server.addr",
+			expect: "192.168.0.1",
+		},
+		{
+			name:   "test ${KEY:DEFAULT} with default",
+			path:   "test.server.port",
+			expect: "8080",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			v := c.Value(test.path)
+			if v.Load() != nil {
+				var actual interface{}
+				switch test.expect.(type) {
+				case int:
+					if actual, err = v.Int(); err == nil {
+						assert.Equal(t, test.expect, int(actual.(int64)), "int value should be equal")
+					}
+				case string:
+					if actual, err = v.String(); err == nil {
+						assert.Equal(t, test.expect, actual, "string value should be equal")
+					}
+				case bool:
+					if actual, err = v.Bool(); err == nil {
+						assert.Equal(t, test.expect, actual, "bool value should be equal")
+					}
+				case float64:
+					if actual, err = v.Float(); err == nil {
+						assert.Equal(t, test.expect, actual, "float64 value should be equal")
+					}
+				default:
+					actual = v.Load()
+					if !reflect.DeepEqual(test.expect, actual) {
+						t.Logf("expect: %#v, actural: %#v", test.expect, actual)
+						t.Fail()
+					}
+				}
+				if err != nil {
+					t.Error(err)
+				}
+			} else {
+				t.Error("value path not found")
+			}
+		})
+	}
+
+}

--- a/config/env/env_test.go
+++ b/config/env/env_test.go
@@ -29,7 +29,7 @@ const _testJSON = `
     ]
 }`
 
-func TestEnv(t *testing.T) {
+func TestEnvWithPrefix(t *testing.T) {
 	var (
 		path     = filepath.Join(os.TempDir(), "test_config")
 		filename = filepath.Join(path, "test.json")
@@ -44,11 +44,11 @@ func TestEnv(t *testing.T) {
 	}
 
 	// set env
-	prefix := "KRATOS_"
+	prefix1, prefix2 := "KRATOS_", "FOO"
 	envs := map[string]string{
-		prefix + "SERVICE_NAME": "kratos_app",
-		prefix + "ADDR":         "192.168.0.1",
-		prefix + "AGE":          "20",
+		prefix1 + "SERVICE_NAME": "kratos_app",
+		prefix2 + "ADDR":         "192.168.0.1",
+		prefix1 + "AGE":          "20",
 	}
 
 	for k, v := range envs {
@@ -58,7 +58,7 @@ func TestEnv(t *testing.T) {
 	}
 
 	c := config.New(config.WithSource(
-		NewSource(prefix),
+		NewSource(prefix1, prefix2),
 		file.NewSource(path),
 	))
 
@@ -85,6 +85,16 @@ func TestEnv(t *testing.T) {
 			name:   "test ${KEY:DEFAULT} with default",
 			path:   "test.server.port",
 			expect: "8080",
+		},
+		{
+			name: "test ${KEY} in array",
+			path: "foo",
+			expect: []interface{}{
+				map[string]interface{}{
+					"name": "Tom",
+					"age":  "20",
+				},
+			},
 		},
 	}
 
@@ -114,7 +124,7 @@ func TestEnv(t *testing.T) {
 				default:
 					actual = v.Load()
 					if !reflect.DeepEqual(test.expect, actual) {
-						t.Logf("expect: %#v, actural: %#v", test.expect, actual)
+						t.Logf("\nexpect: %#v\nactural: %#v", test.expect, actual)
 						t.Fail()
 					}
 				}
@@ -126,5 +136,112 @@ func TestEnv(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestEnvWithoutPrefix(t *testing.T) {
+	var (
+		path     = filepath.Join(os.TempDir(), "test_config")
+		filename = filepath.Join(path, "test.json")
+		data     = []byte(_testJSON)
+	)
+	defer os.Remove(path)
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Error(err)
+	}
+	if err := ioutil.WriteFile(filename, data, 0666); err != nil {
+		t.Error(err)
+	}
+
+	// set env
+	envs := map[string]string{
+		"SERVICE_NAME": "kratos_app",
+		"ADDR":         "192.168.0.1",
+		"AGE":          "20",
+	}
+
+	for k, v := range envs {
+		if err := os.Setenv(k, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := config.New(config.WithSource(
+		NewSource(),
+		file.NewSource(path),
+	))
+
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		expect interface{}
+	}{
+		{
+			name:   "test $KEY",
+			path:   "test.server.name",
+			expect: "kratos_app",
+		},
+		{
+			name:   "test ${KEY:DEFAULT} without default",
+			path:   "test.server.addr",
+			expect: "192.168.0.1",
+		},
+		{
+			name:   "test ${KEY:DEFAULT} with default",
+			path:   "test.server.port",
+			expect: "8080",
+		},
+		{
+			name: "test ${KEY} in array",
+			path: "foo",
+			expect: []interface{}{
+				map[string]interface{}{
+					"name": "Tom",
+					"age":  "20",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			v := c.Value(test.path)
+			if v.Load() != nil {
+				var actual interface{}
+				switch test.expect.(type) {
+				case int:
+					if actual, err = v.Int(); err == nil {
+						assert.Equal(t, test.expect, int(actual.(int64)), "int value should be equal")
+					}
+				case string:
+					if actual, err = v.String(); err == nil {
+						assert.Equal(t, test.expect, actual, "string value should be equal")
+					}
+				case bool:
+					if actual, err = v.Bool(); err == nil {
+						assert.Equal(t, test.expect, actual, "bool value should be equal")
+					}
+				case float64:
+					if actual, err = v.Float(); err == nil {
+						assert.Equal(t, test.expect, actual, "float64 value should be equal")
+					}
+				default:
+					actual = v.Load()
+					if !reflect.DeepEqual(test.expect, actual) {
+						t.Logf("\nexpect: %#v\nactural: %#v", test.expect, actual)
+						t.Fail()
+					}
+				}
+				if err != nil {
+					t.Error(err)
+				}
+			} else {
+				t.Error("value path not found")
+			}
+		})
+	}
 }

--- a/config/env/watcher.go
+++ b/config/env/watcher.go
@@ -1,8 +1,6 @@
 package env
 
 import (
-	"fmt"
-
 	"github.com/go-kratos/kratos/v2/config"
 )
 
@@ -17,8 +15,7 @@ func NewWatcher() (config.Watcher, error) {
 // Next will be blocked until the Stop method is called
 func (w *watcher) Next() ([]*config.KeyValue, error) {
 	<-w.exit
-
-	return nil, fmt.Errorf("watcher stoped")
+	return nil, nil
 }
 
 func (w *watcher) Stop() error {

--- a/config/env/watcher.go
+++ b/config/env/watcher.go
@@ -1,0 +1,27 @@
+package env
+
+import (
+	"fmt"
+
+	"github.com/go-kratos/kratos/v2/config"
+)
+
+type watcher struct {
+	exit chan struct{}
+}
+
+func NewWatcher() (config.Watcher, error) {
+	return &watcher{exit: make(chan struct{})}, nil
+}
+
+// Next will be blocked until the Stop method is called
+func (w *watcher) Next() ([]*config.KeyValue, error) {
+	<-w.exit
+
+	return nil, fmt.Errorf("watcher stoped")
+}
+
+func (w *watcher) Stop() error {
+	close(w.exit)
+	return nil
+}

--- a/config/options.go
+++ b/config/options.go
@@ -57,7 +57,7 @@ func WithLogger(l log.Logger) Option {
 // to target map[string]interface{} using src.Format codec.
 func defaultDecoder(src *KeyValue, target map[string]interface{}) error {
 	if src.Format == "" {
-		target[src.Key] = src.Value
+		target[src.Key] = string(src.Value)
 		return nil
 	}
 	if codec := encoding.GetCodec(src.Format); codec != nil {

--- a/config/options.go
+++ b/config/options.go
@@ -57,7 +57,7 @@ func WithLogger(l log.Logger) Option {
 // to target map[string]interface{} using src.Format codec.
 func defaultDecoder(src *KeyValue, target map[string]interface{}) error {
 	if src.Format == "" {
-		target[src.Key] = string(src.Value)
+		target[src.Key] = src.Value
 		return nil
 	}
 	if codec := encoding.GetCodec(src.Format); codec != nil {

--- a/config/options.go
+++ b/config/options.go
@@ -92,8 +92,13 @@ func defaultResolver(input map[string]interface{}) error {
 				}
 			case []interface{}:
 				for i, iface := range vt {
-					if s, ok := iface.(string); ok {
-						vt[i] = os.Expand(s, mapper)
+					switch it := iface.(type) {
+					case string:
+						vt[i] = os.Expand(it, mapper)
+					case map[string]interface{}:
+						if err := resolve(it); err != nil {
+							return err
+						}
 					}
 				}
 				sub[k] = vt

--- a/config/reader.go
+++ b/config/reader.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -59,15 +61,20 @@ func (r *reader) Source() ([]byte, error) {
 }
 
 func cloneMap(src map[string]interface{}) (map[string]interface{}, error) {
-	data, err := marshalJSON(src)
+	// https://gist.github.com/soroushjp/0ec92102641ddfc3ad5515ca76405f4d
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	dec := gob.NewDecoder(&buf)
+	err := enc.Encode(src)
 	if err != nil {
 		return nil, err
 	}
-	dst := make(map[string]interface{})
-	if err = unmarshalJSON(data, &dst); err != nil {
+	var copy map[string]interface{}
+	err = dec.Decode(&copy)
+	if err != nil {
 		return nil, err
 	}
-	return dst, nil
+	return copy, nil
 }
 
 func convertMap(src interface{}) interface{} {

--- a/config/reader.go
+++ b/config/reader.go
@@ -63,6 +63,8 @@ func (r *reader) Source() ([]byte, error) {
 func cloneMap(src map[string]interface{}) (map[string]interface{}, error) {
 	// https://gist.github.com/soroushjp/0ec92102641ddfc3ad5515ca76405f4d
 	var buf bytes.Buffer
+	gob.Register(map[string]interface{}{})
+	gob.Register([]interface{}{})
 	enc := gob.NewEncoder(&buf)
 	dec := gob.NewDecoder(&buf)
 	err := enc.Encode(src)

--- a/config/value.go
+++ b/config/value.go
@@ -78,6 +78,8 @@ func (v *atomicValue) String() (string, error) {
 		return val, nil
 	case bool, int, int32, int64, float64:
 		return fmt.Sprint(val), nil
+	case []byte:
+		return string(val), nil
 	default:
 		if s, ok := val.(fmt.Stringer); ok {
 			return s.String(), nil


### PR DESCRIPTION
resolve #1065, add new config source for reading environment variable

* Use `prefix` to filter the required variables
* Watching environment variables change are not support because I did not find a reasonable solution (any suggestions are welcome :). Using `Watch` will block until `Stop` is called.
* When the env var loaded into the `KeyValue` struct, the `Format` field is nil, so when we decode it, we need to change it to `string` or we will get a base64 code when using `json.Unmarshal` to clone a map

CC @ymh199478 