### PR TITLE
fix: remove the output of the proto command

### DIFF
--- a/cmd/kratos/internal/proto/proto.go
+++ b/cmd/kratos/internal/proto/proto.go
@@ -13,14 +13,10 @@ var CmdProto = &cobra.Command{
 	Use:   "proto",
 	Short: "Generate the proto files",
 	Long:  "Generate the proto files.",
-	Run:   run,
 }
 
 func init() {
 	CmdProto.AddCommand(add.CmdAdd)
 	CmdProto.AddCommand(client.CmdClient)
 	CmdProto.AddCommand(server.CmdServer)
-}
-
-func run(cmd *cobra.Command, args []string) {
 }


### PR DESCRIPTION
we input `kratos proto` in command line without any tips