### PR TITLE
context done and timeout

### DIFF
--- a/transport/grpc/resolver/discovery/builder.go
+++ b/transport/grpc/resolver/discovery/builder.go
@@ -48,9 +48,9 @@ func NewBuilder(d registry.Discovery, opts ...Option) resolver.Builder {
 }
 
 func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
-	defer cancel()
-	w, err := b.discoverer.Watch(ctx, target.Endpoint)
+	//ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	//defer cancel()
+	w, err := b.discoverer.Watch(context.Background(), target.Endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +58,6 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts res
 	r := &discoveryResolver{
 		w:      w,
 		cc:     cc,
-		ctx:    ctx,
-		cancel: cancel,
 		log:    log.NewHelper(b.logger),
 	}
 	r.ctx, r.cancel = context.WithCancel(context.Background())

--- a/transport/grpc/resolver/discovery/resolver.go
+++ b/transport/grpc/resolver/discovery/resolver.go
@@ -31,6 +31,7 @@ func (r *discoveryResolver) watch() {
 		ins, err := r.w.Next()
 		if err != nil {
 			r.log.Errorf("Failed to watch discovery endpoint: %v", err)
+
 			time.Sleep(time.Second)
 			continue
 		}


### PR DESCRIPTION
fix #1111 
![image](https://user-images.githubusercontent.com/57396775/126995225-0e0e3a9a-8b78-4d8e-9641-8569341fc0f3.png)
因为watch是异步的 context cancel掉的时候 还没执行watch 
而且不大理解这个为什么要用超时 超时cancel掉 之后再也不能从etcd等获取节点了