### PR TITLE
tests(coverage): Increase middleware tests coverage

### DIFF
--- a/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/middleware/circuitbreaker/circuitbreaker_test.go
@@ -1,0 +1,79 @@
+package circuitbreaker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	kratos_errors "github.com/go-kratos/kratos/v2/errors"
+	"github.com/go-kratos/kratos/v2/internal/group"
+	"github.com/go-kratos/kratos/v2/transport"
+)
+
+type transportMock struct {
+	kind      transport.Kind
+	endpoint  string
+	operation string
+}
+
+type circuitBreakerMock struct {
+	err error
+}
+
+func (tr *transportMock) Kind() transport.Kind {
+	return tr.kind
+}
+
+func (tr *transportMock) Endpoint() string {
+	return tr.endpoint
+}
+
+func (tr *transportMock) Operation() string {
+	return tr.operation
+}
+
+func (tr *transportMock) RequestHeader() transport.Header {
+	return nil
+}
+
+func (tr *transportMock) ReplyHeader() transport.Header {
+	return nil
+}
+
+func (c *circuitBreakerMock) Allow() error { return c.err }
+func (c *circuitBreakerMock) MarkSuccess() {}
+func (c *circuitBreakerMock) MarkFailed()  {}
+
+func Test_WithGroup(t *testing.T) {
+	o := options{
+		group: group.NewGroup(func() interface{} {
+			return ""
+		}),
+	}
+
+	WithGroup(nil)(&o)
+	if o.group != nil {
+		t.Error("The group property must be updated to nil.")
+	}
+}
+
+func Test_Server(t *testing.T) {
+	nextValid := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "Hello valid", nil
+	}
+	nextInvalid := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, kratos_errors.InternalServer("", "")
+	}
+
+	ctx := transport.NewClientContext(context.Background(), &transportMock{})
+
+	Client(func(o *options) {
+		o.group = group.NewGroup(func() interface{} {
+			return &circuitBreakerMock{err: errors.New("CB Error.")}
+		})
+	})(nextValid)(ctx, nil)
+
+	Client(func(_ *options) {})(nextValid)(ctx, nil)
+
+	Client(func(_ *options) {})(nextInvalid)(ctx, nil)
+}

--- a/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/middleware/circuitbreaker/circuitbreaker_test.go
@@ -67,13 +67,13 @@ func Test_Server(t *testing.T) {
 
 	ctx := transport.NewClientContext(context.Background(), &transportMock{})
 
-	Client(func(o *options) {
+	_, _ = Client(func(o *options) {
 		o.group = group.NewGroup(func() interface{} {
-			return &circuitBreakerMock{err: errors.New("CB Error.")}
+			return &circuitBreakerMock{err: errors.New("circuitbreaker error")}
 		})
 	})(nextValid)(ctx, nil)
 
-	Client(func(_ *options) {})(nextValid)(ctx, nil)
+	_, _ = Client(func(_ *options) {})(nextValid)(ctx, nil)
 
-	Client(func(_ *options) {})(nextInvalid)(ctx, nil)
+	_, _ = Client(func(_ *options) {})(nextInvalid)(ctx, nil)
 }

--- a/middleware/logging/logging_test.go
+++ b/middleware/logging/logging_test.go
@@ -97,3 +97,26 @@ func TestHTTP(t *testing.T) {
 		})
 	}
 }
+
+type (
+	dummy struct {
+		field string
+	}
+	dummyStringer struct {
+		field string
+	}
+)
+
+func (d *dummyStringer) String() string {
+	return "my value"
+}
+
+func Test_extractArgs(t *testing.T) {
+	if extractArgs(&dummyStringer{field: ""}) != "my value" {
+		t.Errorf(`The stringified dummyStringer structure must be equal to "my value", %v given`, extractArgs(&dummyStringer{field: ""}))
+	}
+
+	if extractArgs(&dummy{field: "value"}) != "&{field:value}" {
+		t.Errorf(`The stringified dummy structure must be equal to "&{field:value}", %v given`, extractArgs(&dummy{field: "value"}))
+	}
+}

