### PR TITLE
docs: some wrong err msg description

### DIFF
--- a/contrib/registry/nacos/registry.go
+++ b/contrib/registry/nacos/registry.go
@@ -81,7 +81,7 @@ func New(cli naming_client.INamingClient, opts ...Option) (r *Registry) {
 // Register the registration.
 func (r *Registry) Register(_ context.Context, si *registry.ServiceInstance) error {
 	if si.Name == "" {
-		return fmt.Errorf("kratos/nacos: serviceInstance.name cannot is empty")
+		return fmt.Errorf("kratos/nacos: serviceInstance.name can not be empty")
 	}
 	for _, endpoint := range si.Endpoints {
 		u, err := url.Parse(endpoint)


### PR DESCRIPTION
`cannot is empty` -> `can not be emptu`