### PR TITLE
feat(auth/jwt): provide function SignToken as a separate method

### DIFF
--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -126,7 +126,7 @@ func Client(keyProvider jwt.Keyfunc, opts ...Option) middleware.Middleware {
 	}
 }
 
-// SignToken is used to issue JWT token.
+// SignToken is used to sign JWT token.
 func SignToken(keyProvider jwt.Keyfunc, opts ...Option) (string, error) {
 	o := &options{
 		signingMethod: jwt.SigningMethodHS256,

--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -113,7 +113,7 @@ func Client(keyProvider jwt.Keyfunc, opts ...Option) middleware.Middleware {
 			if keyProvider == nil {
 				return nil, ErrNeedTokenProvider
 			}
-			tokenStr,err := SignToken(keyProvider, opts...)
+			tokenStr, err := SignToken(keyProvider, opts...)
 			if err != nil {
 				return nil, err
 			}
@@ -138,7 +138,7 @@ func SignToken(keyProvider jwt.Keyfunc, opts ...Option) (string, error) {
 	token := jwt.NewWithClaims(o.signingMethod, o.claims)
 	key, err := keyProvider(token)
 	if err != nil {
-		return "",ErrGetKey
+		return "", ErrGetKey
 	}
 	tokenStr, err := token.SignedString(key)
 	if err != nil {


### PR DESCRIPTION
Extract the sign token related code originally contained in Client() and provide it as a separate function.