--- a/middleware/metadata/metadata_test.go
+++ b/middleware/metadata/metadata_test.go
@@ -126,3 +126,14 @@ func TestClient(t *testing.T) {
 		t.Fatalf("want foo got %v", reply)
 	}
 }
+
+func Test_WithPropagatedPrefix(t *testing.T) {
+	o := &options{
+		prefix: []string{"override"},
+	}
+	WithPropagatedPrefix("something", "another")(o)
+
+	if len(o.prefix) != 2 {
+		t.Error("The prefix must be overrided.")
+	}
+}

--- a/middleware/metrics/metrics_test.go
+++ b/middleware/metrics/metrics_test.go
@@ -2,20 +2,152 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/go-kratos/kratos/v2/metrics"
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/go-kratos/kratos/v2/transport/http"
 )
 
-func TestMetrics(t *testing.T) {
-	next := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return req.(string) + "https://go-kratos.dev", nil
+type (
+	mockCounter struct {
+		lvs   []string
+		value float64
 	}
-	_, err := Server()(next)(context.Background(), "test:")
-	if err != nil {
-		t.Errorf("expect %v, got %v", nil, err)
+	mockObserver struct {
+		lvs   []string
+		value float64
+	}
+)
+
+func (m *mockCounter) With(lvs ...string) metrics.Counter {
+	return m
+}
+func (m *mockCounter) Inc() {
+	m.value += 1.0
+}
+func (m *mockCounter) Add(delta float64) {
+	m.value += delta
+}
+
+func (m *mockObserver) With(lvs ...string) metrics.Observer {
+	return m
+}
+func (m *mockObserver) Observe(delta float64) {
+	m.value += delta
+}
+
+func TestWithRequests(t *testing.T) {
+	mock := mockCounter{
+		lvs:   []string{"Initial"},
+		value: 1.23,
+	}
+	o := options{
+		requests: &mock,
 	}
 
-	_, err = Client()(next)(context.Background(), "test:")
+	WithRequests(&mock)(&o)
+
+	if _, ok := o.requests.(*mockCounter); !ok {
+		t.Errorf(`The type of the option requests property must be of "mockCounter", %T given.`, o.requests)
+	}
+
+	counter := o.requests.(*mockCounter)
+
+	if len(counter.lvs) != 1 || counter.lvs[0] != "Initial" {
+		t.Errorf(`The given counter lvs must have only one element equal to "Initial", %v given`, counter.lvs)
+	}
+	if counter.value != 1.23 {
+		t.Errorf(`The given counter value must be equal to 1.23, %v given`, counter.value)
+	}
+}
+
+func TestWithSeconds(t *testing.T) {
+	mock := mockObserver{
+		lvs:   []string{"Initial"},
+		value: 1.23,
+	}
+	o := options{
+		seconds: &mock,
+	}
+
+	WithSeconds(&mock)(&o)
+
+	if _, ok := o.seconds.(*mockObserver); !ok {
+		t.Errorf(`The type of the option requests property must be of "mockObserver", %T given.`, o.requests)
+	}
+
+	observer := o.seconds.(*mockObserver)
+
+	if len(observer.lvs) != 1 || observer.lvs[0] != "Initial" {
+		t.Errorf(`The given observer lvs must have only one element equal to "Initial", %v given`, observer.lvs)
+	}
+	if observer.value != 1.23 {
+		t.Errorf(`The given observer value must be equal to 1.23, %v given`, observer.value)
+	}
+}
+
+func TestServer(t *testing.T) {
+	e := errors.New("Got an error.")
+	nextError := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, e
+	}
+	nextValid := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "Hello valid", nil
+	}
+
+	_, err := Server()(nextError)(context.Background(), "test:")
+	if err != e {
+		t.Error("The given error mismatch the expected.")
+	}
+
+	res, err := Server(func(o *options) {
+		o.requests = &mockCounter{
+			lvs:   []string{"Initial"},
+			value: 1.23,
+		}
+		o.seconds = &mockObserver{
+			lvs:   []string{"Initial"},
+			value: 1.23,
+		}
+	})(nextValid)(transport.NewServerContext(context.Background(), &http.Transport{}), "test:")
 	if err != nil {
-		t.Errorf("expect %v, got %v", nil, err)
+		t.Error("The server must not throw an error.")
+	}
+	if res != "Hello valid" {
+		t.Error(`The server must return a "Hello valid" response.`)
+	}
+}
+
+func TestClient(t *testing.T) {
+	e := errors.New("Got an error.")
+	nextError := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return nil, e
+	}
+	nextValid := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "Hello valid", nil
+	}
+
+	_, err := Client()(nextError)(context.Background(), "test:")
+	if err != e {
+		t.Error("The given error mismatch the expected.")
+	}
+
+	res, err := Client(func(o *options) {
+		o.requests = &mockCounter{
+			lvs:   []string{"Initial"},
+			value: 1.23,
+		}
+		o.seconds = &mockObserver{
+			lvs:   []string{"Initial"},
+			value: 1.23,
+		}
+	})(nextValid)(transport.NewClientContext(context.Background(), &http.Transport{}), "test:")
+	if err != nil {
+		t.Error("The server must not throw an error.")
+	}
+	if res != "Hello valid" {
+		t.Error(`The server must return a "Hello valid" response.`)
 	}
 }

--- a/middleware/metrics/metrics_test.go
+++ b/middleware/metrics/metrics_test.go
@@ -24,9 +24,11 @@ type (
 func (m *mockCounter) With(lvs ...string) metrics.Counter {
 	return m
 }
+
 func (m *mockCounter) Inc() {
 	m.value += 1.0
 }
+
 func (m *mockCounter) Add(delta float64) {
 	m.value += delta
 }
@@ -34,6 +36,7 @@ func (m *mockCounter) Add(delta float64) {
 func (m *mockObserver) With(lvs ...string) metrics.Observer {
 	return m
 }
+
 func (m *mockObserver) Observe(delta float64) {
 	m.value += delta
 }
@@ -89,7 +92,7 @@ func TestWithSeconds(t *testing.T) {
 }
 
 func TestServer(t *testing.T) {
-	e := errors.New("Got an error.")
+	e := errors.New("got an error")
 	nextError := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return nil, e
 	}
@@ -121,7 +124,7 @@ func TestServer(t *testing.T) {
 }
 
 func TestClient(t *testing.T) {
-	e := errors.New("Got an error.")
+	e := errors.New("got an error")
 	nextError := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return nil, e
 	}

--- a/middleware/ratelimit/ratelimit_test.go
+++ b/middleware/ratelimit/ratelimit_test.go
@@ -1,0 +1,64 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-kratos/aegis/ratelimit"
+)
+
+type (
+	ratelimitMock struct {
+		reached bool
+	}
+	ratelimitReachedMock struct {
+		reached bool
+	}
+)
+
+func (r *ratelimitMock) Allow() (ratelimit.DoneFunc, error) {
+	return func(_ ratelimit.DoneInfo) {
+		r.reached = true
+	}, nil
+}
+
+func (r *ratelimitReachedMock) Allow() (ratelimit.DoneFunc, error) {
+	return func(_ ratelimit.DoneInfo) {
+		r.reached = true
+	}, errors.New("Errored.")
+}
+
+func Test_WithLimiter(t *testing.T) {
+	o := options{
+		limiter: &ratelimitMock{},
+	}
+
+	WithLimiter(nil)(&o)
+	if o.limiter != nil {
+		t.Error("The limiter property must be updated.")
+	}
+}
+
+func Test_Server(t *testing.T) {
+	nextValid := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return "Hello valid", nil
+	}
+
+	rlm := &ratelimitMock{}
+	rlrm := &ratelimitReachedMock{}
+
+	Server(func(o *options) {
+		o.limiter = rlm
+	})(nextValid)(context.Background(), nil)
+	if !rlm.reached {
+		t.Error("The ratelimit must run the done function.")
+	}
+
+	Server(func(o *options) {
+		o.limiter = rlrm
+	})(nextValid)(context.Background(), nil)
+	if rlrm.reached {
+		t.Error("The ratelimit must not run the done function and should be denied.")
+	}
+}

