### PR TITLE
append config watchers when watch source

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ func (c *config) Load() error {
 			c.log.Errorf("failed to watch config source: %v", err)
 			return err
 		}
+		c.watchers = append(c.watchers, w)
 		go c.watch(w)
 	}
 	if err := c.reader.Resolve(); err != nil {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
add watchers to config when load.

#### Which issue(s) this PR fixes:
fixes #1318 

#### Other special notes for reviewer: