### PR TITLE
replace env underscore to dot

### DIFF
--- a/config/env/env.go
+++ b/config/env/env.go
@@ -36,6 +36,7 @@ func (e *env) Load() (kv []*config.KeyValue, err error) {
 			}
 		}
 
+		strings.Replace(k, "_", ".", -1)
 		kv = append(kv, &config.KeyValue{
 			Key:   k,
 			Value: []byte(v),

--- a/config/env/env.go
+++ b/config/env/env.go
@@ -35,8 +35,12 @@ func (e *env) Load() (kv []*config.KeyValue, err error) {
 				k = k[1:]
 			}
 		}
-
-		strings.Replace(k, "_", ".", -1)
+		if strings.Contains(k, "_") {
+			kv = append(kv, &config.KeyValue{
+				Key:   strings.Replace(k, "_", ".", -1),
+				Value: []byte(v),
+			})
+		}
 		kv = append(kv, &config.KeyValue{
 			Key:   k,
 			Value: []byte(v),


### PR DESCRIPTION
因为 . 在env里是非法字符，一般会用_来代替.的，所以需要替换回来
这样可以正确获取到 aa.bbb.ccc的value了