### PR TITLE
Feature/proto gen go http adding register with prefix path

### DIFF
--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -75,16 +75,26 @@ type {{.ServiceType}}HTTPClient interface {
 	
 type {{.ServiceType}}HTTPClientImpl struct{
 	cc *http.Client
+	prefixPath *string
 }
 	
 func New{{.ServiceType}}HTTPClient (client *http.Client) {{.ServiceType}}HTTPClient {
 	return &{{.ServiceType}}HTTPClientImpl{client}
 }
 
+func New{{.ServiceType}}HTTPClientWithPrefixPath (client *http.Client, prefixPath string) {{.ServiceType}}HTTPClient {
+	return &{{.ServiceType}}HTTPClientImpl{cc: client, prefixPath: &prefixPath}
+}
+
 {{range .MethodSets}}
 func (c *{{$svrType}}HTTPClientImpl) {{.Name}}(ctx context.Context, in *{{.Request}}, opts ...http.CallOption) (*{{.Reply}}, error) {
 	var out {{.Reply}}
 	pattern := "{{.Path}}"
+
+	if c.prefixPath != nil {
+		pattern = "/" + *c.prefixPath + pattern
+	}
+
 	path := binding.EncodeURL(pattern, in, {{not .HasBody}})
 	opts = append(opts, http.Operation("/{{$svrName}}/{{.Name}}"))
 	opts = append(opts, http.PathTemplate(pattern))

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -22,7 +22,7 @@ func Register{{.ServiceType}}HTTPServer(s *http.Server, srv {{.ServiceType}}HTTP
 	{{- end}}
 }
 
-func Register{{.ServiceType}}HTTPServerWithPrefixPath(s *http.Server, srv {{.ServiceType}}HTTPServer,prefixPath string) {
+func Register{{.ServiceType}}HTTPServerWithPrefixPath(s *http.Server, srv {{.ServiceType}}HTTPServer, prefixPath string) {
 	r := s.Route(prefixPath)
 	{{- range .Methods}}
 	r.{{.Method}}("{{.Path}}", _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv))

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -22,6 +22,13 @@ func Register{{.ServiceType}}HTTPServer(s *http.Server, srv {{.ServiceType}}HTTP
 	{{- end}}
 }
 
+func Register{{.ServiceType}}HTTPServerWithPrefixPath(s *http.Server, srv {{.ServiceType}}HTTPServer,prefixPath string) {
+	r := s.Route(prefixPath)
+	{{- range .Methods}}
+	r.{{.Method}}("{{.Path}}", _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv))
+	{{- end}}
+}
+
 {{range .Methods}}
 func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {


### PR DESCRIPTION
Description: for more dynamic register url path i added a new template function call Register{{.ServiceType}}HTTPServerWithPrefixPath(s *http.Server, srv {{.ServiceType}}HTTPServer, prefixPath string)