### PR TITLE
fix: change installation package path for protoc-gen-openapi

### DIFF
--- a/cmd/kratos/internal/base/install.go
+++ b/cmd/kratos/internal/base/install.go
@@ -7,14 +7,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"regexp"
+	"strings"
 )
 
 // GoInstall go get path.
 func GoInstall(path ...string) error {
-	reg := regexp.MustCompile(`.*@v\d+[\.\d+]+$`)
 	for _, p := range path {
-		if !reg.MatchString(p) {
+		if !strings.Contains(p, "@") {
 			p += "@latest"
 		}
 		fmt.Printf("go install %s\n", p)

--- a/cmd/kratos/internal/base/install.go
+++ b/cmd/kratos/internal/base/install.go
@@ -7,13 +7,18 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 )
 
 // GoInstall go get path.
 func GoInstall(path ...string) error {
+	reg := regexp.MustCompile(`.*@v\d+[\.\d+]+$`)
 	for _, p := range path {
-		fmt.Printf("go install %s@latest\n", p)
-		cmd := exec.Command("go", "install", fmt.Sprintf("%s@latest", p))
+		if !reg.MatchString(p) {
+			p += "@latest"
+		}
+		fmt.Printf("go install %s\n", p)
+		cmd := exec.Command("go", "install", p)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {

--- a/cmd/kratos/internal/upgrade/upgrade.go
+++ b/cmd/kratos/internal/upgrade/upgrade.go
@@ -26,7 +26,7 @@ func Run(cmd *cobra.Command, args []string) {
 		"google.golang.org/grpc/cmd/protoc-gen-go-grpc",
 		"github.com/envoyproxy/protoc-gen-validate",
 		"github.com/google/gnostic",
-		"github.com/google/gnostic/cmd/protoc-gen-openapi",
+		"github.com/google/gnostic/cmd/protoc-gen-openapi@v0.6.2",
 	)
 	if err != nil {
 		fmt.Println(err)

--- a/cmd/kratos/internal/upgrade/upgrade.go
+++ b/cmd/kratos/internal/upgrade/upgrade.go
@@ -26,7 +26,7 @@ func Run(cmd *cobra.Command, args []string) {
 		"google.golang.org/grpc/cmd/protoc-gen-go-grpc",
 		"github.com/envoyproxy/protoc-gen-validate",
 		"github.com/google/gnostic",
-		"github.com/google/gnostic/apps/protoc-gen-openapi",
+		"github.com/google/gnostic/cmd/protoc-gen-openapi",
 	)
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
google/gnostic: [refactor: rename apps to cmd and add go.mod](https://github.com/google/gnostic/commit/94bcf11351a51ca2ef62918cf8a7c7a5d2aa9b43)

fix: change installation package path for [protoc-gen-openapi](https://github.com/google/gnostic/tree/master/cmd/protoc-gen-openapi)