### PR TITLE
fix http resovler bug

### DIFF
--- a/transport/http/resolver.go
+++ b/transport/http/resolver.go
@@ -124,13 +124,6 @@ func (r *resolver) update(services []*registry.ServiceInstance) {
 	}
 }
 
-func (r *resolver) fetch(ctx context.Context) []*registry.ServiceInstance {
-	r.lock.RLock()
-	nodes := r.nodes
-	r.lock.RUnlock()
-	return nodes
-}
-
 func parseEndpoint(endpoints []string) (string, string, error) {
 	for _, e := range endpoints {
 		u, err := url.Parse(e)

--- a/transport/http/resolver.go
+++ b/transport/http/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/registry"
@@ -36,8 +37,9 @@ func parseTarget(endpoint string) (*Target, error) {
 }
 
 type resolver struct {
-	lock  sync.RWMutex
-	nodes []*registry.ServiceInstance
+	lock    sync.RWMutex
+	nodes   []*registry.ServiceInstance
+	updater Updater
 
 	target  *Target
 	watcher registry.Watcher
@@ -53,62 +55,73 @@ func newResolver(ctx context.Context, discovery registry.Discovery, target *Targ
 		target:  target,
 		watcher: watcher,
 		logger:  log.NewHelper(log.DefaultLogger),
+		updater: updater,
 	}
-	done := make(chan error, 1)
-	go func() {
-		for {
-			var executed bool
-			services, err := watcher.Next()
-			if err != nil {
-				r.logger.Errorf("http client watch service %v got unexpected error:=%v", target, err)
-				if block {
-					select {
-					case done <- err:
-					default:
-					}
-				}
-				return
-			}
-			var nodes []*registry.ServiceInstance
-			for _, in := range services {
-				_, endpoint, err := parseEndpoint(in.Endpoints)
-				if err != nil {
-					r.logger.Errorf("Failed to parse (%v) discovery endpoint: %v error %v", target, in.Endpoints, err)
-					continue
-				}
-				if endpoint == "" {
-					continue
-				}
-				nodes = append(nodes, in)
-			}
-			if len(nodes) != 0 {
-				updater.Update(nodes)
-				r.lock.Lock()
-				r.nodes = nodes
-				r.lock.Unlock()
-				if block && !executed {
-					executed = true
-					done <- nil
-				}
-			} else {
-				r.logger.Warnf("[http resovler]Zero endpoint found,refused to write,ser: %s ins: %v", target.Endpoint, nodes)
-			}
-		}
-	}()
 	if block {
-		select {
-		case e := <-done:
-			if e != nil {
-				watcher.Stop()
+		done := make(chan error, 1)
+		go func() {
+			for {
+				services, err := watcher.Next()
+				if err != nil {
+					done <- err
+					return
+				}
+				r.update(services)
+				if len(r.nodes) > 0 {
+					done <- nil
+					return
+				}
 			}
-			return r, e
+		}()
+		select {
+		case err := <-done:
+			if err != nil {
+				watcher.Stop()
+				return nil, err
+			}
 		case <-ctx.Done():
 			r.logger.Errorf("http client watch service %v reaching context deadline!", target)
 			watcher.Stop()
 			return nil, ctx.Err()
 		}
 	}
+
+	go func() {
+		for {
+			services, err := watcher.Next()
+			if err != nil {
+				r.logger.Errorf("http client watch service %v got unexpected error:=%v", target, err)
+				time.Sleep(time.Second)
+				continue
+			}
+			r.update(services)
+		}
+	}()
+
 	return r, nil
+}
+
+func (r *resolver) update(services []*registry.ServiceInstance) {
+	var nodes []*registry.ServiceInstance
+	for _, in := range services {
+		_, endpoint, err := parseEndpoint(in.Endpoints)
+		if err != nil {
+			r.logger.Errorf("Failed to parse (%v) discovery endpoint: %v error %v", r.target, in.Endpoints, err)
+			continue
+		}
+		if endpoint == "" {
+			continue
+		}
+		nodes = append(nodes, in)
+	}
+	if len(nodes) != 0 {
+		r.updater.Update(nodes)
+		r.lock.Lock()
+		r.nodes = nodes
+		r.lock.Unlock()
+	} else {
+		r.logger.Warnf("[http resovler]Zero endpoint found,refused to write,ser: %s ins: %v", r.target.Endpoint, nodes)
+	}
 }
 
 func (r *resolver) fetch(ctx context.Context) []*registry.ServiceInstance {


### PR DESCRIPTION
之前的http resovler 一旦watch 返回error会导致整个流程return,现在改成先阻塞获取，再异步监听（永不退出）