### PR TITLE
fix(config): fix data race

### DIFF
--- a/config/file/file_test.go
+++ b/config/file/file_test.go
@@ -69,14 +69,14 @@ const (
 	}
 }`
 
-//	_testYaml = `
-//Foo:
-//    bar :
-//        - {name: nihao,age: 1}
-//        - {name: nihao,age: 1}
-//
-//
-//`
+	//	_testYaml = `
+	//Foo:
+	//    bar :
+	//        - {name: nihao,age: 1}
+	//        - {name: nihao,age: 1}
+	//
+	//
+	//`
 )
 
 //func TestScan(t *testing.T) {

--- a/config/file/file_test.go
+++ b/config/file/file_test.go
@@ -300,26 +300,24 @@ func TestMergeDataRace(t *testing.T) {
 		NewSource(path),
 	))
 	wg := &sync.WaitGroup{}
+	wg.Add(2)
 	go func() {
-		wg.Add(1)
+		defer wg.Done()
 		for i := 0; i < 100; i++ {
 			var conf struct{}
 			if err := c.Scan(&conf); err != nil {
 				t.Error(err)
 			}
 		}
-		wg.Done()
 	}()
 
 	go func() {
-		wg.Add(1)
+		defer wg.Done()
 		for i := 0; i < 100; i++ {
 			if err := c.Load(); err != nil {
 				t.Error(err)
 			}
 		}
-		wg.Done()
 	}()
 	wg.Wait()
-
 }


### PR DESCRIPTION
There are some data races in current codes. These data races will break the Github Actions CI testing sometimes. The unit test in this PR could reproduce this issue. This data race will happen when Scan() and Load() in the same time.

This PR adds a lock to the config values map in order to avoid concurrent reads and writes.

data race message:
```
WARNING: DATA RACE
Read at 0x00c0004ac0b8 by goroutine 16:
  github.com/go-kratos/kratos/v2/config.(*reader).Source()
      /Users/windfarer/github/kratos/config/reader.go:58 +0x44
  github.com/go-kratos/kratos/v2/config.(*config).Scan()
      /Users/windfarer/github/kratos/config/config.go:131 +0x5b
  github.com/go-kratos/kratos/v2/config/file.TestMergeDataRace.func1()
      /Users/windfarer/github/kratos/config/file/file_test.go:308 +0x8d

Previous write at 0x00c0004ac0b8 by goroutine 17:
  github.com/go-kratos/kratos/v2/config.(*reader).Merge()
      /Users/windfarer/github/kratos/config/reader.go:49 +0x2fc
  github.com/go-kratos/kratos/v2/config.(*config).Load()
      /Users/windfarer/github/kratos/config/config.go:101 +0x144
  github.com/go-kratos/kratos/v2/config/file.TestMergeDataRace.func2()
      /Users/windfarer/github/kratos/config/file/file_test.go:318 +0x75

WARNING: DATA RACE
Read at 0x00c00040a930 by goroutine 16:
  github.com/go-kratos/kratos/v2/config.convertMap()
      /Users/windfarer/github/kratos/config/reader.go:98 +0xa4
  github.com/go-kratos/kratos/v2/config.convertMap()
      /Users/windfarer/github/kratos/config/reader.go:100 +0x1c9
  github.com/go-kratos/kratos/v2/config.convertMap()
      /Users/windfarer/github/kratos/config/reader.go:100 +0x1c9
  github.com/go-kratos/kratos/v2/config.(*reader).Source()
      /Users/windfarer/github/kratos/config/reader.go:69 +0x6c
  github.com/go-kratos/kratos/v2/config.(*config).Scan()
      /Users/windfarer/github/kratos/config/config.go:131 +0x5b
  github.com/go-kratos/kratos/v2/config/file.TestMergeDataRace.func1()
      /Users/windfarer/github/kratos/config/file/file_test.go:308 +0xcc

Previous write at 0x00c00040a930 by goroutine 17:
  runtime.mapassign_faststr()
      /usr/local/Cellar/go/1.15.5/libexec/src/runtime/map_faststr.go:202 +0x0
  github.com/go-kratos/kratos/v2/config.defaultResolver.func2()
      /Users/windfarer/github/kratos/config/options.go:102 +0x674
  github.com/go-kratos/kratos/v2/config.defaultResolver.func2()
      /Users/windfarer/github/kratos/config/options.go:104 +0x193
  github.com/go-kratos/kratos/v2/config.defaultResolver.func2()
      /Users/windfarer/github/kratos/config/options.go:104 +0x193
  github.com/go-kratos/kratos/v2/config.defaultResolver()
      /Users/windfarer/github/kratos/config/options.go:123 +0x98
  github.com/go-kratos/kratos/v2/config.(*reader).Resolve()
      /Users/windfarer/github/kratos/config/reader.go:73 +0x88
  github.com/go-kratos/kratos/v2/config.(*config).Load()
      /Users/windfarer/github/kratos/config/config.go:112 +0x1fe
  github.com/go-kratos/kratos/v2/config/file.TestMergeDataRace.func2()
      /Users/windfarer/github/kratos/config/file/file_test.go:317 +0xb3

``` 
