### PR TITLE
fix(registry/consul):fix update TTL problem

### DIFF
--- a/contrib/registry/consul/client.go
+++ b/contrib/registry/consul/client.go
@@ -121,26 +121,7 @@ func (c *Client) Register(_ context.Context, svc *registry.ServiceInstance, enab
 			})
 		}
 	}
-	err := c.cli.Agent().ServiceRegister(asr)
-	if err != nil {
-		return err
-	}
-	_ = c.cli.Agent().UpdateTTL("service:"+svc.ID, "pass", "pass")
-	if c.heartbeat {
-		go func() {
-			ticker := time.NewTicker(time.Second * time.Duration(c.healthcheckInterval))
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					_ = c.cli.Agent().UpdateTTL("service:"+svc.ID, "pass", "pass")
-				case <-c.ctx.Done():
-					return
-				}
-			}
-		}()
-	}
-	return nil
+	return c.cli.Agent().ServiceRegister(asr)
 }
 
 // Deregister deregister service by service ID

--- a/contrib/registry/consul/client.go
+++ b/contrib/registry/consul/client.go
@@ -23,8 +23,6 @@ type Client struct {
 	resolver ServiceResolver
 	// healthcheck time interval in seconds
 	healthcheckInterval int
-	// heartbeat enable heartbeat
-	heartbeat bool
 }
 
 // NewClient creates consul client
@@ -33,7 +31,6 @@ func NewClient(cli *api.Client) *Client {
 		cli:                 cli,
 		resolver:            defaultResolver,
 		healthcheckInterval: 10,
-		heartbeat:           true,
 	}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	return c

--- a/contrib/registry/consul/registry.go
+++ b/contrib/registry/consul/registry.go
@@ -26,15 +26,6 @@ func WithHealthCheck(enable bool) Option {
 	}
 }
 
-// WithHeartbeat enable or disable heartbeat
-func WithHeartbeat(enable bool) Option {
-	return func(o *Registry) {
-		if o.cli != nil {
-			o.cli.heartbeat = enable
-		}
-	}
-}
-
 // WithServiceResolver with endpoint function option.
 func WithServiceResolver(fn ServiceResolver) Option {
 	return func(o *Registry) {

--- a/contrib/registry/consul/registry_test.go
+++ b/contrib/registry/consul/registry_test.go
@@ -39,7 +39,6 @@ func TestRegister(t *testing.T) {
 		t.Fatalf("create consul client failed: %v", err)
 	}
 	opts := []Option{
-		WithHeartbeat(true),
 		WithHealthCheck(true),
 		WithHealthCheckInterval(5),
 	}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
TTL-Check and TCP-Check cannot both be used at the same time. So this PR try to remove TTL-Check.


#### Which issue(s) this PR fixes (resolves / be part of):
fixes #1775 


