### PR TITLE
日志截取

### DIFF
--- a/middleware/logging/logging.go
+++ b/middleware/logging/logging.go
@@ -11,6 +11,9 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 )
 
+// Half of req what needs to be displayed
+var halfReqLength = 4 * 1024
+
 // Server is an server logging middleware.
 func Server(logger log.Logger) middleware.Middleware {
 	return func(handler middleware.Handler) middleware.Handler {
@@ -85,10 +88,16 @@ func Client(logger log.Logger) middleware.Middleware {
 
 // extractArgs returns the string of the req
 func extractArgs(req interface{}) string {
+	var s string
 	if stringer, ok := req.(fmt.Stringer); ok {
-		return stringer.String()
+		s = stringer.String()
+	} else {
+		s = fmt.Sprintf("%+v", req)
 	}
-	return fmt.Sprintf("%+v", req)
+	if len(s) > halfReqLength*2 {
+		s = s[:halfReqLength] + " ... " + s[len(s)-halfReqLength:]
+	}
+	return s
 }
 
 // extractError returns the string of the error

--- a/middleware/logging/logging_test.go
+++ b/middleware/logging/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -94,6 +95,39 @@ func TestHTTP(t *testing.T) {
 			v, e := next(test.ctx, "req.args")
 			t.Logf("[%s]reply: %v, error: %v", test.name, v, e)
 			t.Logf("[%s]log:%s", test.name, bf.String())
+		})
+	}
+}
+
+func Test_extractArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		reqLen  int
+		wantLen int
+	}{
+		{
+			name:    "length@double",
+			reqLen:  halfReqLength * 2,
+			wantLen: halfReqLength * 2,
+		},
+		{
+			name:    "length@without",
+			reqLen:  halfReqLength*2 + 1,
+			wantLen: halfReqLength*2 + len(" ... "),
+		},
+		{
+			name:    "length@within",
+			reqLen:  halfReqLength*2 - 1,
+			wantLen: halfReqLength*2 - 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := strings.Repeat("-", test.reqLen)
+			res := extractArgs(req)
+			if len(res) != test.wantLen {
+				t.Errorf("want length %d got %d res is (%s)", test.wantLen, len(res), res)
+			}
 		})
 	}
 }


### PR DESCRIPTION
req传入内容过长时，打印req会占用大量资源，
实际上我们需要关心的就只是开头和结尾而已
所以截取前后4k就够用了