### PR TITLE
fix(example/blog/makefile): directory does not exist

### DIFF
--- a/examples/blog/Makefile
+++ b/examples/blog/Makefile
@@ -37,7 +37,7 @@ http:
 # generate errors code
 errors:
 	protoc --proto_path=. \
-           --proto_path=./third_party \
+           --proto_path=$(KRATOS)/third_party \
            --go_out=paths=source_relative:. \
            --go-errors_out=paths=source_relative:. \
            $(API_PROTO_FILES)


### PR DESCRIPTION
在 kratos/examples/blog 执行 make errors 时报错 
./third_party: warning: directory does not exist.