### PR TITLE
style(cmd/errors/examples/middleware/transport): fix common words' spelling mistakes

### DIFF
--- a/cmd/kratos/internal/proto/server/server.go
+++ b/cmd/kratos/internal/proto/server/server.go
@@ -69,7 +69,7 @@ func run(cmd *cobra.Command, args []string) {
 		}),
 	)
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		fmt.Printf("Target directory: %s does not exsits\n", targetDir)
+		fmt.Printf("Target directory: %s does not exsit\n", targetDir)
 		return
 	}
 	for _, s := range res {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -32,10 +32,10 @@ func TestError(t *testing.T) {
 	}
 
 	if !errors.As(err, &base) {
-		t.Errorf("should be matchs: %v", err)
+		t.Errorf("should be matches: %v", err)
 	}
 	if !IsBadRequest(err) {
-		t.Errorf("should be matchs: %v", err)
+		t.Errorf("should be matches: %v", err)
 	}
 
 	if reason := Reason(err); reason != err3.Reason {

--- a/examples/benchmark/test.sh
+++ b/examples/benchmark/test.sh
@@ -26,7 +26,7 @@ test_web_framework()
 
   pkill -9 $server_bin_name
   sleep 2
-  echo "finsihed testing $2"
+  echo "finished testing $2"
   echo
 }
 

--- a/examples/i18n/README.md
+++ b/examples/i18n/README.md
@@ -103,7 +103,7 @@ goi18n extract
 The string which should be translated will be extracted from your code, and write into `active.en.toml`
 You should create the empty target language file:
 ```bash
-touch tranlate.zh.toml
+touch translate.zh.toml
 ```
 
 Then fill the translate file:

--- a/examples/i18n/third_party/validate/validate.proto
+++ b/examples/i18n/third_party/validate/validate.proto
@@ -733,11 +733,11 @@ message RepeatedRules {
     optional uint64 max_items = 2;
 
     // Unique specifies that all elements in this field must be unique. This
-    // contraint is only applicable to scalar and enum types (messages are not
+    // constraint is only applicable to scalar and enum types (messages are not
     // supported).
     optional bool   unique    = 3;
 
-    // Items specifies the contraints to be applied to each item in the field.
+    // Items specifies the constraints to be applied to each item in the field.
     // Repeated message fields will still execute validation against each item
     // unless skip is specified here.
     optional FieldRules items = 4;

--- a/middleware/selector/selector.go
+++ b/middleware/selector/selector.go
@@ -79,11 +79,11 @@ func (b *Builder) Build() middleware.Middleware {
 	} else {
 		transporter = serverTransporter
 	}
-	return selector(transporter, b.matchs, b.ms...)
+	return selector(transporter, b.matches, b.ms...)
 }
 
-// matchs is match operation compliance Builder
-func (b *Builder) matchs(ctx context.Context, transporter transporter) bool {
+// matches is match operation compliance Builder
+func (b *Builder) matches(ctx context.Context, transporter transporter) bool {
 	info, ok := transporter(ctx)
 	if !ok {
 		return false

--- a/third_party/validate/validate.proto
+++ b/third_party/validate/validate.proto
@@ -733,11 +733,11 @@ message RepeatedRules {
     optional uint64 max_items = 2;
 
     // Unique specifies that all elements in this field must be unique. This
-    // contraint is only applicable to scalar and enum types (messages are not
+    // constraint is only applicable to scalar and enum types (messages are not
     // supported).
     optional bool   unique    = 3;
 
-    // Items specifies the contraints to be applied to each item in the field.
+    // Items specifies the constraints to be applied to each item in the field.
     // Repeated message fields will still execute validation against each item
     // unless skip is specified here.
     optional FieldRules items = 4;

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -211,7 +211,7 @@ func TestUnaryInterceptor(t *testing.T) {
 	}
 }
 
-func TestStramInterceptor(t *testing.T) {
+func TestStreamInterceptor(t *testing.T) {
 	o := &Server{}
 	v := []grpc.StreamServerInterceptor{
 		func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {

--- a/transport/http/resolver.go
+++ b/transport/http/resolver.go
@@ -125,7 +125,7 @@ func (r *resolver) update(services []*registry.ServiceInstance) bool {
 		nodes = append(nodes, selector.NewNode(ept, ins))
 	}
 	if len(nodes) == 0 {
-		r.logger.Warnf("[http resovler]Zero endpoint found,refused to write,ser: %s ins: %v", r.target.Endpoint, nodes)
+		r.logger.Warnf("[http resolver]Zero endpoint found,refused to write,set: %s ins: %v", r.target.Endpoint, nodes)
 		return false
 	}
 	r.rebalancer.Apply(nodes)

--- a/transport/http/resolver_test.go
+++ b/transport/http/resolver_test.go
@@ -59,15 +59,15 @@ type mockRebalancer struct{}
 
 func (m *mockRebalancer) Apply(nodes []selector.Node) {}
 
-type mockDiscoverys struct {
+type mockDiscoveries struct {
 	isSecure bool
 }
 
-func (d *mockDiscoverys) GetService(ctx context.Context, serviceName string) ([]*registry.ServiceInstance, error) {
+func (d *mockDiscoveries) GetService(ctx context.Context, serviceName string) ([]*registry.ServiceInstance, error) {
 	return nil, nil
 }
 
-func (d *mockDiscoverys) Watch(ctx context.Context, serviceName string) (registry.Watcher, error) {
+func (d *mockDiscoveries) Watch(ctx context.Context, serviceName string) (registry.Watcher, error) {
 	return &mockWatch{isSecure: d.isSecure}, nil
 }
 
@@ -104,11 +104,11 @@ func TestResolver(t *testing.T) {
 		Authority: "",
 		Endpoint:  "discovery://helloworld",
 	}
-	_, err := newResolver(context.Background(), &mockDiscoverys{true}, ta, &mockRebalancer{}, false, false)
+	_, err := newResolver(context.Background(), &mockDiscoveries{true}, ta, &mockRebalancer{}, false, false)
 	if err != nil {
 		t.Errorf("expect %v, got %v", nil, err)
 	}
-	_, err = newResolver(context.Background(), &mockDiscoverys{false}, ta, &mockRebalancer{}, true, true)
+	_, err = newResolver(context.Background(), &mockDiscoveries{false}, ta, &mockRebalancer{}, true, true)
 	if err != nil {
 		t.Errorf("expect %v, got %v", nil, err)
 	}


### PR DESCRIPTION
* matchs to matches
* contraint to constraint
* resovle to resolver
* ser to set

#### Description (what this PR does / why we need it):
fix spelling mistake
