### PR TITLE
fix: the selector doesn't work without Discovery

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -271,7 +271,6 @@ func (client *Client) Do(req *http.Request, opts ...CallOption) (*http.Response,
 
 func (client *Client) do(req *http.Request) (*http.Response, error) {
 	var done func(context.Context, selector.DoneInfo)
-	//if client.r != nil {
 	if client.opts.selector != nil {
 		var (
 			err  error

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -151,7 +151,6 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 		decoder:      DefaultResponseDecoder,
 		errorDecoder: DefaultErrorDecoder,
 		transport:    http.DefaultTransport,
-		selector:     wrr.New(),
 	}
 	for _, o := range opts {
 		o(&options)
@@ -169,6 +168,9 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	var r *resolver
 	if options.discovery != nil {
 		if target.Scheme == "discovery" {
+			if options.selector == nil {
+				options.selector = wrr.New()
+			}
 			if r, err = newResolver(ctx, options.discovery, target, options.selector, options.block, insecure); err != nil {
 				return nil, fmt.Errorf("[http client] new resolver failed!err: %v", options.endpoint)
 			}
@@ -269,7 +271,8 @@ func (client *Client) Do(req *http.Request, opts ...CallOption) (*http.Response,
 
 func (client *Client) do(req *http.Request) (*http.Response, error) {
 	var done func(context.Context, selector.DoneInfo)
-	if client.r != nil {
+	//if client.r != nil {
+	if client.opts.selector != nil {
 		var (
 			err  error
 			node selector.Node

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	nethttp "net/http"
 	"reflect"
 	"strconv"
@@ -337,7 +336,7 @@ func TestWithSelectorInvoked(t *testing.T) {
 		t.Error(err)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, "https://test.com/test", nil)
+	req, err := nethttp.NewRequest(nethttp.MethodGet, "https://test.com/test", nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
the selector doesn't work without Discovery:
(transport/http): when create http client with WithSelector() without WithDiscovery(), the selector doesn't work when client.Do(req)

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
fixes: https://github.com/go-kratos/kratos/issues/2037

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->