### PR TITLE
feat: allow specify namespace for k8s registry

### DIFF
--- a/contrib/registry/kubernetes/registry.go
+++ b/contrib/registry/kubernetes/registry.go
@@ -89,9 +89,18 @@ type Registry struct {
 	stopCh chan struct{}
 }
 
-// NewRegistry is used to initialize the Registry
+// NewRegistry initialize the k8s registry with global namespace.
 func NewRegistry(clientSet *kubernetes.Clientset) *Registry {
-	informerFactory := informers.NewSharedInformerFactory(clientSet, time.Minute*10)
+	return NewRegistryWithNamespace(clientSet, corev1.NamespaceAll)
+}
+
+// NewRegistry initialize the k8s registry with specific namespace.
+func NewRegistryWithNamespace(clientSet *kubernetes.Clientset, namespace string) *Registry {
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(
+		clientSet,
+		time.Minute*10,
+		informers.WithNamespace(namespace),
+	)
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	podLister := informerFactory.Core().V1().Pods().Lister()
 	return &Registry{


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
Currently the k8s registry uses default option for informer, which requires the global permission to list and watch pods for all namespaces. This PR adds a custom constructor to specifiy custom namespace without breaking the original one.


#### Which issue(s) this PR fixes (resolves / be part of):


#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->
