### PR TITLE
feat(log): Helper implemented io.Writer

### DIFF
--- a/log/helper_writer.go
+++ b/log/helper_writer.go
@@ -1,0 +1,43 @@
+package log
+
+import "io"
+
+type writerWrapper struct {
+	helper *Helper
+	level  Level
+}
+
+type writerOption func(w *writerWrapper)
+
+// WithWriteLevel set writerWrapper level.
+func WithWriterLevel(level Level) writerOption {
+	return func(w *writerWrapper) {
+		w.level = level
+	}
+}
+
+// WithWriteMessageKey set writerWrapper helper message key.
+func WithWriteMessageKey(key string) writerOption {
+	return func(w *writerWrapper) {
+		if key != "" {
+			w.helper.msgKey = key
+		}
+	}
+}
+
+// NewWriter return a writer wrapper.
+func NewWriter(logger Logger, opts ...writerOption) io.Writer {
+	ww := &writerWrapper{
+		helper: NewHelper(logger, WithMessageKey(DefaultMessageKey)),
+		level:  LevelInfo, // default level
+	}
+	for _, opt := range opts {
+		opt(ww)
+	}
+	return ww
+}
+
+func (ww *writerWrapper) Write(p []byte) (int, error) {
+	ww.helper.Log(ww.level, ww.helper.msgKey, string(p))
+	return 0, nil
+}

--- a/log/helper_writer.go
+++ b/log/helper_writer.go
@@ -7,17 +7,17 @@ type writerWrapper struct {
 	level  Level
 }
 
-type writerOption func(w *writerWrapper)
+type WriterOptionFn func(w *writerWrapper)
 
 // WithWriteLevel set writerWrapper level.
-func WithWriterLevel(level Level) writerOption {
+func WithWriterLevel(level Level) WriterOptionFn {
 	return func(w *writerWrapper) {
 		w.level = level
 	}
 }
 
 // WithWriteMessageKey set writerWrapper helper message key.
-func WithWriteMessageKey(key string) writerOption {
+func WithWriteMessageKey(key string) WriterOptionFn {
 	return func(w *writerWrapper) {
 		if key != "" {
 			w.helper.msgKey = key
@@ -26,7 +26,7 @@ func WithWriteMessageKey(key string) writerOption {
 }
 
 // NewWriter return a writer wrapper.
-func NewWriter(logger Logger, opts ...writerOption) io.Writer {
+func NewWriter(logger Logger, opts ...WriterOptionFn) io.Writer {
 	ww := &writerWrapper{
 		helper: NewHelper(logger, WithMessageKey(DefaultMessageKey)),
 		level:  LevelInfo, // default level

--- a/log/helper_writer_test.go
+++ b/log/helper_writer_test.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWriterWrapper(t *testing.T) {
+	var buf bytes.Buffer
+	logger := NewStdLogger(&buf)
+	content := "ThisIsSomeTestLogMessage"
+	testCases := []struct {
+		w                io.Writer
+		acceptLevel      Level
+		acceptMessageKey string
+	}{
+		{
+			w:                NewWriter(logger),
+			acceptLevel:      LevelInfo, // default level
+			acceptMessageKey: DefaultMessageKey,
+		},
+		{
+			w:                NewWriter(logger, WithWriterLevel(LevelDebug)),
+			acceptLevel:      LevelDebug,
+			acceptMessageKey: DefaultMessageKey,
+		},
+		{
+			w:                NewWriter(logger, WithWriteMessageKey("XxXxX")),
+			acceptLevel:      LevelInfo, // default level
+			acceptMessageKey: "XxXxX",
+		},
+		{
+			w:                NewWriter(logger, WithWriterLevel(LevelError), WithWriteMessageKey("XxXxX")),
+			acceptLevel:      LevelError,
+			acceptMessageKey: "XxXxX",
+		},
+	}
+	for _, tc := range testCases {
+		_, err := tc.w.Write([]byte(content))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(buf.String(), tc.acceptLevel.String()) {
+			t.Errorf("expected level: %s, got: %s", tc.acceptLevel, buf.String())
+		}
+		if !strings.Contains(buf.String(), tc.acceptMessageKey) {
+			t.Errorf("expected message key: %s, got: %s", tc.acceptMessageKey, buf.String())
+		}
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -80,7 +80,7 @@ func TestLogger(t *testing.T) {
 	v := xlog.NewStdLogger(log.Writer())
 	Logger(v)(o)
 	if !reflect.DeepEqual(xlog.NewHelper(v), o.logger) {
-		t.Fatalf("o.logger:%s is not equal to xlog.NewHelper(v):%s", o.logger, xlog.NewHelper(v))
+		t.Fatalf("o.logger:%v is not equal to xlog.NewHelper(v):%v", o.logger, xlog.NewHelper(v))
 	}
 }
 


### PR DESCRIPTION
Implemented io.Writer, easy to use in standard library, like log.New.

#### Description (what this PR does / why we need it):

`Helper` can set to `http.Server{}.ErrorLog`.

Example 1(transport/http):

```go
// import stdlog "log"
// import log "github.com/go-kratos/kratos/v2/log"
// file: https://github.com/go-kratos/kratos/blob/main/transport/http/server.go#L153
srv.Server = &http.Server{
	Handler:   FilterChain(srv.filters...)(srv.router),
	// record http error log to helper.
	ErrorLog:  stdlog.New(srv.log.WithWriterLevel(log.LevelError), "", 0),
}
```

Example 2 (go-redis):

```go
// import stdlog "log"
// import log "github.com/go-kratos/kratos/v2/log"
helper := log.NewHelper(logger, log.WithWriterLevel(log.LevelInfo))
redis.SetLogger(stdlog.New(helper, "", 0))
```

#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->

