### PR TITLE
feat: etcd config supports multiple keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type Observer func(string, Value)
 // Config is a config interface.
 type Config interface {
 	Load() error
-	Scan(v interface{}) error
+	Scan(v ...interface{}) error
 	Value(key string) Value
 	Watch(key string, o Observer) error
 	Close() error
@@ -136,12 +136,17 @@ func (c *config) Value(key string) Value {
 	return &errValue{err: ErrNotFound}
 }
 
-func (c *config) Scan(v interface{}) error {
+func (c *config) Scan(vs ...interface{}) error {
 	data, err := c.reader.Source()
 	if err != nil {
 		return err
 	}
-	return unmarshalJSON(data, v)
+	for _, v := range vs {
+		if err := unmarshalJSON(data, v); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *config) Watch(key string, o Observer) error {

--- a/contrib/config/etcd/watcher.go
+++ b/contrib/config/etcd/watcher.go
@@ -21,7 +21,10 @@ func newWatcher(s *source) *watcher {
 	if s.options.prefix {
 		opts = append(opts, clientv3.WithPrefix())
 	}
-	w.ch = s.client.Watch(s.options.ctx, s.options.path, opts...)
+
+	for _, path := range s.options.paths {
+		w.ch = s.client.Watch(s.options.ctx, path, opts...)
+	}
 
 	return w
 }


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

etcd config supports multiple keys

like this:
```bash
# with prefix
/kratos/test/db.yaml
/kratos/test/cache.yaml
/kratos/test/app
```

### Implementation mode

compatible with existing versions

example:
```go
func WithPath(paths ...string) Option {
	return func(o *options) {
		o.paths = paths
	}
}
````

### Usage demonstration

example:
```go
source, err := etcd.New(client, WithPrefix(true), WithPath("/kratos/test/db.yaml",
                                                   "/kratos/test/cache.yaml",
                                                   "/kratos/test/app"))
```


