### PR TITLE
chore: add icon in issues template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: Bug Report
+name: "\U0001F41B Bug Report"
 about: Create a report to help us improve.
 title: ''
 labels: bug

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F41B Bug Report"
-about: Create a report to help us improve.
+about: Report something that's broken. Please ensure your kratos version is still supported.
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation issue
+    url: https://go-kratos.dev/en/docs/
+    about: For documentation issues, open a pull request at the go-kratos/go-kratos.dev repository

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: "\U0001F4A1 Feature Request"
-about: Suggest an idea for Kratos.
+about: For ideas or feature requests, start a new discussion.
 title: "[Feature]"
 labels: feature
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,5 +1,5 @@
 ---
-name: Feature Request
+name: "\U0001F4A1 Feature Request"
 about: Suggest an idea for Kratos.
 title: "[Feature]"
 labels: feature

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-name: Question
+name: "\U0001F680 Question"
 about: Ask a question about Kratos.
 title: "[Question]"
 labels: question


### PR DESCRIPTION
为 issues 加入了可爱的 icon 图标，并且对于文档类问题引导用户进入 kratos 文档网站，效果如下：

<img width="944" alt="1" src="https://user-images.githubusercontent.com/12524356/129753856-a72e537e-b662-4ed2-9695-f0b14b1426db.png">


