### PR TITLE
fix: add "make proto" for generating pb.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,8 @@ test-coverage:
 lint: $(LINTER)
 	@${TOOLS_SHELL} lint
 	@echo "lint check finished"
+
+.PHONY: proto
+proto:
+	protoc --proto_path=./api --proto_path=./third_party --go_out=paths=source_relative:./api --go-grpc_out=paths=source_relative:./api --go-http_out=paths=source_relative:./api metadata/metadata.proto
+	protoc --proto_path=./third_party --go_out=paths=source_relative:./ errors/errors.proto

--- a/api/metadata/server.go
+++ b/api/metadata/server.go
@@ -18,9 +18,6 @@ import (
 	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
-//nolint:lll
-//go:generate protoc --proto_path=. --proto_path=../../third_party --go_out=paths=source_relative:. --go-grpc_out=paths=source_relative:. --go-http_out=paths=source_relative:. metadata.proto
-
 // Server is api meta server
 type Server struct {
 	UnimplementedMetadataServer

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -9,8 +9,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-//go:generate protoc -I. --go_out=paths=source_relative:. errors.proto
-
 const (
 	// UnknownCode is unknown code for error info.
 	UnknownCode = 500


### PR DESCRIPTION
part of #2108 

上个提交应该没有考虑后续 `go generate` 会产生覆盖的情况，此提交补充。