### PR TITLE
fix(transport/codec): Repair the error when the request parameter is "emptypb. Empty"

### DIFF
--- a/transport/http/codec.go
+++ b/transport/http/codec.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"google.golang.org/protobuf/types/known/emptypb"
 	"io"
 	"net/http"
 
@@ -23,6 +24,9 @@ type EncodeErrorFunc func(http.ResponseWriter, *http.Request, error)
 
 // DefaultRequestDecoder decodes the request body to object.
 func DefaultRequestDecoder(r *http.Request, v interface{}) error {
+	if _, ok := v.(*emptypb.Empty); ok {
+		return nil
+	}
 	codec, ok := CodecForRequest(r, "Content-Type")
 	if !ok {
 		return errors.BadRequest("CODEC", r.Header.Get("Content-Type"))


### PR DESCRIPTION
修复当 POST 请求参数为 `emptypb. Empty` 时解析请求时会报错的问题
例如：
```
 rpc Logout(google.protobuf.Empty) returns (google.protobuf.Empty){
    option (google.api.http) = {
      post: "/account/logout"
      body: "*"
    };
};
```