### PR TITLE
fix(cmd):  generate error func name and unit test fail

### DIFF
--- a/cmd/protoc-gen-go-errors/errors.go
+++ b/cmd/protoc-gen-go-errors/errors.go
@@ -17,7 +17,7 @@ const (
 	fmtPackage    = protogen.GoImportPath("fmt")
 )
 
-var enCases = cases.Title(language.AmericanEnglish)
+var enCases = cases.Title(language.AmericanEnglish, cases.NoLower)
 
 // generateFile generates a _errors.pb.go file containing kratos errors definitions.
 func generateFile(gen *protogen.Plugin, file *protogen.File) *protogen.GeneratedFile {


### PR DESCRIPTION
Fix on a submit error caused by https://github.com/go-kratos/kratos/commit/4f21094a562287eec80df46e336cd65b8f745053

None of the commit unit test (Test_case2Camel) will pass

