### PR TITLE
fix: move TraceID and SpanID

### DIFF
--- a/examples/traces/app/message/main.go
+++ b/examples/traces/app/message/main.go
@@ -65,8 +65,8 @@ func (s *server) GetUserMessage(ctx context.Context, request *v1.GetUserMessageR
 
 func main() {
 	logger := log.NewStdLogger(os.Stdout)
-	logger = log.With(logger, "trace_id", tracing.TraceID())
-	logger = log.With(logger, "span_id", tracing.SpanID())
+	logger = log.With(logger, "trace_id", log.TraceID())
+	logger = log.With(logger, "span_id", log.SpanID())
 	log := log.NewHelper(logger)
 
 	url := "http://jaeger:14268/api/traces"

--- a/examples/traces/app/user/main.go
+++ b/examples/traces/app/user/main.go
@@ -90,8 +90,8 @@ func (s *server) GetMyMessages(ctx context.Context, in *v1.GetMyMessagesRequest)
 
 func main() {
 	logger := log.NewStdLogger(os.Stdout)
-	logger = log.With(logger, "trace_id", tracing.TraceID())
-	logger = log.With(logger, "span_id", tracing.SpanID())
+	logger = log.With(logger, "trace_id", log.TraceID())
+	logger = log.With(logger, "span_id", log.SpanID())
 	log := log.NewHelper(logger)
 
 	url := "http://jaeger:14268/api/traces"

--- a/log/value.go
+++ b/log/value.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/log/value.go
+++ b/log/value.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -57,6 +58,26 @@ func bindValues(ctx context.Context, keyvals []interface{}) {
 		if v, ok := keyvals[i].(Valuer); ok {
 			keyvals[i] = v(ctx)
 		}
+	}
+}
+
+// TraceID returns a traceid valuer.
+func TraceID() Valuer {
+	return func(ctx context.Context) interface{} {
+		if span := trace.SpanContextFromContext(ctx); span.HasTraceID() {
+			return span.TraceID().String()
+		}
+		return ""
+	}
+}
+
+// SpanID returns a spanid valuer.
+func SpanID() Valuer {
+	return func(ctx context.Context) interface{} {
+		if span := trace.SpanContextFromContext(ctx); span.HasSpanID() {
+			return span.SpanID().String()
+		}
+		return ""
 	}
 }
 

--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -3,8 +3,6 @@ package tracing
 import (
 	"context"
 
-	"github.com/go-kratos/kratos/v2/log"
-
 	"github.com/go-kratos/kratos/v2/middleware"
 	"github.com/go-kratos/kratos/v2/transport"
 	"go.opentelemetry.io/otel/propagation"
@@ -66,22 +64,3 @@ func Client(opts ...Option) middleware.Middleware {
 	}
 }
 
-// TraceID returns a traceid valuer.
-func TraceID() log.Valuer {
-	return func(ctx context.Context) interface{} {
-		if span := trace.SpanContextFromContext(ctx); span.HasTraceID() {
-			return span.TraceID().String()
-		}
-		return ""
-	}
-}
-
-// SpanID returns a spanid valuer.
-func SpanID() log.Valuer {
-	return func(ctx context.Context) interface{} {
-		if span := trace.SpanContextFromContext(ctx); span.HasSpanID() {
-			return span.SpanID().String()
-		}
-		return ""
-	}
-}

--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -63,4 +63,3 @@ func Client(opts ...Option) middleware.Middleware {
 		}
 	}
 }
-


### PR DESCRIPTION
因为之前 middleware 单独依赖，框架中移除 otel 依赖，就把 TraceID 和 SpanID 移动到了 tracing 中间件下，现在既然不需要移除 otel 依赖的话，这两个可以继续放在 log 下