### PR TITLE
fix: using t.TempDir instead

### DIFF
--- a/config/env/env_test.go
+++ b/config/env/env_test.go
@@ -31,7 +31,7 @@ const _testJSON = `
 
 func TestEnvWithPrefix(t *testing.T) {
 	var (
-		path     = filepath.Join(os.TempDir(), "test_config")
+		path     = filepath.Join(t.TempDir(), "test_config")
 		filename = filepath.Join(path, "test.json")
 		data     = []byte(_testJSON)
 	)
@@ -143,7 +143,7 @@ func TestEnvWithPrefix(t *testing.T) {
 
 func TestEnvWithoutPrefix(t *testing.T) {
 	var (
-		path     = filepath.Join(os.TempDir(), "test_config")
+		path     = filepath.Join(t.TempDir(), "test_config")
 		filename = filepath.Join(path, "test.json")
 		data     = []byte(_testJSON)
 	)

--- a/config/file/file_test.go
+++ b/config/file/file_test.go
@@ -84,7 +84,7 @@ const (
 
 func TestFile(t *testing.T) {
 	var (
-		path = filepath.Join(os.TempDir(), "test_config")
+		path = filepath.Join(t.TempDir(), "test_config")
 		file = filepath.Join(path, "test.json")
 		data = []byte(_testJSON)
 	)
@@ -178,7 +178,7 @@ func testSource(t *testing.T, path string, data []byte) {
 }
 
 func TestConfig(t *testing.T) {
-	path := filepath.Join(os.TempDir(), "test_config.json")
+	path := filepath.Join(t.TempDir(), "test_config.json")
 	defer os.Remove(path)
 	if err := ioutil.WriteFile(path, []byte(_testJSON), 0666); err != nil {
 		t.Error(err)
@@ -192,7 +192,7 @@ func TestConfig(t *testing.T) {
 }
 
 func testConfig(t *testing.T, c config.Config) {
-	var expected = map[string]interface{}{
+	expected := map[string]interface{}{
 		"test.settings.int_key":      int64(1000),
 		"test.settings.float_key":    float64(1000.1),
 		"test.settings.string_key":   "string_value",
@@ -258,7 +258,6 @@ func testConfig(t *testing.T, c config.Config) {
 	if _, err := c.Value("not_found_key").Bool(); errors.Is(err, config.ErrNotFound) {
 		t.Logf("not_found_key not match: %v", err)
 	}
-
 }
 
 func testScan(t *testing.T, c config.Config) {


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests for your PR, such as using `go test ./...`
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    deps: Changes external dependencies
    break: Changes has break change

    docs: Documentation only changes
    refactor: A code change that neither fixes a bug nor adds a feature
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    test: Adding missing tests or correcting existing tests
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

When using os.TempDir() test may FAIL sometime, using t.TempDir() instead.

#### Which issue(s) this PR fixes:
<!--
* Automatically closes linked issue when PR is merged.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
fixes #1288 

#### Other special notes for reviewer:

