### PR TITLE
test(encoding/form): well konw types test (#2147)

### DIFF
--- a/encoding/form/well_known_types_test.go
+++ b/encoding/form/well_known_types_test.go
@@ -1,0 +1,95 @@
+package form
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestMarshalTimeStamp(t *testing.T) {
+	tests := []struct {
+		input  *timestamppb.Timestamp
+		expect string
+	}{
+		{
+			input:  timestamppb.New(time.Date(2022, 1, 2, 3, 4, 5, 6, time.UTC)),
+			expect: "2022-01-02T03:04:05.000000006Z",
+		},
+		{
+			input:  timestamppb.New(time.Date(2022, 13, 1, 13, 61, 61, 100, time.UTC)),
+			expect: "2023-01-01T14:02:01.000000100Z",
+		},
+	}
+	for _, v := range tests {
+		content, err := marshalTimestamp(v.input.ProtoReflect())
+		if err != nil {
+			t.Errorf("expect %v,got %v", nil, err)
+		}
+		if got, want := content, v.expect; got != want {
+			t.Errorf("expect %v,got %v", want, got)
+		}
+	}
+}
+
+func TestMarshalDuration(t *testing.T) {
+	tests := []struct {
+		input  *durationpb.Duration
+		expect string
+	}{
+		{
+			input:  durationpb.New(time.Duration(1<<63 - 1)),
+			expect: "2562047h47m16.854775807s",
+		},
+		{
+			input:  durationpb.New(time.Duration(-1 << 63)),
+			expect: "-2562047h47m16.854775808s",
+		},
+		{
+			input:  durationpb.New(100 * time.Second),
+			expect: "1m40s",
+		},
+		{
+			input:  durationpb.New(-100 * time.Second),
+			expect: "-1m40s",
+		},
+	}
+	for _, v := range tests {
+		content, err := marshalDuration(v.input.ProtoReflect())
+		if err != nil {
+			t.Errorf("expect %v,got %v", nil, err)
+		}
+		if got, want := content, v.expect; got != want {
+			t.Errorf("expect %v,got %v", want, got)
+		}
+	}
+}
+
+func TestMarshalBytes(t *testing.T) {
+	tests := []struct {
+		input  protoreflect.Message
+		expect string
+	}{
+		{
+			input:  wrapperspb.Bytes([]byte("abc123!?$*&()'-=@~")).ProtoReflect(),
+			expect: base64.StdEncoding.EncodeToString([]byte("abc123!?$*&()'-=@~")),
+		},
+		{
+			input:  wrapperspb.Bytes([]byte("kratos")).ProtoReflect(),
+			expect: base64.StdEncoding.EncodeToString([]byte("kratos")),
+		},
+	}
+	for _, v := range tests {
+		content, err := marshalBytes(v.input)
+		if err != nil {
+			t.Errorf("expect %v,got %v", nil, err)
+		}
+		if got, want := content, v.expect; got != want {
+			t.Errorf("expect %v,got %v", want, got)
+		}
+	}
+}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
add tests for `encoding/form/well_konw_types.go `

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

part of #2147 

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
