### PR TITLE
test(contrib): add etcd registry_unit_test

### DIFF
--- a/contrib/registry/etcd/registry_test.go
+++ b/contrib/registry/etcd/registry_test.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-func TestRegistry(t *testing.T) {
+func TestRegistry_GetService(t *testing.T) {
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:2379"},
 		DialTimeout: time.Second, DialOptions: []grpc.DialOption{grpc.WithBlock()},
@@ -21,62 +22,208 @@ func TestRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer client.Close()
-
-	ctx := context.Background()
 	s := &registry.ServiceInstance{
-		ID:   "0",
-		Name: "helloworld",
+		ID:        "1",
+		Name:      "hello",
+		Version:   "v1.0.0",
+		Endpoints: []string{"127.0.0.1:8080"},
 	}
 
 	r := New(client)
-	w, err := r.Watch(ctx, s.Name)
-	if err != nil {
-		t.Fatal(err)
+	type fields struct {
+		registry *Registry
 	}
-	defer func() {
-		_ = w.Stop()
-	}()
-	go func() {
-		for {
-			res, err1 := w.Next()
-			if err1 != nil {
+	type args struct {
+		ctx         context.Context
+		serviceName string
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		want      []*registry.ServiceInstance
+		wantErr   bool
+		preFunc   func(t *testing.T)
+		deferFunc func(t *testing.T)
+	}{
+		{
+			name: "normal",
+			preFunc: func(t *testing.T) {
+				err = r.Register(context.Background(), s)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			deferFunc: func(t *testing.T) {
+				err = r.Deregister(context.Background(), s)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:         context.Background(),
+				serviceName: s.Name,
+			},
+			want:    []*registry.ServiceInstance{s},
+			wantErr: false,
+		},
+		{
+			name: "can't get any",
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:         context.Background(),
+				serviceName: "helloxxx",
+			},
+			want:    []*registry.ServiceInstance{},
+			wantErr: false,
+		},
+		{
+			name: "conn close",
+			preFunc: func(t *testing.T) {
+				client.Close()
+			},
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:         context.Background(),
+				serviceName: "hello",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.preFunc != nil {
+				tt.preFunc(t)
+			}
+			if tt.deferFunc != nil {
+				defer tt.deferFunc(t)
+			}
+			r := tt.fields.registry
+			got, err := r.GetService(tt.args.ctx, tt.args.serviceName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetService() got = %v", got)
 				return
 			}
-			t.Logf("watch: %d", len(res))
-			for _, r := range res {
-				t.Logf("next: %+v", r)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService() got = %v, want %v", got, tt.want)
 			}
-		}
-	}()
-	time.Sleep(time.Second)
-
-	if err1 := r.Register(ctx, s); err1 != nil {
-		t.Fatal(err1)
-	}
-	time.Sleep(time.Second)
-
-	res, err := r.GetService(ctx, s.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res) != 1 && res[0].Name != s.Name {
-		t.Errorf("not expected: %+v", res)
-	}
-
-	if err1 := r.Deregister(ctx, s); err1 != nil {
-		t.Fatal(err1)
-	}
-	time.Sleep(time.Second)
-
-	res, err = r.GetService(ctx, s.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res) != 0 {
-		t.Errorf("not expected empty")
+		})
 	}
 }
+func TestRegistry_Register(t *testing.T) {
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"127.0.0.1:2379"},
+		DialTimeout: time.Second, DialOptions: []grpc.DialOption{grpc.WithBlock()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	s := &registry.ServiceInstance{
+		ID:        "1",
+		Name:      "hello",
+		Version:   "v1.0.0",
+		Endpoints: []string{"127.0.0.1:8080"},
+	}
 
+	r := New(client)
+	type fields struct {
+		registry *Registry
+	}
+	type args struct {
+		ctx     context.Context
+		service *registry.ServiceInstance
+	}
+	tests := []struct {
+		name      string
+		fields    fields
+		args      args
+		wantErr   bool
+		want      []*registry.ServiceInstance
+		preFunc   func(t *testing.T)
+		deferFunc func(t *testing.T)
+	}{
+		{
+			name: "normal",
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:     context.Background(),
+				service: s,
+			},
+			wantErr: false,
+		},
+		{
+			name: "namespace",
+			fields: fields{
+				registry: New(client, Namespace("invalid")),
+			},
+			args: args{
+				ctx: context.Background(),
+				service: &registry.ServiceInstance{
+					ID:        "2",
+					Name:      "hello1",
+					Version:   "v1.0.0",
+					Endpoints: []string{"127.0.0.1:8080"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ttl",
+			fields: fields{
+				registry: New(client, RegisterTTL(3*time.Second)),
+			},
+			args: args{
+				ctx: context.Background(),
+				service: &registry.ServiceInstance{
+					ID:        "3",
+					Name:      "hello_ttl",
+					Version:   "v1.0.0",
+					Endpoints: []string{"127.0.0.1:8080"},
+				},
+			},
+			wantErr: false,
+			want:    []*registry.ServiceInstance{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.preFunc != nil {
+				tt.preFunc(t)
+			}
+			if tt.deferFunc != nil {
+				defer tt.deferFunc(t)
+			}
+			r := tt.fields.registry
+			if err := r.Register(tt.args.ctx, tt.args.service); (err != nil) != tt.wantErr {
+				t.Errorf("Register() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.name == "ttl" {
+				time.Sleep(5 * time.Second)
+				got, err := r.GetService(tt.args.ctx, tt.args.service.Name)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("GetService() got = %v", got)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("GetService() got = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
 func TestHeartBeat(t *testing.T) {
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:2379"},
@@ -149,5 +296,147 @@ func TestHeartBeat(t *testing.T) {
 	}
 	if len(res) == 0 {
 		t.Errorf("reconnect failed")
+	}
+}
+func TestRegistry_Watch(t *testing.T) {
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"127.0.0.1:2379"},
+		DialTimeout: time.Second, DialOptions: []grpc.DialOption{grpc.WithBlock()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	closeClient, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{"127.0.0.1:2379"},
+		DialTimeout: time.Second, DialOptions: []grpc.DialOption{grpc.WithBlock()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeClient.Close()
+	defer client.Close()
+	s := &registry.ServiceInstance{
+		ID:        "1",
+		Name:      "hello",
+		Version:   "v1.0.0",
+		Endpoints: []string{"127.0.0.1:8080"},
+	}
+
+	r := New(client)
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	type fields struct {
+		registry *Registry
+	}
+	type args struct {
+		ctx         context.Context
+		serviceName string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		want    []*registry.ServiceInstance
+
+		preFunc     func(t *testing.T)
+		deferFunc   func(t *testing.T)
+		processFunc func(t *testing.T, w registry.Watcher)
+	}{
+		{
+			name: "normal",
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:         context.Background(),
+				serviceName: s.Name,
+			},
+			wantErr: false,
+			want:    []*registry.ServiceInstance{s},
+			deferFunc: func(t *testing.T) {
+				err = r.Deregister(context.Background(), s)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+			processFunc: func(t *testing.T, w registry.Watcher) {
+				err = r.Register(context.Background(), s)
+				if err != nil {
+					t.Error(err)
+				}
+			},
+		},
+		{
+			name: "ctx cancel",
+			fields: fields{
+				registry: r,
+			},
+			args: args{
+				ctx:         cancelCtx,
+				serviceName: s.Name,
+			},
+			wantErr: true,
+			want:    nil,
+			processFunc: func(t *testing.T, w registry.Watcher) {
+				cancel()
+			},
+		},
+		{
+			name: "disconnect",
+			fields: fields{
+				registry: New(closeClient),
+			},
+			args: args{
+				ctx:         context.Background(),
+				serviceName: s.Name,
+			},
+			wantErr: true,
+			want:    nil,
+			processFunc: func(t *testing.T, w registry.Watcher) {
+				closeClient.Close()
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.preFunc != nil {
+				tt.preFunc(t)
+			}
+			if tt.deferFunc != nil {
+				defer tt.deferFunc(t)
+			}
+			r := tt.fields.registry
+			watcher, err := r.Watch(tt.args.ctx, tt.args.serviceName)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			defer func() {
+				err = watcher.Stop()
+				if err != nil {
+					t.Error(err)
+				}
+			}()
+			_, err = watcher.Next()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+
+			if tt.processFunc != nil {
+				tt.processFunc(t, watcher)
+			}
+
+			want, err := watcher.Next()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Watch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(want, tt.want) {
+				t.Errorf("Watch() watcher = %v, want %v", watcher, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
add etcd registry unit test

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
https://github.com/go-kratos/kratos/issues/2135
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
