### PR TITLE
fix(middleware/auth/jwt): server method not using customer claim for parsing

### DIFF
--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -66,7 +66,7 @@ func WithClaims(claims jwt.Claims) Option {
 func Server(keyFunc jwt.Keyfunc, opts ...Option) middleware.Middleware {
 	o := &options{
 		signingMethod: jwt.SigningMethodHS256,
-		claims:        jwt.StandardClaims{},
+		claims:        jwt.MapClaims{},
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -82,7 +82,7 @@ func Server(keyFunc jwt.Keyfunc, opts ...Option) middleware.Middleware {
 					return nil, ErrMissingJwtToken
 				}
 				jwtToken := auths[1]
-				tokenInfo, err := jwt.Parse(jwtToken, keyFunc)
+				tokenInfo, err := jwt.ParseWithClaims(jwtToken, o.claims, keyFunc)
 				if err != nil {
 					if ve, ok := err.(*jwt.ValidationError); ok {
 						if ve.Errors&jwt.ValidationErrorMalformed != 0 {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
85行的 `jwt.Parse`，最终会调用 `p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)`, 所以将69行的claims修改为`jwt.MapClaims{}`，将85行改为`jwt.ParseWithClaims`

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If you PR is not fully resolved issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
fixes #1719 
