### PR TITLE
support expand config keys

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -61,7 +61,19 @@ func WithLogger(l log.Logger) Option {
 // to target map[string]interface{} using src.Format codec.
 func defaultDecoder(src *KeyValue, target map[string]interface{}) error {
 	if src.Format == "" {
-		target[src.Key] = src.Value
+		// expand key "aaa.bbb" into map[aaa]map[bbb]interface{}
+		keys := strings.Split(src.Key, ".")
+		for i, k := range keys {
+			if i == len(keys)-1 {
+				// all kv data without format should be treated as string,
+				// otherwise there will be problems with json parsing
+				target[k] = string(src.Value)
+			} else {
+				sub := make(map[string]interface{})
+				target[k] = sub
+				target = sub
+			}
+		}
 		return nil
 	}
 	if codec := encoding.GetCodec(src.Format); codec != nil {

--- a/config/options.go
+++ b/config/options.go
@@ -65,9 +65,7 @@ func defaultDecoder(src *KeyValue, target map[string]interface{}) error {
 		keys := strings.Split(src.Key, ".")
 		for i, k := range keys {
 			if i == len(keys)-1 {
-				// all kv data without format should be treated as string,
-				// otherwise there will be problems with json parsing
-				target[k] = string(src.Value)
+				target[k] = src.Value
 			} else {
 				sub := make(map[string]interface{})
 				target[k] = sub

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -16,7 +16,7 @@ func TestDefaultDecoder(t *testing.T) {
 	err := defaultDecoder(src, target)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]interface{}{
-		"service": "config",
+		"service": []byte("config"),
 	}, target)
 
 	src = &KeyValue{
@@ -30,7 +30,7 @@ func TestDefaultDecoder(t *testing.T) {
 	assert.Equal(t, map[string]interface{}{
 		"service": map[string]interface{}{
 			"name": map[string]interface{}{
-				"alias": "2233",
+				"alias": []byte("2233"),
 			},
 		},
 	}, target)

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultDecoder(t *testing.T) {
+	src := &KeyValue{
+		Key:    "service",
+		Value:  []byte("config"),
+		Format: "",
+	}
+	target := make(map[string]interface{}, 0)
+	err := defaultDecoder(src, target)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"service": "config",
+	}, target)
+
+	src = &KeyValue{
+		Key:    "service.name.alias",
+		Value:  []byte("2233"),
+		Format: "",
+	}
+	target = make(map[string]interface{}, 0)
+	err = defaultDecoder(src, target)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"service": map[string]interface{}{
+			"name": map[string]interface{}{
+				"alias": "2233",
+			},
+		},
+	}, target)
+}

--- a/config/reader.go
+++ b/config/reader.go
@@ -99,6 +99,9 @@ func convertMap(src interface{}) interface{} {
 			dst[k] = convertMap(v)
 		}
 		return dst
+	case []byte:
+		// there will be no binary data in the config data
+		return string(m)
 	default:
 		return src
 	}


### PR DESCRIPTION
支持将类似aaa.bbb的key展开成map[aaa]map[bbb]interface{}


这样可以实现通过key来覆盖文件中的结构体value，比如：
spring:
  cloud:
    consul:
      discovery:
        catalogServicesWatch:
          enabled: false
          
会被spring.cloud.consul.discovery.catalogServicesWatch.enabled=true 覆盖