### PR TITLE
fix: protoc-gen-go-errors generated function comments have extra blank lines.

### DIFF
--- a/cmd/protoc-gen-go-errors/template.go
+++ b/cmd/protoc-gen-go-errors/template.go
@@ -8,18 +8,18 @@ import (
 var errorsTemplate = `
 {{ range .Errors }}
 
-{{if .HasComment}}{{.Comment}}{{end}}
+{{ if .HasComment }}{{ .Comment }}{{ end -}}
 func Is{{.CamelValue}}(err error) bool {
 	if err == nil {
 		return false
 	}
 	e := errors.FromError(err)
-	return e.Reason == {{.Name}}_{{.Value}}.String() && e.Code == {{.HTTPCode}} 
+	return e.Reason == {{ .Name }}_{{ .Value }}.String() && e.Code == {{ .HTTPCode }} 
 }
 
-{{if .HasComment}}{{.Comment}}{{end}}
-func Error{{.CamelValue}}(format string, args ...interface{}) *errors.Error {
-	 return errors.New({{.HTTPCode}}, {{.Name}}_{{.Value}}.String(), fmt.Sprintf(format, args...))
+{{ if .HasComment }}{{ .Comment }}{{ end -}}
+func Error{{ .CamelValue }}(format string, args ...interface{}) *errors.Error {
+	 return errors.New({{ .HTTPCode }}, {{ .Name }}_{{ .Value }}.String(), fmt.Sprintf(format, args...))
 }
 
 {{- end }}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

protoc-gen-go-errors generated function comments have extra blank lines.
like this:
```go
// 未知的错误

func ErrorUnknownError(format string, args ...interface{}) *errors.Error {
	return errors.New(500, ErrorReason_UNKNOWN_ERROR.String(), fmt.Sprintf(format, args...))
}
```

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->