### PR TITLE
http/bm: add prefix matcher for the path prefix

### DIFF
--- a/pkg/net/http/blademaster/routergroup.go
+++ b/pkg/net/http/blademaster/routergroup.go
@@ -62,7 +62,7 @@ func (group *RouterGroup) Prefix(prefix string, handlers ...Handler) IRoutes {
 // PrefixFunc adds a matcher for the URL path prefix.
 func (group *RouterGroup) PrefixFunc(prefix string, handlers ...HandlerFunc) IRoutes {
 	return group.UseFunc(func(c *Context) {
-		if strings.HasPrefix(c.Request.RequestURI, prefix) {
+		if strings.HasPrefix(c.Request.URL.Path, prefix) {
 			for _, h := range handlers {
 				h.ServeHTTP(c)
 			}

--- a/pkg/net/http/blademaster/server.go
+++ b/pkg/net/http/blademaster/server.go
@@ -392,6 +392,22 @@ func (engine *Engine) Use(middleware ...Handler) IRoutes {
 	return engine
 }
 
+// PrefixFunc adds a matcher for the URL path prefix.
+func (engine *Engine) PrefixFunc(prefix string, handlers ...HandlerFunc) IRoutes {
+	engine.RouterGroup.PrefixFunc(prefix, handlers...)
+	engine.rebuild404Handlers()
+	engine.rebuild405Handlers()
+	return engine
+}
+
+// Prefix adds a matcher for the URL path prefix.
+func (engine *Engine) Prefix(prefix string, handlers ...Handler) IRoutes {
+	engine.RouterGroup.Prefix(prefix, handlers...)
+	engine.rebuild404Handlers()
+	engine.rebuild405Handlers()
+	return engine
+}
+
 // Ping is used to set the general HTTP ping handler.
 func (engine *Engine) Ping(handler HandlerFunc) {
 	engine.GET("/ping", handler)


### PR DESCRIPTION
For the Kratos V2 server:
```go
srv := http.NewServer()
pb.RegisterGreeterHTTPServer(srv, &server{})

engine := bm.Default()
engine.PrefixFunc("/helloworld", func(ctx *bm.Context) {
    srv.ServeHTTP(ctx.Writer, ctx.Request)
})

```