--- a/middleware/ratelimit/ratelimit_test.go
+++ b/middleware/ratelimit/ratelimit_test.go
@@ -26,7 +26,7 @@ func (r *ratelimitMock) Allow() (ratelimit.DoneFunc, error) {
 func (r *ratelimitReachedMock) Allow() (ratelimit.DoneFunc, error) {
 	return func(_ ratelimit.DoneInfo) {
 		r.reached = true
-	}, errors.New("Errored.")
+	}, errors.New("errored")
 }
 
 func Test_WithLimiter(t *testing.T) {
@@ -48,14 +48,14 @@ func Test_Server(t *testing.T) {
 	rlm := &ratelimitMock{}
 	rlrm := &ratelimitReachedMock{}
 
-	Server(func(o *options) {
+	_, _ = Server(func(o *options) {
 		o.limiter = rlm
 	})(nextValid)(context.Background(), nil)
 	if !rlm.reached {
 		t.Error("The ratelimit must run the done function.")
 	}
 
-	Server(func(o *options) {
+	_, _ = Server(func(o *options) {
 		o.limiter = rlrm
 	})(nextValid)(context.Background(), nil)
 	if rlrm.reached {

--- a/middleware/recovery/recovery_test.go
+++ b/middleware/recovery/recovery_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/errors"
+	"github.com/go-kratos/kratos/v2/log"
 )
 
 func TestOnce(t *testing.T) {
@@ -33,4 +34,9 @@ func TestNotPanic(t *testing.T) {
 	if e != nil {
 		t.Errorf("e isn't nil")
 	}
+}
+
+// Deprecated: Remove this test with WithLogger method.
+func TestWithLogger(t *testing.T) {
+	_ = WithLogger(log.DefaultLogger)
 }

--- a/middleware/selector/selector_test.go
+++ b/middleware/selector/selector_test.go
@@ -2,7 +2,6 @@ package selector
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -243,9 +242,20 @@ func TestHeaderFunc(t *testing.T) {
 
 func testMiddleware(handler middleware.Handler) middleware.Handler {
 	return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
-		fmt.Println("before")
 		reply, err = handler(ctx, req)
-		fmt.Println("after")
 		return
+	}
+}
+
+func Test_RegexMatch(t *testing.T) {
+	if regexMatch("^\b(?", "something") {
+		t.Error("The invalid regex must not match.")
+	}
+}
+
+func Test_matches(t *testing.T) {
+	b := Builder{}
+	if b.matches(context.Background(), func(_ context.Context) (transport.Transporter, bool) { return nil, false }) {
+		t.Error("The matches method must return false.")
 	}
 }

--- a/middleware/tracing/statsHandler.go
+++ b/middleware/tracing/statsHandler.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/peer"
@@ -13,6 +14,7 @@ type ClientHandler struct{}
 
 // HandleConn exists to satisfy gRPC stats.Handler.
 func (c *ClientHandler) HandleConn(ctx context.Context, cs stats.ConnStats) {
+	fmt.Println("Handle connection.")
 }
 
 // TagConn exists to satisfy gRPC stats.Handler.

--- a/middleware/tracing/statsHandler_test.go
+++ b/middleware/tracing/statsHandler_test.go
@@ -10,25 +10,29 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
+type ctxKey string
+
+const testKey ctxKey = "MY_TEST_KEY"
+
 func Test_Client_HandleConn(t *testing.T) {
 	(&ClientHandler{}).HandleConn(context.Background(), nil)
 }
 
 func Test_Client_TagConn(t *testing.T) {
 	client := &ClientHandler{}
-	ctx := context.WithValue(context.Background(), "MY_TEST_KEY", 123)
+	ctx := context.WithValue(context.Background(), testKey, 123)
 
-	if client.TagConn(ctx, nil).Value("MY_TEST_KEY") != 123 {
-		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value("MY_TEST_KEY"))
+	if client.TagConn(ctx, nil).Value(testKey) != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
 	}
 }
 
 func Test_Client_TagRPC(t *testing.T) {
 	client := &ClientHandler{}
-	ctx := context.WithValue(context.Background(), "MY_TEST_KEY", 123)
+	ctx := context.WithValue(context.Background(), testKey, 123)
 
-	if client.TagRPC(ctx, nil).Value("MY_TEST_KEY") != 123 {
-		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value("MY_TEST_KEY"))
+	if client.TagRPC(ctx, nil).Value(testKey) != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value(testKey))
 	}
 }
 
@@ -49,7 +53,7 @@ func Test_Client_HandleRPC(t *testing.T) {
 	rs := stats.OutHeader{}
 
 	// Handle stats.RPCStats is not type of stats.OutHeader case
-	client.HandleRPC(nil, nil)
+	client.HandleRPC(context.TODO(), nil)
 
 	// Handle context doesn't have the peerkey filled with a Peer instance
 	client.HandleRPC(ctx, &rs)
@@ -64,10 +68,10 @@ func Test_Client_HandleRPC(t *testing.T) {
 	// Handle context with Span
 	_, span := trace.NewNoopTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
 	spanCtx := trace.SpanContext{}
-	spanId := [8]byte{12, 12, 12, 12, 12, 12, 12, 12}
-	traceId := [16]byte{12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12}
-	spanCtx = spanCtx.WithTraceID(traceId)
-	spanCtx = spanCtx.WithSpanID(spanId)
+	spanID := [8]byte{12, 12, 12, 12, 12, 12, 12, 12}
+	traceID := [16]byte{12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12}
+	spanCtx = spanCtx.WithTraceID(traceID)
+	spanCtx = spanCtx.WithSpanID(spanID)
 	mSpan := mockSpan{
 		Span:        span,
 		mockSpanCtx: &spanCtx,

--- a/middleware/tracing/statsHandler_test.go
+++ b/middleware/tracing/statsHandler_test.go
@@ -1,0 +1,77 @@
+package tracing
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/stats"
+)
+
+func Test_Client_HandleConn(t *testing.T) {
+	(&ClientHandler{}).HandleConn(context.Background(), nil)
+}
+
+func Test_Client_TagConn(t *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.WithValue(context.Background(), "MY_TEST_KEY", 123)
+
+	if client.TagConn(ctx, nil).Value("MY_TEST_KEY") != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value("MY_TEST_KEY"))
+	}
+}
+
+func Test_Client_TagRPC(t *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.WithValue(context.Background(), "MY_TEST_KEY", 123)
+
+	if client.TagRPC(ctx, nil).Value("MY_TEST_KEY") != 123 {
+		t.Errorf(`The context value must be 123 for the "MY_KEY_TEST" key, %v given.`, client.TagConn(ctx, nil).Value("MY_TEST_KEY"))
+	}
+}
+
+type (
+	mockSpan struct {
+		trace.Span
+		mockSpanCtx *trace.SpanContext
+	}
+)
+
+func (m *mockSpan) SpanContext() trace.SpanContext {
+	return *m.mockSpanCtx
+}
+
+func Test_Client_HandleRPC(t *testing.T) {
+	client := &ClientHandler{}
+	ctx := context.Background()
+	rs := stats.OutHeader{}
+
+	// Handle stats.RPCStats is not type of stats.OutHeader case
+	client.HandleRPC(nil, nil)
+
+	// Handle context doesn't have the peerkey filled with a Peer instance
+	client.HandleRPC(ctx, &rs)
+
+	// Handle context with the peerkey filled with a Peer instance
+	ip, _ := net.ResolveIPAddr("ip", "1.1.1.1")
+	ctx = peer.NewContext(ctx, &peer.Peer{
+		Addr: ip,
+	})
+	client.HandleRPC(ctx, &rs)
+
+	// Handle context with Span
+	_, span := trace.NewNoopTracerProvider().Tracer("Tracer").Start(ctx, "Spanname")
+	spanCtx := trace.SpanContext{}
+	spanId := [8]byte{12, 12, 12, 12, 12, 12, 12, 12}
+	traceId := [16]byte{12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12}
+	spanCtx = spanCtx.WithTraceID(traceId)
+	spanCtx = spanCtx.WithSpanID(spanId)
+	mSpan := mockSpan{
+		Span:        span,
+		mockSpanCtx: &spanCtx,
+	}
+	ctx = trace.ContextWithSpan(ctx, &mSpan)
+	client.HandleRPC(ctx, &rs)
+}

--- a/middleware/tracing/tracer_test.go
+++ b/middleware/tracing/tracer_test.go
@@ -23,7 +23,7 @@ func Test_NewTracer(t *testing.T) {
 			t.Error("The NewTracer with an invalid SpanKindMustCrash must panic")
 		}
 	}()
-	tracer = NewTracer(666, func(o *options) {
+	_ = NewTracer(666, func(o *options) {
 		o.tracerProvider = trace.NewNoopTracerProvider()
 	})
 }
@@ -35,7 +35,7 @@ func Test_Tracer_End(t *testing.T) {
 	ctx, span := trace.NewNoopTracerProvider().Tracer("noop").Start(context.Background(), "noopSpan")
 
 	// Handle with error case
-	tracer.End(ctx, span, nil, errors.New("Dummy error."))
+	tracer.End(ctx, span, nil, errors.New("dummy error"))
 
 	// Handle without error case
 	tracer.End(ctx, span, nil, nil)

--- a/middleware/tracing/tracer_test.go
+++ b/middleware/tracing/tracer_test.go
@@ -1,0 +1,54 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/internal/testdata/binding"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Test_NewTracer(t *testing.T) {
+	tracer := NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = trace.NewNoopTracerProvider()
+	})
+
+	if tracer.kind != trace.SpanKindClient {
+		t.Errorf("The tracer kind must be equal to trace.SpanKindClient, %v given.", tracer.kind)
+	}
+
+	defer func() {
+		if recover() == nil {
+			t.Error("The NewTracer with an invalid SpanKindMustCrash must panic")
+		}
+	}()
+	tracer = NewTracer(666, func(o *options) {
+		o.tracerProvider = trace.NewNoopTracerProvider()
+	})
+}
+
+func Test_Tracer_End(t *testing.T) {
+	tracer := NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = trace.NewNoopTracerProvider()
+	})
+	ctx, span := trace.NewNoopTracerProvider().Tracer("noop").Start(context.Background(), "noopSpan")
+
+	// Handle with error case
+	tracer.End(ctx, span, nil, errors.New("Dummy error."))
+
+	// Handle without error case
+	tracer.End(ctx, span, nil, nil)
+
+	m := &binding.HelloRequest{}
+
+	// Handle the trace KindServer
+	tracer = NewTracer(trace.SpanKindServer, func(o *options) {
+		o.tracerProvider = trace.NewNoopTracerProvider()
+	})
+	tracer.End(ctx, span, m, nil)
+	tracer = NewTracer(trace.SpanKindClient, func(o *options) {
+		o.tracerProvider = trace.NewNoopTracerProvider()
+	})
+	tracer.End(ctx, span, m, nil)
+}

