### PR TITLE
feat(middleware/auth/jwt): add customer header

### DIFF
--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -49,6 +49,7 @@ type Option func(*options)
 type options struct {
 	signingMethod jwt.SigningMethod
 	claims        jwt.Claims
+	header        map[string]interface{}
 }
 
 // WithSigningMethod with signing method option.
@@ -62,6 +63,13 @@ func WithSigningMethod(method jwt.SigningMethod) Option {
 func WithClaims(claims jwt.Claims) Option {
 	return func(o *options) {
 		o.claims = claims
+	}
+}
+
+//WithHeader withe customer header for client side
+func WithHeader(header map[string]interface{}) Option {
+	return func(o *options) {
+		o.header = header
 	}
 }
 
@@ -125,6 +133,11 @@ func Client(keyProvider jwt.Keyfunc, opts ...Option) middleware.Middleware {
 				return nil, ErrNeedTokenProvider
 			}
 			token := jwt.NewWithClaims(o.signingMethod, o.claims)
+			if o.header != nil {
+				for k, v := range o.header {
+					token.Header[k] = v
+				}
+			}
 			key, err := keyProvider(token)
 			if err != nil {
 				return nil, ErrGetKey

--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -22,7 +22,7 @@ const (
 	// bearerFormat authorization token format
 	bearerFormat string = "Bearer %s"
 
-	// authorizationKey holds the key used to store the JWT Token in the request header.
+	// authorizationKey holds the key used to store the JWT Token in the request tokenHeader.
 	authorizationKey string = "Authorization"
 
 	// reason holds the error reason.
@@ -49,7 +49,7 @@ type Option func(*options)
 type options struct {
 	signingMethod jwt.SigningMethod
 	claims        jwt.Claims
-	header        map[string]interface{}
+	tokenHeader   map[string]interface{}
 }
 
 // WithSigningMethod with signing method option.
@@ -66,10 +66,10 @@ func WithClaims(claims jwt.Claims) Option {
 	}
 }
 
-// WithHeader withe customer header for client side
-func WithHeader(header map[string]interface{}) Option {
+// WithTokenHeader withe customer tokenHeader for client side
+func WithTokenHeader(header map[string]interface{}) Option {
 	return func(o *options) {
-		o.header = header
+		o.tokenHeader = header
 	}
 }
 
@@ -133,8 +133,8 @@ func Client(keyProvider jwt.Keyfunc, opts ...Option) middleware.Middleware {
 				return nil, ErrNeedTokenProvider
 			}
 			token := jwt.NewWithClaims(o.signingMethod, o.claims)
-			if o.header != nil {
-				for k, v := range o.header {
+			if o.tokenHeader != nil {
+				for k, v := range o.tokenHeader {
 					token.Header[k] = v
 				}
 			}

--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -66,7 +66,7 @@ func WithClaims(claims jwt.Claims) Option {
 	}
 }
 
-//WithHeader withe customer header for client side
+// WithHeader withe customer header for client side
 func WithHeader(header map[string]interface{}) Option {
 	return func(o *options) {
 		o.header = header

--- a/middleware/auth/jwt/jwt.go
+++ b/middleware/auth/jwt/jwt.go
@@ -24,19 +24,22 @@ const (
 
 	// authorizationKey holds the key used to store the JWT Token in the request header.
 	authorizationKey string = "Authorization"
+
+	// reason holds the error reason.
+	reason string = "UNAUTHORIZED"
 )
 
 var (
-	ErrMissingJwtToken        = errors.Unauthorized("UNAUTHORIZED", "JWT token is missing")
-	ErrMissingKeyFunc         = errors.Unauthorized("UNAUTHORIZED", "keyFunc is missing")
-	ErrTokenInvalid           = errors.Unauthorized("UNAUTHORIZED", "Token is invalid")
-	ErrTokenExpired           = errors.Unauthorized("UNAUTHORIZED", "JWT token has expired")
-	ErrTokenParseFail         = errors.Unauthorized("UNAUTHORIZED", "Fail to parse JWT token ")
-	ErrUnSupportSigningMethod = errors.Unauthorized("UNAUTHORIZED", "Wrong signing method")
-	ErrWrongContext           = errors.Unauthorized("UNAUTHORIZED", "Wrong context for middleware")
-	ErrNeedTokenProvider      = errors.Unauthorized("UNAUTHORIZED", "Token provider is missing")
-	ErrSignToken              = errors.Unauthorized("UNAUTHORIZED", "Can not sign token.Is the key correct?")
-	ErrGetKey                 = errors.Unauthorized("UNAUTHORIZED", "Can not get key while signing token")
+	ErrMissingJwtToken        = errors.Unauthorized(reason, "JWT token is missing")
+	ErrMissingKeyFunc         = errors.Unauthorized(reason, "keyFunc is missing")
+	ErrTokenInvalid           = errors.Unauthorized(reason, "Token is invalid")
+	ErrTokenExpired           = errors.Unauthorized(reason, "JWT token has expired")
+	ErrTokenParseFail         = errors.Unauthorized(reason, "Fail to parse JWT token ")
+	ErrUnSupportSigningMethod = errors.Unauthorized(reason, "Wrong signing method")
+	ErrWrongContext           = errors.Unauthorized(reason, "Wrong context for middleware")
+	ErrNeedTokenProvider      = errors.Unauthorized(reason, "Token provider is missing")
+	ErrSignToken              = errors.Unauthorized(reason, "Can not sign token.Is the key correct?")
+	ErrGetKey                 = errors.Unauthorized(reason, "Can not get key while signing token")
 )
 
 // Option is jwt option.
@@ -93,7 +96,7 @@ func Server(keyFunc jwt.Keyfunc, opts ...Option) middleware.Middleware {
 							return nil, ErrTokenParseFail
 						}
 					}
-					return nil, errors.Unauthorized("UNAUTHORIZED", err.Error())
+					return nil, errors.Unauthorized(reason, err.Error())
 				} else if !tokenInfo.Valid {
 					return nil, ErrTokenInvalid
 				} else if tokenInfo.Method != o.signingMethod {

--- a/middleware/auth/jwt/jwt_test.go
+++ b/middleware/auth/jwt/jwt_test.go
@@ -315,7 +315,7 @@ func TestClientWithHeader(t *testing.T) {
 	next := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "reply", nil
 	}
-	handler := Client(tProvider, WithClaims(mapClaims), WithHeader(tokenHeader))(next)
+	handler := Client(tProvider, WithClaims(mapClaims), WithTokenHeader(tokenHeader))(next)
 	header := &headerCarrier{}
 	_, err2 := handler(transport.NewClientContext(context.Background(), &Transport{reqHeader: header}), "ok")
 	assert.Equal(t, nil, err2)


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
Allow user put a customer header of JWT token while using the client auth middleware 



