### PR TITLE
feat(transport): add listener option

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -79,6 +79,8 @@ func TLSConfig(c *tls.Config) ServerOption {
 func Listener(lis net.Listener) ServerOption {
 	return func(s *Server) {
 		s.lis = lis
+		s.address = lis.Addr().String()
+		s.network = "tcp"
 	}
 }
 

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/url"
 	"strings"
 	"testing"
@@ -20,9 +21,13 @@ type testKey struct{}
 func TestServer(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, testKey{}, "test")
-	srv := NewServer(Middleware([]middleware.Middleware{
+	mdws := Middleware([]middleware.Middleware{
 		func(middleware.Handler) middleware.Handler { return nil },
-	}...))
+	}...)
+	lis, err := net.Listen("tcp", ":12345")
+	assert.NoError(t, err)
+	opts := []ServerOption{mdws, Listener(lis)}
+	srv := NewServer(opts...)
 
 	if e, err := srv.Endpoint(); err != nil || e == nil || strings.HasSuffix(e.Host, ":0") {
 		t.Fatal(e, err)

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -118,6 +118,8 @@ func StrictSlash(strictSlash bool) ServerOption {
 func Listener(lis net.Listener) ServerOption {
 	return func(o *Server) {
 		o.lis = lis
+		o.address = lis.Addr().String()
+		o.network = "tcp"
 	}
 }
 

--- a/transport/http/server_test.go
+++ b/transport/http/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,7 +31,9 @@ func TestServer(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(testData{Path: r.RequestURI})
 	}
 	ctx := context.Background()
-	srv := NewServer()
+	lis, err := net.Listen("tcp", ":12345")
+	assert.NoError(t, err)
+	srv := NewServer(Listener(lis))
 	srv.HandleFunc("/index", fn)
 	srv.HandleFunc("/index/{id:[0-9]+}", fn)
 	srv.HandleHeader("content-type", "application/grpc-web+json", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
net.Listener is an interface, which allows users to implement it themselves. For example, users can wrap the net.Listener of the standard library to do something when receiving a connection, such as outputting logs. The framework should provide such extensibility as the standard library.

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If you PR is not fully resolved issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
fixes #1413 

#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->
