### PR TITLE
fix: perhaps MISSING

### DIFF
--- a/errors/types.go
+++ b/errors/types.go
@@ -3,7 +3,7 @@ package errors
 
 // BadRequest new BadRequest error that is mapped to a 400 response.
 func BadRequest(reason, message string) *Error {
-	return Newf(400, reason, message)
+	return New(400, reason, message)
 }
 
 // IsBadRequest determines if err is an error which indicates a BadRequest error.
@@ -14,7 +14,7 @@ func IsBadRequest(err error) bool {
 
 // Unauthorized new Unauthorized error that is mapped to a 401 response.
 func Unauthorized(reason, message string) *Error {
-	return Newf(401, reason, message)
+	return New(401, reason, message)
 }
 
 // IsUnauthorized determines if err is an error which indicates a Unauthorized error.
@@ -25,7 +25,7 @@ func IsUnauthorized(err error) bool {
 
 // Forbidden new Forbidden error that is mapped to a 403 response.
 func Forbidden(reason, message string) *Error {
-	return Newf(403, reason, message)
+	return New(403, reason, message)
 }
 
 // IsForbidden determines if err is an error which indicates a Forbidden error.
@@ -36,7 +36,7 @@ func IsForbidden(err error) bool {
 
 // NotFound new NotFound error that is mapped to a 404 response.
 func NotFound(reason, message string) *Error {
-	return Newf(404, reason, message)
+	return New(404, reason, message)
 }
 
 // IsNotFound determines if err is an error which indicates an NotFound error.
@@ -47,7 +47,7 @@ func IsNotFound(err error) bool {
 
 // Conflict new Conflict error that is mapped to a 409 response.
 func Conflict(reason, message string) *Error {
-	return Newf(409, reason, message)
+	return New(409, reason, message)
 }
 
 // IsConflict determines if err is an error which indicates a Conflict error.
@@ -58,7 +58,7 @@ func IsConflict(err error) bool {
 
 // InternalServer new InternalServer error that is mapped to a 500 response.
 func InternalServer(reason, message string) *Error {
-	return Newf(500, reason, message)
+	return New(500, reason, message)
 }
 
 // IsInternalServer determines if err is an error which indicates an Internal error.
@@ -69,7 +69,7 @@ func IsInternalServer(err error) bool {
 
 // ServiceUnavailable new ServiceUnavailable error that is mapped to a HTTP 503 response.
 func ServiceUnavailable(reason, message string) *Error {
-	return Newf(503, reason, message)
+	return New(503, reason, message)
 }
 
 // IsServiceUnavailable determines if err is an error which indicates a Unavailable error.
@@ -80,7 +80,7 @@ func IsServiceUnavailable(err error) bool {
 
 // GatewayTimeout new GatewayTimeout error that is mapped to a HTTP 504 response.
 func GatewayTimeout(reason, message string) *Error {
-	return Newf(504, reason, message)
+	return New(504, reason, message)
 }
 
 // IsGatewayTimeout determines if err is an error which indicates a GatewayTimeout error.
@@ -91,7 +91,7 @@ func IsGatewayTimeout(err error) bool {
 
 // ClientClosed new ClientClosed error that is mapped to a HTTP 499 response.
 func ClientClosed(reason, message string) *Error {
-	return Newf(499, reason, message)
+	return New(499, reason, message)
 }
 
 // IsClientClosed determines if err is an error which indicates a IsClientClosed error.


### PR DESCRIPTION
fix for unexpected placeholders due to escaping

sample: 
```go
msg := `values=%7B%22g`
err := errors.BadRequest("x-reason", msg)

fmt.Println(err.Message == msg) // false
fmt.Println(err.Message)        // values=%!B(MISSING)%!g(MISSING)
```