### PR TITLE
test(log): increase tests coverage

### DIFF
--- a/log/global_test.go
+++ b/log/global_test.go
@@ -11,7 +11,12 @@ import (
 
 func TestGlobalLog(t *testing.T) {
 	buffer := &bytes.Buffer{}
-	SetLogger(NewStdLogger(buffer))
+	logger := NewStdLogger(buffer)
+	SetLogger(logger)
+
+	if GetLogger() != logger {
+		t.Error("GetLogger() is not equal to logger")
+	}
 
 	testCases := []struct {
 		level   Level
@@ -48,19 +53,38 @@ func TestGlobalLog(t *testing.T) {
 		msg := fmt.Sprintf(tc.content[0].(string), tc.content[1:]...)
 		switch tc.level {
 		case LevelDebug:
+			Debug(msg)
+			expected = append(expected, fmt.Sprintf("%s msg=%s", "DEBUG", msg))
 			Debugf(tc.content[0].(string), tc.content[1:]...)
 			expected = append(expected, fmt.Sprintf("%s msg=%s", "DEBUG", msg))
+			Debugw("log", msg)
+			expected = append(expected, fmt.Sprintf("%s log=%s", "DEBUG", msg))
 		case LevelInfo:
+			Info(msg)
+			expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", msg))
 			Infof(tc.content[0].(string), tc.content[1:]...)
 			expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", msg))
+			Infow("log", msg)
+			expected = append(expected, fmt.Sprintf("%s log=%s", "INFO", msg))
 		case LevelWarn:
+			Warn(msg)
+			expected = append(expected, fmt.Sprintf("%s msg=%s", "WARN", msg))
 			Warnf(tc.content[0].(string), tc.content[1:]...)
 			expected = append(expected, fmt.Sprintf("%s msg=%s", "WARN", msg))
+			Warnw("log", msg)
+			expected = append(expected, fmt.Sprintf("%s log=%s", "WARN", msg))
 		case LevelError:
+			Error(msg)
+			expected = append(expected, fmt.Sprintf("%s msg=%s", "ERROR", msg))
 			Errorf(tc.content[0].(string), tc.content[1:]...)
 			expected = append(expected, fmt.Sprintf("%s msg=%s", "ERROR", msg))
+			Errorw("log", msg)
+			expected = append(expected, fmt.Sprintf("%s log=%s", "ERROR", msg))
 		}
 	}
+	Log(LevelInfo, DefaultMessageKey, "test log")
+	expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", "test log"))
+
 	expected = append(expected, "")
 
 	t.Logf("Content: %s", buffer.String())
@@ -85,7 +109,7 @@ func TestGlobalLogUpdate(t *testing.T) {
 	}
 }
 
-func TestGolbalContext(t *testing.T) {
+func TestGlobalContext(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	SetLogger(NewStdLogger(buffer))
 	Context(context.Background()).Infof("111")

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,7 +7,8 @@ import (
 
 func TestInfo(t *testing.T) {
 	logger := DefaultLogger
-	logger = With(logger, "ts", DefaultTimestamp, "caller", DefaultCaller)
+	logger = With(logger, "ts", DefaultTimestamp)
+	logger = With(logger, "caller", DefaultCaller)
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }
 


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
log tests coverage: 81.6% -> 90.8%

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
part of https://github.com/go-kratos/kratos/issues/2147

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
