### PR TITLE
fix(cmd/proto-gen-http):  non nil assertion for error

### DIFF
--- a/cmd/protoc-gen-go-errors/template.go
+++ b/cmd/protoc-gen-go-errors/template.go
@@ -9,6 +9,9 @@ var errorsTemplate = `
 {{ range .Errors }}
 
 func Is{{.CamelValue}}(err error) bool {
+	if err == nil {
+		return false
+	}
 	e := errors.FromError(err)
 	return e.Reason == {{.Name}}_{{.Value}}.String() && e.Code == {{.HTTPCode}} 
 }


### PR DESCRIPTION
修复： errors 插件生成的代码中， Isxxx 判断函数未对 入参 err 进行空判断。