### PR TITLE
fix(config): Support colon as default value in config.yaml

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -183,6 +183,7 @@ func TestDefaultResolver(t *testing.T) {
 				"enable":   "${ENABLE:false}",
 				"rate":     "${RATE}",
 				"empty":    "${EMPTY:foobar}",
+				"url":      "${URL:http://example.com}",
 				"array": []interface{}{
 					"${PORT}",
 					map[string]interface{}{"foobar": "${NOTEXIST:8081}"},
@@ -236,6 +237,11 @@ func TestDefaultResolver(t *testing.T) {
 			name:   "test empty value with default",
 			path:   "foo.bar.empty",
 			expect: "",
+		},
+		{
+			name:   "test url with default",
+			path:   "foo.bar.url",
+			expect: "http://example.com",
 		},
 		{
 			name:   "test array",

--- a/config/options.go
+++ b/config/options.go
@@ -84,7 +84,7 @@ func defaultDecoder(src *KeyValue, target map[string]interface{}) error {
 // placeholder format in ${key:default} or $key.
 func defaultResolver(input map[string]interface{}) error {
 	mapper := func(name string) string {
-		args := strings.Split(strings.TrimSpace(name), ":")
+		args := strings.SplitN(strings.TrimSpace(name), ":", 2)
 		if v, has := readValue(input, args[0]); has {
 			s, _ := v.String()
 			return s


### PR DESCRIPTION

#### Description (what this PR does / why we need it):
This PR fixes a bug where the default variable of a config option was trimmed when a colon was found


#### Which issue(s) this PR fixes:

fixes #

#### Other special notes for reviewer:
