### PR TITLE
fix: catch server stop error

### DIFF
--- a/app.go
+++ b/app.go
@@ -116,15 +116,11 @@ func (a *App) Run() error {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, a.opts.sigs...)
 	eg.Go(func() error {
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-c:
-				if err := a.Stop(); err != nil {
-					return err
-				}
-			}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-c:
+			return a.Stop()
 		}
 	})
 	if err := eg.Wait(); err != nil && !errors.Is(err, context.Canceled) {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
**问题**：服务在收到 `os.Signal` 后退出，但并未返回服务在关闭过程中出现的错误。
**原因**：在 `errgroup` 中返回了 `ctx.Err()`。按照原有的代码逻辑，如果不考虑极端情况，在收到 `os.Signal` 后 `errgroup` 都会返回 `context.Canceled`，因为 `errgroup` 只会返回第一个错误，而 `context.Canceled` 这个错误在 `Run` 方法中会被忽略，这就导致了 `Run`  未捕获到服务关闭过程中的错误。
**p.s.** 这里把 `for` 代码也删了，因为考虑到 `ctx.Err()` 仅会返回 `context.Canceled` 以及 `context.DeadlineExceeded`，结合上下文，该 `ctx` 不会出现超时的情况，所以不需要返回 `ctx.Err()`。

#### Which issue(s) this PR fixes (resolves / be part of):
#### Other special notes for the reviewers:
