### PR TITLE
fix(config): load env and file source order bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -67,11 +67,15 @@ func (c *config) watch(w Watcher) {
 		kvs, err := w.Next()
 		if err != nil {
 			time.Sleep(time.Second)
-			c.log.Errorf("Failed to watch next config: %v", err)
+			c.log.Errorf("failed to watch next config: %v", err)
 			continue
 		}
 		if err := c.reader.Merge(kvs...); err != nil {
-			c.log.Errorf("Failed to merge next config: %v", err)
+			c.log.Errorf("failed to merge next config: %v", err)
+			continue
+		}
+		if err := c.reader.Resolve(); err != nil {
+			c.log.Errorf("failed to resolve next config: %v", err)
 			continue
 		}
 		c.cached.Range(func(key, value interface{}) bool {

--- a/config/config.go
+++ b/config/config.go
@@ -95,15 +95,19 @@ func (c *config) Load() error {
 			return err
 		}
 		if err := c.reader.Merge(kvs...); err != nil {
-			c.log.Errorf("Failed to merge config source: %v", err)
+			c.log.Errorf("failed to merge config source: %v", err)
 			return err
 		}
 		w, err := src.Watch()
 		if err != nil {
-			c.log.Errorf("Failed to watch config source: %v", err)
+			c.log.Errorf("failed to watch config source: %v", err)
 			return err
 		}
 		go c.watch(w)
+	}
+	if err := c.reader.Resolve(); err != nil {
+		c.log.Errorf("failed to resolve config source: %v", err)
+		return err
 	}
 	return nil
 }

--- a/config/env/env_test.go
+++ b/config/env/env_test.go
@@ -58,8 +58,8 @@ func TestEnvWithPrefix(t *testing.T) {
 	}
 
 	c := config.New(config.WithSource(
-		NewSource(prefix1, prefix2),
 		file.NewSource(path),
+		NewSource(prefix1, prefix2),
 	))
 
 	if err := c.Load(); err != nil {

--- a/config/options.go
+++ b/config/options.go
@@ -81,7 +81,7 @@ func defaultResolver(input map[string]interface{}) error {
 		} else if len(args) > 1 { // default value
 			return args[1]
 		}
-		return ""
+		return args[0]
 	}
 
 	var resolve func(map[string]interface{}) error

--- a/config/options.go
+++ b/config/options.go
@@ -81,7 +81,7 @@ func defaultResolver(input map[string]interface{}) error {
 		} else if len(args) > 1 { // default value
 			return args[1]
 		}
-		return args[0]
+		return ""
 	}
 
 	var resolve func(map[string]interface{}) error

--- a/config/reader.go
+++ b/config/reader.go
@@ -17,6 +17,7 @@ type Reader interface {
 	Merge(...*KeyValue) error
 	Value(string) (Value, bool)
 	Source() ([]byte, error)
+	Resolve() error
 }
 
 type reader struct {
@@ -45,9 +46,6 @@ func (r *reader) Merge(kvs ...*KeyValue) error {
 			return err
 		}
 	}
-	if err := r.opts.resolver(merged); err != nil {
-		return err
-	}
 	r.values = merged
 	return nil
 }
@@ -58,6 +56,10 @@ func (r *reader) Value(path string) (Value, bool) {
 
 func (r *reader) Source() ([]byte, error) {
 	return marshalJSON(convertMap(r.values))
+}
+
+func (r *reader) Resolve() error {
+	return r.opts.resolver(r.values)
 }
 
 func cloneMap(src map[string]interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
When you want to use env vars to replace the placeholders in config file, you must put env source first to init the config. It's not very friendly to users.
Changed the error message to lowercase to comply with Go's error standard.