### PR TITLE
http: handle default mux

### DIFF
--- a/transport/http/codec.go
+++ b/transport/http/codec.go
@@ -12,6 +12,12 @@ import (
 // SupportPackageIsVersion1 These constants should not be referenced from any other code.
 const SupportPackageIsVersion1 = true
 
+// Request type net/http.
+type Request = http.Request
+
+// ResponseWriter type net/http.
+type ResponseWriter = http.ResponseWriter
+
 // DecodeRequestFunc is decode request func.
 type DecodeRequestFunc func(*http.Request, interface{}) error
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -149,6 +149,8 @@ func NewServer(opts ...ServerOption) *Server {
 		o(srv)
 	}
 	srv.router = mux.NewRouter().StrictSlash(srv.strictSlash)
+	srv.router.NotFoundHandler = http.DefaultServeMux
+	srv.router.MethodNotAllowedHandler = http.DefaultServeMux
 	srv.router.Use(srv.filter())
 	srv.Server = &http.Server{
 		Handler:   FilterChain(srv.filters...)(srv.router),


### PR DESCRIPTION
auto configure:
```go
func init() {
	exporter, err := metric.NewExporter()
	if err != nil {
		panic(err)
	}
	http.HandleFunc("/metrics", exporter.ServeHTTP)
	global.SetMeterProvider(exporter.MeterProvider())
}
```