### PR TITLE
fix(grpc/resovler): create watcher overtime

### DIFF
--- a/transport/grpc/resolver/discovery/builder.go
+++ b/transport/grpc/resolver/discovery/builder.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -61,6 +62,7 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, opts res
 	select {
 	case <-done:
 	case <-time.After(b.timeout):
+		err = errors.New("discovery create watcher overtime")
 	}
 	if err != nil {
 		cancel()


### PR DESCRIPTION
当时Watch 超时时，应该报错返回 不应该继续执行因为discoveryResolver的registry.Watcher 为空 会引起panic