### PR TITLE
fix(cmd): fixed a camel word enum error (#1618)

### DIFF
--- a/cmd/protoc-gen-go-errors/errors.go
+++ b/cmd/protoc-gen-go-errors/errors.go
@@ -94,7 +94,11 @@ func genErrorsReason(gen *protogen.Plugin, file *protogen.File, g *protogen.Gene
 
 func case2Camel(name string) string {
 	if !strings.Contains(name, "_") {
-		return strings.Title(strings.ToLower(name))
+		upperName := strings.ToUpper(name)
+		if upperName == name {
+			name = strings.ToLower(name)
+		}
+		return strings.Title(name)
 	}
 	name = strings.ToLower(name)
 	name = strings.Replace(name, "_", " ", -1)

--- a/cmd/protoc-gen-go-errors/errors_test.go
+++ b/cmd/protoc-gen-go-errors/errors_test.go
@@ -46,6 +46,11 @@ func Test_case2Camel(t *testing.T) {
 			args: args{"systemError"},
 			want: "SystemError",
 		},
+		{
+			name: "lower1",
+			args: args{"system"},
+			want: "System",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/protoc-gen-go-errors/errors_test.go
+++ b/cmd/protoc-gen-go-errors/errors_test.go
@@ -1,0 +1,57 @@
+package main
+
+import "testing"
+
+func Test_case2Camel(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "snake1",
+			args: args{"SYSTEM_ERROR"},
+			want: "SystemError",
+		},
+		{
+			name: "snake2",
+			args: args{"System_Error"},
+			want: "SystemError",
+		},
+		{
+			name: "snake3",
+			args: args{"system_error"},
+			want: "SystemError",
+		},
+		{
+			name: "snake4",
+			args: args{"System_error"},
+			want: "SystemError",
+		},
+		{
+			name: "upper1",
+			args: args{"UNKNOWN"},
+			want: "Unknown",
+		},
+		{
+			name: "camel1",
+			args: args{"SystemError"},
+			want: "SystemError",
+		},
+		{
+			name: "camel2",
+			args: args{"systemError"},
+			want: "SystemError",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := case2Camel(tt.args.name); got != tt.want {
+				t.Errorf("case2Camel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
fix https://github.com/go-kratos/kratos/pull/1618

```
enum ErrorReason {
  option (errors.default_code) = 500;

  InvalidParameter = 0 [(errors.code) = 400];
}
```
Originally I got  IsInvalidParameter and ErrorInvalidParameter，but now i got IsInvalidparameter and ErrorInvalidparameter

This change compatible with  UPPER、Camel and Snake
