### PR TITLE
优化工具体验,使用proto在不加后续参数时无任何输出

### DIFF
--- a/cmd/kratos/internal/proto/proto.go
+++ b/cmd/kratos/internal/proto/proto.go
@@ -13,14 +13,10 @@ var CmdProto = &cobra.Command{
 	Use:   "proto",
 	Short: "Generate the proto files",
 	Long:  "Generate the proto files.",
-	Run:   run,
 }
 
 func init() {
 	CmdProto.AddCommand(add.CmdAdd)
 	CmdProto.AddCommand(client.CmdClient)
 	CmdProto.AddCommand(server.CmdServer)
-}
-
-func run(cmd *cobra.Command, args []string) {
 }


### PR DESCRIPTION
优化kratos 工具使用体验，在使用`kratos proto`后面不加参数时，没有任何输出，优化工具体验
如：
`kratos proto`回车后无任何输出和提示
