### PR TITLE
gen-go-http 增加生成 newHttpHandler 方法，兼容之前的 api 注册

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -12,8 +12,10 @@ import (
 
 const (
 	contextPackage       = protogen.GoImportPath("context")
+	stdhttpPackage = protogen.GoImportPath("net/http")
 	transportHTTPPackage = protogen.GoImportPath("github.com/go-kratos/kratos/v2/transport/http")
 	bindingPackage       = protogen.GoImportPath("github.com/go-kratos/kratos/v2/transport/http/binding")
+	muxPackage = protogen.GoImportPath("github.com/gorilla/mux")
 )
 
 var methodSets = make(map[string]int)
@@ -31,6 +33,7 @@ func generateFile(gen *protogen.Plugin, file *protogen.File, omitempty bool) *pr
 	g.P()
 	g.P("package ", file.GoPackageName)
 	g.P()
+	g.P(`import stdhttp "net/http"`)
 	generateFileContent(gen, file, g, omitempty)
 	return g
 }
@@ -44,6 +47,7 @@ func generateFileContent(gen *protogen.Plugin, file *protogen.File, g *protogen.
 	g.P("// is compatible with the kratos package it is being compiled against.")
 	g.P("var _ = new(", contextPackage.Ident("Context"), ")")
 	g.P("var _ = ", bindingPackage.Ident("EncodeURL"))
+	g.P("var _ = new(", muxPackage.Ident("Router"),")")
 	g.P("const _ = ", transportHTTPPackage.Ident("SupportPackageIsVersion1"))
 	g.P()
 

--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -15,6 +15,7 @@ const (
 	stdhttpPackage = protogen.GoImportPath("net/http")
 	transportHTTPPackage = protogen.GoImportPath("github.com/go-kratos/kratos/v2/transport/http")
 	bindingPackage       = protogen.GoImportPath("github.com/go-kratos/kratos/v2/transport/http/binding")
+	middlewarePackage = protogen.GoImportPath("github.com/go-kratos/kratos/v2/middleware")
 	muxPackage = protogen.GoImportPath("github.com/gorilla/mux")
 )
 
@@ -47,6 +48,7 @@ func generateFileContent(gen *protogen.Plugin, file *protogen.File, g *protogen.
 	g.P("// is compatible with the kratos package it is being compiled against.")
 	g.P("var _ = new(", contextPackage.Ident("Context"), ")")
 	g.P("var _ = ", bindingPackage.Ident("EncodeURL"))
+	g.P("var _ = ", middlewarePackage.Ident("Chain"))
 	g.P("var _ = new(", muxPackage.Ident("Router"),")")
 	g.P("const _ = ", transportHTTPPackage.Ident("SupportPackageIsVersion1"))
 	g.P()

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -22,6 +22,16 @@ func Register{{.ServiceType}}HTTPServer(s *http.Server, srv {{.ServiceType}}HTTP
 	{{- end}}
 }
 
+func New{{.ServiceType}}HTTPServerHandler(s *http.Server, srv {{.ServiceType}}HTTPServer) stdhttp.Handler{
+	muxRouter := mux.NewRouter()
+	r := s.Route("/")
+	{{- range .Methods}}
+
+	muxRouter.Handle("{{.Path}}",r.BuildHandler(_{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv))).Methods("{{.Method}}")
+	{{- end}}
+	return muxRouter
+}
+
 {{range .Methods}}
 func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {

--- a/transport/http/router.go
+++ b/transport/http/router.go
@@ -37,6 +37,21 @@ func (r *Router) Group(prefix string, filters ...FilterFunc) *Router {
 	return newRouter(path.Join(r.prefix, prefix), r.srv, newFilters...)
 }
 
+func (r *Router) BuildHandler(h HandlerFunc, filters ...FilterFunc)http.Handler{
+	next := http.Handler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		ctx := r.pool.Get().(Context)
+		ctx.Reset(res, req)
+		if err := h(ctx); err != nil {
+			r.srv.ene(res, req, err)
+		}
+		ctx.Reset(nil, nil)
+		r.pool.Put(ctx)
+	}))
+	next = FilterChain(filters...)(next)
+	next = FilterChain(r.filters...)(next)
+	return next
+}
+
 // Handle registers a new route with a matcher for the URL path and method.
 func (r *Router) Handle(method, relativePath string, h HandlerFunc, filters ...FilterFunc) {
 	next := http.Handler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -235,3 +235,4 @@ func (s *Server) Stop(ctx context.Context) error {
 	s.log.Info("[HTTP] server stopping")
 	return s.Shutdown(ctx)
 }
+


### PR DESCRIPTION
现在的 api 注册 直接将 handler 注册到 server 里了，
不像之前可以 newHandler 出来然后可以自由如何处理这个 handler

