### PR TITLE
fix:#1987 Http and grpc generate route alignment

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -192,14 +192,14 @@ func buildMethodDesc(g *protogen.GeneratedFile, m *protogen.Method, method, path
 		}
 	}
 	return &methodDesc{
-		Name:      m.GoName,
-		ParseName: string(m.Desc.Name()),
-		Num:       methodSets[m.GoName],
-		Request:   g.QualifiedGoIdent(m.Input.GoIdent),
-		Reply:     g.QualifiedGoIdent(m.Output.GoIdent),
-		Path:      path,
-		Method:    method,
-		HasVars:   len(vars) > 0,
+		Name:         m.GoName,
+		OriginalName: string(m.Desc.Name()),
+		Num:          methodSets[m.GoName],
+		Request:      g.QualifiedGoIdent(m.Input.GoIdent),
+		Reply:        g.QualifiedGoIdent(m.Output.GoIdent),
+		Path:         path,
+		Method:       method,
+		HasVars:      len(vars) > 0,
 	}
 }
 

--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -192,13 +192,14 @@ func buildMethodDesc(g *protogen.GeneratedFile, m *protogen.Method, method, path
 		}
 	}
 	return &methodDesc{
-		Name:    m.GoName,
-		Num:     methodSets[m.GoName],
-		Request: g.QualifiedGoIdent(m.Input.GoIdent),
-		Reply:   g.QualifiedGoIdent(m.Output.GoIdent),
-		Path:    path,
-		Method:  method,
-		HasVars: len(vars) > 0,
+		Name:      m.GoName,
+		ParseName: string(m.Desc.Name()),
+		Num:       methodSets[m.GoName],
+		Request:   g.QualifiedGoIdent(m.Input.GoIdent),
+		Reply:     g.QualifiedGoIdent(m.Output.GoIdent),
+		Path:      path,
+		Method:    method,
+		HasVars:   len(vars) > 0,
 	}
 }
 

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -79,7 +79,7 @@ func (c *{{$svrType}}HTTPClientImpl) {{.Name}}(ctx context.Context, in *{{.Reque
 	var out {{.Reply}}
 	pattern := "{{.Path}}"
 	path := binding.EncodeURL(pattern, in, {{not .HasBody}})
-	opts = append(opts, http.Operation("/{{$svrName}}/{{.ParseName}}"))
+	opts = append(opts, http.Operation("/{{$svrName}}/{{.OriginalName}}"))
 	opts = append(opts, http.PathTemplate(pattern))
 	{{if .HasBody -}}
 	err := c.cc.Invoke(ctx, "{{.Method}}", path, in{{.Body}}, &out{{.ResponseBody}}, opts...)
@@ -104,11 +104,11 @@ type serviceDesc struct {
 
 type methodDesc struct {
 	// method
-	Name      string
-	ParseName string // 解析出来的原名称
-	Num       int
-	Request   string
-	Reply     string
+	Name         string
+	OriginalName string // 解析出来的原名称
+	Num          int
+	Request      string
+	Reply        string
 	// http_rule
 	Path         string
 	Method       string

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -105,7 +105,7 @@ type serviceDesc struct {
 type methodDesc struct {
 	// method
 	Name         string
-	OriginalName string // 解析出来的原名称
+	OriginalName string // The parsed original name
 	Num          int
 	Request      string
 	Reply        string

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -46,7 +46,7 @@ func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) fu
 			return err
 		}
 		{{- end}}
-		http.SetOperation(ctx,"/{{$svrName}}/{{.Name}}")
+		http.SetOperation(ctx,"/{{$svrName}}/{{.OriginalName}}")
 		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
 			return srv.{{.Name}}(ctx, req.(*{{.Request}}))
 		})

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -79,7 +79,7 @@ func (c *{{$svrType}}HTTPClientImpl) {{.Name}}(ctx context.Context, in *{{.Reque
 	var out {{.Reply}}
 	pattern := "{{.Path}}"
 	path := binding.EncodeURL(pattern, in, {{not .HasBody}})
-	opts = append(opts, http.Operation("/{{$svrName}}/{{.Name}}"))
+	opts = append(opts, http.Operation("/{{$svrName}}/{{.ParseName}}"))
 	opts = append(opts, http.PathTemplate(pattern))
 	{{if .HasBody -}}
 	err := c.cc.Invoke(ctx, "{{.Method}}", path, in{{.Body}}, &out{{.ResponseBody}}, opts...)
@@ -104,10 +104,11 @@ type serviceDesc struct {
 
 type methodDesc struct {
 	// method
-	Name    string
-	Num     int
-	Request string
-	Reply   string
+	Name      string
+	ParseName string // 解析出来的原名称
+	Num       int
+	Request   string
+	Reply     string
 	// http_rule
 	Path         string
 	Method       string


### PR DESCRIPTION
fix:#1987
Keep the original content when http is generated