### PR TITLE
fix(cmd): fixed a single word enum error

### DIFF
--- a/cmd/protoc-gen-go-errors/errors.go
+++ b/cmd/protoc-gen-go-errors/errors.go
@@ -94,7 +94,7 @@ func genErrorsReason(gen *protogen.Plugin, file *protogen.File, g *protogen.Gene
 
 func case2Camel(name string) string {
 	if !strings.Contains(name, "_") {
-		return name
+		return strings.Title(strings.ToLower(name))
 	}
 	name = strings.ToLower(name)
 	name = strings.Replace(name, "_", " ", -1)


### PR DESCRIPTION
fix[cmd]: if enum is a word in proto file, it should be camel too.
For example: 
  UNKNOWN field defined in errors proto file. 
   `protoc-gen-go-errors` generate func IsUNKNOWN AND ErrorUNKNOWN, I think IsUnknown and ErrorUnknown will be better.