### PR TITLE
fix: show git output

### DIFF
--- a/cmd/kratos/internal/base/repo.go
+++ b/cmd/kratos/internal/base/repo.go
@@ -77,10 +77,10 @@ func (r *Repo) Pull(ctx context.Context) error {
 	cmd = exec.CommandContext(ctx, "git", "pull")
 	cmd.Dir = r.Path()
 	out, err := cmd.CombinedOutput()
+	fmt.Println(string(out))
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(out))
 	return err
 }
 
@@ -96,10 +96,10 @@ func (r *Repo) Clone(ctx context.Context) error {
 		cmd = exec.CommandContext(ctx, "git", "clone", "-b", r.branch, r.url, r.Path())
 	}
 	out, err := cmd.CombinedOutput()
+	fmt.Println(string(out))
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(out))
 	return nil
 }
 


### PR DESCRIPTION
展示详细错误信息给用户,例如:
from:
ERROR: Failed to create project(exit status 128)

to:
exit status 128
error: Pulling is not possible because you have unmerged files.
hint: Fix them up in the work tree, and then use 'git add/rm <file>'
hint: as appropriate to mark resolution and make a commit.
fatal: Exiting because of an unresolved conflict.