### PR TITLE
encoding/form: support repeated filed map from path etc.

### DIFF
--- a/encoding/form/form.go
+++ b/encoding/form/form.go
@@ -67,7 +67,7 @@ func (c codec) Unmarshal(data []byte, v interface{}) error {
 	}
 	if m, ok := v.(proto.Message); ok {
 		return MapProto(m, vs)
-	} else if m, ok := reflect.Indirect(reflect.ValueOf(v)).Interface().(proto.Message); ok {
+	} else if m, ok = reflect.Indirect(reflect.ValueOf(v)).Interface().(proto.Message); ok {
 		return MapProto(m, vs)
 	}
 

--- a/encoding/form/form_test.go
+++ b/encoding/form/form_test.go
@@ -3,9 +3,10 @@ package form
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/go-kratos/kratos/v2/encoding"
 	"github.com/go-kratos/kratos/v2/internal/complex"
-	"github.com/stretchr/testify/require"
 )
 
 type LoginRequest struct {

--- a/encoding/form/proto_decode.go
+++ b/encoding/form/proto_decode.go
@@ -98,7 +98,7 @@ func populateValues(s string) []string {
 
 	a := make([]string, n)
 	na := 0
-	fieldStart := 0
+	var fieldStart int
 	i := 0
 	// Skip seps in the front of the input.
 	for i < len(s) && separator[s[i]] != 0 {

--- a/encoding/form/proto_decode_test.go
+++ b/encoding/form/proto_decode_test.go
@@ -1,0 +1,44 @@
+package form
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-kratos/kratos/v2/internal/testdata/encoding"
+)
+
+func TestPopulateRepeatedField(t *testing.T) {
+	want := []string{"a", "b", "c"}
+	require.Equal(t, populateValues("a,b,c"), want)
+	require.Equal(t, populateValues("a|b|c"), want)
+	require.Equal(t, populateValues("a b c"), want)
+	require.Equal(t, populateValues("a\tb\tc"), want)
+	require.Equal(t, populateValues("string_do_not_need_split"), []string{"string_do_not_need_split"})
+}
+
+func TestRepeatedFieldMapProto(t *testing.T) {
+	tests := []string{
+		"movie|game|reading|running",
+		"movie,game,reading,running",
+		"movie game reading running",
+		"movie\tgame\treading\trunning",
+	}
+	want := []string{"movie", "game", "reading", "running"}
+	for _, tt := range tests {
+		message := new(encoding.TestModel)
+		err := MapProto(message, map[string][]string{
+			"hobby": {tt},
+		})
+		require.NoError(t, err)
+		require.Equal(t, message.Hobby, want)
+	}
+
+	normal := "movie_game_reading_running"
+	message := new(encoding.TestModel)
+	err := MapProto(message, map[string][]string{
+		"hobby": {normal},
+	})
+	require.NoError(t, err)
+	require.Equal(t, message.Hobby, []string{normal})
+}

--- a/transport/http/binding/bind_test.go
+++ b/transport/http/binding/bind_test.go
@@ -1,0 +1,25 @@
+package binding
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/go-kratos/kratos/v2/internal/testdata/encoding"
+)
+
+func TestBindFormRepeated(t *testing.T) {
+	req := new(encoding.TestModel)
+	err := BindQuery(url.Values{
+		"hobby": []string{"movie,game,reading,running"},
+	}, req)
+	require.NoError(t, err)
+	require.Equal(t, req.Hobby, []string{"movie", "game", "reading", "running"})
+	req = new(encoding.TestModel)
+	err = BindQuery(url.Values{
+		"hobby": []string{"movie_game_reading_running"},
+	}, req)
+	require.NoError(t, err)
+	require.Equal(t, req.Hobby, []string{"movie_game_reading_running"})
+}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
https://github.com/go-kratos/kratos/issues/1193



#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->
Now there is no compulsion to use the same legal separator, which means that the user can use the format `a b,c|d\te`, which will also be legally parsed as `[]string{"a", "b", "c", "d", "e"}`, I'm not sure if this is good practice, maybe we can restrict it to a single legal separator.
