### PR TITLE
feat(contrib/opensergo): add opensergo reportMetadata fields

### DIFF
--- a/contrib/opensergo/README.md
+++ b/contrib/opensergo/README.md
@@ -1,2 +1,32 @@
 # OpenSergo
 
+## Usage
+
+```go
+	osServer, err := opensergo.New(opensergo.WithEndpoint("localhost:9090"))
+	if err != nil {
+		panic("init opensergo error")
+	}
+
+	s := &server{}
+	grpcSrv := grpc.NewServer(
+		grpc.Address(":9000"),
+		grpc.Middleware(
+			recovery.Recovery(),
+		),
+	)
+	helloworld.RegisterGreeterServer(grpcSrv, s)
+
+	app := kratos.New(
+		kratos.Name(Name),
+		kratos.Server(
+			grpcSrv,
+		),
+	)
+
+	osServer.ReportMetadata(context.Background(), app)
+
+	if err := app.Run(); err != nil {
+		log.Fatal(err)
+	}
+```

--- a/contrib/opensergo/README.md
+++ b/contrib/opensergo/README.md
@@ -1,0 +1,2 @@
+# OpenSergo
+

--- a/contrib/opensergo/go.mod
+++ b/contrib/opensergo/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-kratos/kratos/v2 v2.2.2
 	github.com/opensergo/opensergo-go v0.0.0-20220331070310-e5b01fee4d1c
 	golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2
+	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd
 	google.golang.org/grpc v1.46.2
 	google.golang.org/protobuf v1.28.0
 )
@@ -17,6 +18,5 @@ require (
 	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
-	google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd // indirect
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/contrib/opensergo/opensergo.go
+++ b/contrib/opensergo/opensergo.go
@@ -131,7 +131,7 @@ func listDescriptors() (services []*v1.ServiceDescriptor, types []*v1.TypeDescri
 				pattern := proto.GetExtension(md.Options(), annotations.E_Http).(*annotations.HttpRule).GetPattern()
 				var httpPath, httpMethod string
 				if pattern != nil {
-					httpPath, httpMethod = HttpPatternInfo(pattern)
+					httpPath, httpMethod = HTTPPatternInfo(pattern)
 				}
 				methodDesc := v1.MethodDescriptor{
 					Name:            mName,
@@ -183,7 +183,7 @@ func listDescriptors() (services []*v1.ServiceDescriptor, types []*v1.TypeDescri
 	return
 }
 
-func HttpPatternInfo(pattern interface{}) (method string, path string) {
+func HTTPPatternInfo(pattern interface{}) (method string, path string) {
 	switch p := pattern.(type) {
 	case *annotations.HttpRule_Get:
 		return "GET", p.Get

--- a/contrib/opensergo/opensergo.go
+++ b/contrib/opensergo/opensergo.go
@@ -132,8 +132,8 @@ func listDescriptors() (services []*v1.ServiceDescriptor, types []*v1.TypeDescri
 					OutputTypes:     []string{outputType},
 					ClientStreaming: &isClientStreaming,
 					ServerStreaming: &isServerStreaming,
-					// TODO: Description: ,
-					// TODO: HttpPaths: md.,
+					// TODO: Description: *string,
+					// TODO: HttpPaths: []string,
 					// TODO: HttpMethods: []string,
 				}
 				methods = append(methods, &methodDesc)
@@ -161,7 +161,7 @@ func listDescriptors() (services []*v1.ServiceDescriptor, types []*v1.TypeDescri
 					Number:   int32(fd.Number()),
 					Type:     v1.FieldDescriptor_Type(kind),
 					TypeName: &typeName,
-					// TODO: Description: ,
+					// TODO: Description: *string,
 				})
 			}
 

--- a/contrib/opensergo/opensergo.go
+++ b/contrib/opensergo/opensergo.go
@@ -186,15 +186,15 @@ func listDescriptors() (services []*v1.ServiceDescriptor, types []*v1.TypeDescri
 func HttpPatternInfo(pattern interface{}) (method string, path string) {
 	switch p := pattern.(type) {
 	case *annotations.HttpRule_Get:
-		return "Get", p.Get
+		return "GET", p.Get
 	case *annotations.HttpRule_Post:
-		return "Post", p.Post
+		return "POST", p.Post
 	case *annotations.HttpRule_Delete:
-		return "Delete", p.Delete
+		return "DELETE", p.Delete
 	case *annotations.HttpRule_Patch:
-		return "Patch", p.Patch
+		return "PATCH", p.Patch
 	case *annotations.HttpRule_Put:
-		return "Put", p.Put
+		return "PUT", p.Put
 	case *annotations.HttpRule_Custom:
 		return p.Custom.Kind, p.Custom.Path
 	default:


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a conventional commits format title: `<type>[optional scope]: <description>`
    
    Some suggestion on <type>:

    fix: A bug fix
    feat: A new feature
    test: Adding missing tests or correcting existing tests
    refactor: A code change that neither fixes a bug nor adds a feature
    break: Changes has break change

    docs: Documentation only changes
    deps: Changes external dependencies
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    chore Daily work, examples, etc.
    ci: Changes to our CI configuration files and scripts
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
add some fields for opensergo reportMeatadata

#### Other special notes for reviewer:
<!--
* Somethings that need extra attention for reviewer
* Some additional notes, TODO list, etc.
-->
I'm still not sure about some parts, any advice is welcome.
* ~~Is there any way to get the HTTP options information defined in proto file~~
* For the `description` field, I'm not sure if it should be read from proto file automatically or use a config option for users.
* For the `node` field, do we need to assume the deployment environment, such as kubernetes, to get some information automatically.