--- a/middleware/tracing/tracing_test.go
+++ b/middleware/tracing/tracing_test.go
@@ -42,6 +42,7 @@ type mockTransport struct {
 	endpoint  string
 	operation string
 	header    headerCarrier
+	request   *http.Request
 }
 
 func (tr *mockTransport) Kind() transport.Kind            { return tr.kind }
@@ -49,6 +50,16 @@ func (tr *mockTransport) Endpoint() string                { return tr.endpoint }
 func (tr *mockTransport) Operation() string               { return tr.operation }
 func (tr *mockTransport) RequestHeader() transport.Header { return tr.header }
 func (tr *mockTransport) ReplyHeader() transport.Header   { return tr.header }
+func (tr *mockTransport) Request() *http.Request {
+	if tr.request == nil {
+		rq, _ := http.NewRequest(http.MethodGet, "/endpoint", nil)
+
+		return rq
+	}
+
+	return tr.request
+}
+func (tr *mockTransport) PathTemplate() string { return "" }
 
 func TestTracer(t *testing.T) {
 	carrier := headerCarrier{}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
```
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:56:                   WithSigningMethod       100.0%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:65:                   WithClaims              100.0%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:72:                   WithTokenHeader         100.0%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:79:                   Server                  87.5%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:134:                  Client                  91.3%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:172:                  NewContext              100.0%
github.com/go-kratos/kratos/v2/middleware/auth/jwt/jwt.go:177:                  FromContext             100.0%
github.com/go-kratos/kratos/v2/middleware/circuitbreaker/circuitbreaker.go:22:  WithGroup               100.0%
github.com/go-kratos/kratos/v2/middleware/circuitbreaker/circuitbreaker.go:34:  Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/logging/logging.go:15:                Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/logging/logging.go:51:                Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/logging/logging.go:87:                extractArgs             100.0%
github.com/go-kratos/kratos/v2/middleware/logging/logging.go:95:                extractError            100.0%
github.com/go-kratos/kratos/v2/middleware/metadata/metadata.go:20:              hasPrefix               100.0%
github.com/go-kratos/kratos/v2/middleware/metadata/metadata.go:31:              WithConstants           100.0%
github.com/go-kratos/kratos/v2/middleware/metadata/metadata.go:38:              WithPropagatedPrefix    100.0%
github.com/go-kratos/kratos/v2/middleware/metadata/metadata.go:45:              Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/metadata/metadata.go:70:              Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/metrics/metrics.go:18:                WithRequests            100.0%
github.com/go-kratos/kratos/v2/middleware/metrics/metrics.go:25:                WithSeconds             100.0%
github.com/go-kratos/kratos/v2/middleware/metrics/metrics.go:39:                Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/metrics/metrics.go:74:                Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/middleware.go:14:                     Chain                   100.0%
github.com/go-kratos/kratos/v2/middleware/ratelimit/ratelimit.go:20:            WithLimiter             100.0%
github.com/go-kratos/kratos/v2/middleware/ratelimit/ratelimit.go:31:            Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/recovery/recovery.go:26:              WithHandler             100.0%
github.com/go-kratos/kratos/v2/middleware/recovery/recovery.go:34:              WithLogger              100.0%
github.com/go-kratos/kratos/v2/middleware/recovery/recovery.go:39:              Recovery                100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:41:              Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:46:              Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:51:              Prefix                  100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:57:              Regex                   100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:63:              Path                    100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:69:              Match                   100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:75:              Build                   100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:86:              matches                 100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:119:             selector                100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:130:             pathMatch               100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:134:             prefixMatch             100.0%
github.com/go-kratos/kratos/v2/middleware/selector/selector.go:138:             regexMatch              100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/metadata.go:19:               Inject                  100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/metadata.go:27:               Extract                 100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/metadata.go:43:               Fields                  100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/span.go:20:                   setClientSpan           100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/span.go:57:                   setServerSpan           100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/span.go:100:                  parseFullMethod         100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/span.go:119:                  peerAttr                100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/span.go:135:                  parseTarget             100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/statsHandler.go:16:           HandleConn              100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/statsHandler.go:21:           TagConn                 100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/statsHandler.go:26:           HandleRPC               100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/statsHandler.go:41:           TagRPC                  100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracer.go:24:                 NewTracer               100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracer.go:46:                 Start                   100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracer.go:61:                 End                     100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:23:                WithPropagator          100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:31:                WithTracerProvider      100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:38:                Server                  100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:54:                Client                  100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:70:                TraceID                 100.0%
github.com/go-kratos/kratos/v2/middleware/tracing/tracing.go:80:                SpanID                  100.0%
github.com/go-kratos/kratos/v2/middleware/validate/validate.go:15:              Validator               100.0%
total:                                                                          (statements)            98.6%
```
I am not able to improve the jwt.go Client/Server coverage.

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
Part of #2147 
Middlewares coverage improvements


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
