### PR TITLE
fix: enhance errors.FromError

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/grpc_testing"
 )
 
 func TestError(t *testing.T) {
@@ -45,5 +49,12 @@ func TestError(t *testing.T) {
 	se := FromError(gs.Err())
 	if se.Reason != "reason" {
 		t.Errorf("got %+v want %+v", se, err)
+	}
+
+	gs2, _ := status.New(codes.InvalidArgument, "bad request").WithDetails(&grpc_testing.Empty{})
+	se2 := FromError(gs2.Err())
+	// codes.InvalidArgument should convert to http.StatusBadRequest
+	if se2.Code != http.StatusBadRequest {
+		t.Errorf("convert code err, got %d want %d", UnknownCode, http.StatusBadRequest)
 	}
 }


### PR DESCRIPTION
add converting support for grpc status whose details not contain any  `errdetails.ErrorInfo`

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
enhance errors.FromError
add converting support for grpc status whose details not contain any  `errdetails.ErrorInfo`

ie. a grpc status with code `codes.InvalidArgument` should be converted to `http.StatusBadRequest` instead of `UnknownCode`.