### PR TITLE
fix: if not kratos context then panic will result

### DIFF
--- a/middleware/tracing/metadata.go
+++ b/middleware/tracing/metadata.go
@@ -19,7 +19,7 @@ var _ propagation.TextMapPropagator = Metadata{}
 func (b Metadata) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
 	app, ok := kratos.FromContext(ctx)
 	if ok {
-		carrier.Set(serviceHeader, app.Name())	
+		carrier.Set(serviceHeader, app.Name())
 	}
 }
 

--- a/middleware/tracing/metadata.go
+++ b/middleware/tracing/metadata.go
@@ -17,8 +17,10 @@ var _ propagation.TextMapPropagator = Metadata{}
 
 // Inject sets metadata key-values from ctx into the carrier.
 func (b Metadata) Inject(ctx context.Context, carrier propagation.TextMapCarrier) {
-	app, _ := kratos.FromContext(ctx)
-	carrier.Set(serviceHeader, app.Name())
+	app, ok := kratos.FromContext(ctx)
+	if ok {
+		carrier.Set(serviceHeader, app.Name())	
+	}
 }
 
 // Extract returns a copy of parent with the metadata from the carrier added.


### PR DESCRIPTION
当ctx不是kratos的context，则app.Name()会导致panic