### PR TITLE
fix: keep slash suffix when join route prefix and path

### DIFF
--- a/transport/http/router.go
+++ b/transport/http/router.go
@@ -3,6 +3,7 @@ package http
 import (
 	"net/http"
 	"path"
+	"strings"
 	"sync"
 )
 
@@ -50,7 +51,12 @@ func (r *Router) Handle(method, relativePath string, h HandlerFunc, filters ...F
 	}))
 	next = FilterChain(filters...)(next)
 	next = FilterChain(r.filters...)(next)
-	r.srv.router.Handle(path.Join(r.prefix, relativePath), next).Methods(method)
+
+	p := path.Join(r.prefix, relativePath)
+	if strings.HasSuffix(relativePath, "/") {
+		p += "/"
+	}
+	r.srv.router.Handle(p, next).Methods(method)
 }
 
 // GET registers a new GET route for a path with matching handler in the router.


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
keep slash suffix when join route prefix and path

with or without slash suffix in path may be route to different handler. 
It really matters.


#### Which issue(s) this PR fixes (resolves / be part of):
fixes #1853

