### PR TITLE
feat: Allow to define the a generic base url for all the service methods

### DIFF
--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -15,8 +15,8 @@ type {{.ServiceType}}HTTPServer interface {
 {{- end}}
 }
 
-func Register{{.ServiceType}}HTTPServer(s *http.Server, srv {{.ServiceType}}HTTPServer) {
-	r := s.Route("/")
+func Register{{.ServiceType}}HTTPServer(s *http.Server, srv {{.ServiceType}}HTTPServer, base string) {
+	r := s.Route(base)
 	{{- range .Methods}}
 	r.{{.Method}}("{{.Path}}", _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv))
 	{{- end}}


### PR DESCRIPTION
This allows the http api url to be more generic by using:

```
v1.RegisterBlogServiceHTTPServer(srv, blog, "/api/")
```
