### PR TITLE
fix(encoding/form): FieldMask are converted to/from lower-camel naming conventions.

### DIFF
--- a/encoding/form/form.go
+++ b/encoding/form/form.go
@@ -34,7 +34,7 @@ func (c codec) Marshal(v interface{}) ([]byte, error) {
 	var vs url.Values
 	var err error
 	if m, ok := v.(proto.Message); ok {
-		vs, err = EncodeMap(m)
+		vs, err = EncodeValues(m)
 		if err != nil {
 			return nil, err
 		}
@@ -66,9 +66,9 @@ func (c codec) Unmarshal(data []byte, v interface{}) error {
 		rv = rv.Elem()
 	}
 	if m, ok := v.(proto.Message); ok {
-		return MapProto(m, vs)
+		return DecodeValues(m, vs)
 	} else if m, ok := reflect.Indirect(reflect.ValueOf(v)).Interface().(proto.Message); ok {
-		return MapProto(m, vs)
+		return DecodeValues(m, vs)
 	}
 
 	return c.decoder.Decode(v, vs)

--- a/transport/http/binding/encode.go
+++ b/transport/http/binding/encode.go
@@ -35,7 +35,7 @@ func EncodeURL(pathTemplate string, msg proto.Message, needQuery bool) string {
 		return in
 	})
 	if needQuery {
-		u, err := form.EncodeMap(msg)
+		u, err := form.EncodeValues(msg)
 		if err == nil && len(u) > 0 {
 			for key := range pathParams {
 				delete(u, key)


### PR DESCRIPTION
// The JSON representation for a FieldMask is a JSON string where paths are
// separated by a comma. Fields name in each path are converted to/from
// lower-camel naming conventions. Encoding should fail if the path name would
// end up differently after a round-trip.

references: https://github.com/protocolbuffers/protobuf-go/blob/master/encoding/protojson/well_known_types.go#L842