### PR TITLE
fix: delete redundant type conversion

### DIFF
--- a/contrib/config/consul/config.go
+++ b/contrib/config/consul/config.go
@@ -20,9 +20,9 @@ type options struct {
 
 // WithContext with registry context.
 func WithContext(ctx context.Context) Option {
-	return Option(func(o *options) {
+	return func(o *options) {
 		o.ctx = ctx
-	})
+	}
 }
 
 // WithPath is config path

--- a/contrib/config/etcd/config.go
+++ b/contrib/config/etcd/config.go
@@ -19,25 +19,25 @@ type options struct {
 	prefix bool
 }
 
-//  WithContext with registry context.
+// WithContext with registry context.
 func WithContext(ctx context.Context) Option {
-	return Option(func(o *options) {
+	return func(o *options) {
 		o.ctx = ctx
-	})
+	}
 }
 
 // WithPath is config path
 func WithPath(p string) Option {
-	return Option(func(o *options) {
+	return func(o *options) {
 		o.path = p
-	})
+	}
 }
 
 // WithPrefix is config prefix
 func WithPrefix(prefix bool) Option {
-	return Option(func(o *options) {
+	return func(o *options) {
 		o.prefix = prefix
-	})
+	}
 }
 
 type source struct {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
delete redundant type conversion
