### PR TITLE
refactor(encoding): optimize json encoding

### DIFF
--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -2,10 +2,11 @@ package json
 
 import (
 	"encoding/json"
+	"reflect"
+
 	"github.com/go-kratos/kratos/v2/encoding"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"reflect"
 )
 
 // Name is the name registered for the json codec.

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -2,7 +2,6 @@ package json
 
 import (
 	"encoding/json"
-	"errors"
 	"reflect"
 
 	"github.com/go-kratos/kratos/v2/encoding"
@@ -22,7 +21,6 @@ var (
 	UnmarshalOptions = protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
-	invalidDataErr = errors.New("invalid json data")
 )
 
 func init() {
@@ -33,9 +31,6 @@ func init() {
 type codec struct{}
 
 func (codec) Marshal(v interface{}) ([]byte, error) {
-	if v == nil {
-		return []byte{}, nil
-	}
 	switch m := v.(type) {
 	case json.Marshaler:
 		return m.MarshalJSON()
@@ -47,9 +42,6 @@ func (codec) Marshal(v interface{}) ([]byte, error) {
 }
 
 func (codec) Unmarshal(data []byte, v interface{}) error {
-	if len(data) < 5 {
-		return invalidDataErr
-	}
 	switch m := v.(type) {
 	case json.Unmarshaler:
 		return m.UnmarshalJSON(data)

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/go-kratos/kratos/v2/encoding"
@@ -21,6 +22,7 @@ var (
 	UnmarshalOptions = protojson.UnmarshalOptions{
 		DiscardUnknown: true,
 	}
+	invalidDataErr = errors.New("invalid json data")
 )
 
 func init() {
@@ -46,7 +48,7 @@ func (codec) Marshal(v interface{}) ([]byte, error) {
 
 func (codec) Unmarshal(data []byte, v interface{}) error {
 	if len(data) < 5 {
-		return nil
+		return invalidDataErr
 	}
 	switch m := v.(type) {
 	case json.Unmarshaler:


### PR DESCRIPTION
优化如下：
1、支持使用easyjson或定制实现方法，来提升序列化特别是反序列化的性能
2、api接口提交的body为空json体时，不需要进行反序列化，可以大幅提升性能
3、原先的反序列化方法中先进行反射，调整顺序到后面，避免每次都应用反射