### PR TITLE
fix: remove the use of client timeout as discovery timeout

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -145,7 +145,6 @@ func dial(ctx context.Context, insecure bool, opts ...ClientOption) (*grpc.Clien
 					options.discovery,
 					discovery.WithInsecure(insecure),
 					discovery.WithLogger(options.logger),
-					discovery.WithTimeout(options.timeout),
 				)))
 	}
 	if insecure {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

I think `timeout` in `clientOptions` means the timeout of a grpc client calling, not discovery timeout, it's quite different.

In my project, I set the timeout to 0 with the purpose of no timeout, let the server decide how long to timeout, or use `context.WithTimeout` in the client request.

It works because kratos support that:

https://github.com/go-kratos/kratos/blob/e95452276f1f16490c358ae56afed459a8c6ef14/transport/grpc/client.go#L171-L175

However, it is broken down after v2.1.3, because the value has been used as discovery timeout, unfortunately, zero timeout do not work:

https://github.com/go-kratos/kratos/blob/e95452276f1f16490c358ae56afed459a8c6ef14/transport/grpc/resolver/discovery/builder.go#L68-L76

I noticed that the [commit](https://github.com/go-kratos/kratos/commit/5aeb14d381c2e06cdd8e618b186f49e3b1cc4b9f) which changed it is "gRPC client discovery supports incoming logger", I believe that it is none of the business about the timeout.

I agree that there should be a way to set timeout of discovery `clientOptions`, but it should not borrow `timeout`, maybe create a new field named `discoveryTimeout`?

#### Which issue(s) this PR fixes (resolves / be part of):

None.

#### Other special notes for reviewer:

- @shenqidebaozi 

