### PR TITLE
fix(protoc-gen-go-http): buildMethodDesc for two and more message field

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -163,9 +163,10 @@ func buildMethodDesc(g *protogen.GeneratedFile, m *protogen.Method, method, path
 	defer func() { methodSets[m.GoName]++ }()
 
 	vars := buildPathVars(path)
-	fields := m.Input.Desc.Fields()
 
 	for v, s := range vars {
+		fields := m.Input.Desc.Fields()
+
 		if s != nil {
 			path = replacePath(v, *s, path)
 		}


### PR DESCRIPTION
Description (what this PR does / why we need it):
Generator cannot parse multiple message fields and i fixed it ;)

I have RPC method:
```
  rpc UpsertLevel (UpsertLevelRequest) returns (UpsertLevelResponse) {
    option (google.api.http) = {
      post: "/v1/organization/{level.organization_id}/levels"
      body: "level"
      response_body: "level"
      additional_bindings: {
        put: "/v1/organizations/{level.organization_id}/levels/{level.id}"
        body: "level"
        response_body: "level"
      }
    };
  }
```

and message:
```proto
message UpsertLevelRequest {
  message Level {
    string id = 1;
    string organization_id = 2;
    // ... and other fields
  }
  Level level = 1;
}
```

An error occurs during generation: `ERROR: The corresponding field 'level.id' declaration in message could not be found in '/v1/organizations/{level.organization_id}/levels/{level.id}'`

The error was in the method buildMethodDesc. The "fields" variable overwrote the fields of the child message "message.field".
Now I update the "fields" variable inside the "vars" loop in order to restore the "fields" of the initial message.
