### PR TITLE
fix(contrib): upgrade nacos-sdk-go version to v1.1.1

### DIFF
--- a/contrib/config/nacos/config_test.go
+++ b/contrib/config/nacos/config_test.go
@@ -43,9 +43,10 @@ func TestGetConfig(t *testing.T) {
 		NotLoadCacheAtStart: true,
 		LogDir:              "/tmp/nacos/log",
 		CacheDir:            "/tmp/nacos/cache",
-		RotateTime:          "1h",
-		MaxAge:              3,
-		LogLevel:            "debug",
+		LogRollingConfig: &constant.ClientLogRollingConfig{
+			MaxSize: 1,
+		},
+		LogLevel: "debug",
 	}
 
 	// a more graceful way to create naming client

--- a/contrib/config/nacos/go.mod
+++ b/contrib/config/nacos/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-kratos/kratos/v2 v2.2.1
-	github.com/nacos-group/nacos-sdk-go v1.0.9
+	github.com/nacos-group/nacos-sdk-go v1.1.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )
 

--- a/contrib/registry/nacos/go.mod
+++ b/contrib/registry/nacos/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-kratos/kratos/v2 v2.2.1
-	github.com/nacos-group/nacos-sdk-go v1.0.9
+	github.com/nacos-group/nacos-sdk-go v1.1.1
 )
 
 replace github.com/go-kratos/kratos/v2 => ../../../

--- a/contrib/registry/nacos/registry_test.go
+++ b/contrib/registry/nacos/registry_test.go
@@ -45,9 +45,10 @@ func TestRegistry(t *testing.T) {
 		NotLoadCacheAtStart: true,
 		LogDir:              "/tmp/nacos/log",
 		CacheDir:            "/tmp/nacos/cache",
-		RotateTime:          "1h",
-		MaxAge:              3,
-		LogLevel:            "debug",
+		LogRollingConfig: &constant.ClientLogRollingConfig{
+			MaxSize: 1,
+		},
+		LogLevel: "debug",
 	}
 
 	// a more graceful way to create naming client
@@ -138,9 +139,10 @@ func TestRegistryMany(t *testing.T) {
 		NotLoadCacheAtStart: true,
 		LogDir:              "/tmp/nacos/log",
 		CacheDir:            "/tmp/nacos/cache",
-		RotateTime:          "1h",
-		MaxAge:              3,
-		LogLevel:            "debug",
+		LogRollingConfig: &constant.ClientLogRollingConfig{
+			MaxSize: 1,
+		},
+		LogLevel: "debug",
 	}
 
 	// a more graceful way to create naming client


### PR DESCRIPTION
Description (what this PR does / why we need it):
nacos-sdk-go  fixed a bug that causes panic in version v1.1.0
Link below:
[nacos-sdk-go fix bug](https://github.com/nacos-group/nacos-sdk-go/issues/328)