### PR TITLE
feat(retry): #2202

### DIFF
--- a/retry/condition.go
+++ b/retry/condition.go
@@ -1,0 +1,56 @@
+package retry
+
+type Condition interface {
+	Judge(r Resp) bool
+}
+
+type Resp struct {
+	MD   map[string][]string
+	Code int
+}
+
+type ByCode struct {
+	Codes []int
+}
+
+func (c *ByCode) Judge(r Resp) bool {
+	if len(c.Codes) == 0 {
+		return false
+	}
+	if len(c.Codes) == 1 {
+		return r.Code == c.Codes[0]
+	}
+
+	return c.Codes[0] <= r.Code && r.Code <= c.Codes[1]
+}
+
+func NewByCode(code ...int) *ByCode {
+	return &ByCode{Codes: code}
+}
+
+type ByMetedata struct {
+	Key  string
+	Vals map[string]struct{}
+}
+
+func (c *ByMetedata) Judge(r Resp) bool {
+	value, ok := r.MD[c.Key]
+	if !ok {
+		return false
+	}
+	for _, v := range value {
+		_, ok := c.Vals[v]
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+func NewByMetedata(key string, vals ...string) *ByMetedata {
+	parsedVals := map[string]struct{}{}
+	for _, v := range vals {
+		parsedVals[v] = struct{}{}
+	}
+	return &ByMetedata{Key: key, Vals: parsedVals}
+}

--- a/retry/condition_test.go
+++ b/retry/condition_test.go
@@ -1,0 +1,42 @@
+package retry
+
+import "testing"
+
+func TestByCode(t *testing.T) {
+	testCases := []struct {
+		cond     *ByCode
+		status   int
+		expected bool
+	}{
+		{cond: NewByCode(501), status: 501, expected: true},
+		{cond: NewByCode(), status: 501, expected: false},
+		{cond: NewByCode(501, 509), status: 501, expected: true},
+		{cond: NewByCode(501, 509), status: 500, expected: false},
+	}
+	for _, testCase := range testCases {
+		result := testCase.cond.Judge(Resp{Code: testCase.status})
+		if result != testCase.expected {
+			t.Errorf("cond:%v, status:%v, expected:%v, got:%v", testCase.cond.Codes, testCase.status, testCase.expected, result)
+		}
+	}
+}
+
+func TestByMetedata(t *testing.T) {
+	testCases := []struct {
+		cond     *ByMetedata
+		metedata map[string][]string
+		expected bool
+	}{
+		{cond: NewByMetedata("Grpc-Status", "5"), metedata: map[string][]string{"Grpc-Status": {"5"}}, expected: true},
+		{cond: NewByMetedata("Grpc-Status", "5"), metedata: map[string][]string{"Grpc-Status": {"15", "5"}}, expected: true},
+		{cond: NewByMetedata("Grpc-Status", "5"), metedata: map[string][]string{}, expected: false},
+		{cond: NewByMetedata("Grpc-Status", "5"), metedata: map[string][]string{"Grpc-Status": {"10"}}, expected: false},
+		{cond: NewByMetedata("Grpc-Status", "5", "10"), metedata: map[string][]string{"Grpc-Status": {"10"}}, expected: true},
+	}
+	for _, testCase := range testCases {
+		result := testCase.cond.Judge(Resp{MD: testCase.metedata})
+		if result != testCase.expected {
+			t.Errorf("cond.Key:%v, cond.Vals:%v,metedata:%v, expected:%v, got:%v", testCase.cond.Key, testCase.cond.Vals, testCase.metedata, testCase.expected, result)
+		}
+	}
+}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -1,0 +1,125 @@
+package retry
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// Backoff defines constract for backoff strategies
+type Backoff interface {
+	Next(retry uint) time.Duration
+}
+
+// constantBackoff is a constant backoff
+type constantBackoff struct {
+	initialInterval       int64
+	maximumJitterInterval int64
+}
+
+func (cb *constantBackoff) Next(retry uint) time.Duration {
+	return (time.Duration(cb.initialInterval) * time.Millisecond) + (time.Duration(rand.Int63n(cb.maximumJitterInterval+1)) * time.Millisecond)
+}
+
+func NewConstantBackoff(initialInterval, maximumJitterInterval time.Duration) Backoff {
+	if maximumJitterInterval < 0 {
+		maximumJitterInterval = 0
+	}
+	return &constantBackoff{
+		initialInterval:       int64(initialInterval / time.Millisecond),
+		maximumJitterInterval: int64(maximumJitterInterval / time.Millisecond),
+	}
+}
+
+// exponentialBackoff is a exponential backoff
+type exponentialBackoff struct {
+	exponentFactor        float64
+	initialInterval       float64
+	maxInterval           float64
+	maximumJitterInterval int64
+}
+
+func (eb *exponentialBackoff) Next(retry uint) time.Duration {
+	// https://aws.amazon.com/cn/blogs/architecture/exponential-backoff-and-jitter/
+	return time.Duration(math.Min(eb.initialInterval*math.Pow(eb.exponentFactor, float64(retry)), eb.maxInterval)+
+		float64(rand.Int63n(eb.maximumJitterInterval+1))) * time.Millisecond
+}
+
+func NewExponentialBackoff(exponentFactor float64, initialInterval, maxInterval, maximumJitterInterval time.Duration) Backoff {
+	if maximumJitterInterval < 0 {
+		maximumJitterInterval = 0
+	}
+	return &exponentialBackoff{
+		exponentFactor:        exponentFactor,
+		initialInterval:       float64(initialInterval / time.Millisecond),
+		maxInterval:           float64(maxInterval / time.Millisecond),
+		maximumJitterInterval: int64(maximumJitterInterval / time.Millisecond),
+	}
+}
+
+// Retriable implements retriers
+type Retriable interface {
+	NextInterval(retry uint) time.Duration
+}
+
+// RetriableFunc is an adapter to allow the use of ordinary functions
+// as a Retriable
+type RetriableFunc func(retry uint) time.Duration
+
+func (f RetriableFunc) NextInterval(retry uint) time.Duration {
+	return f(retry)
+}
+
+func NewRetrierFunc(f RetriableFunc) Retriable {
+	return f
+}
+
+// retrier with some backoff strategy
+type retrier struct {
+	backoff Backoff
+}
+
+func (r *retrier) NextInterval(retry uint) time.Duration {
+	return r.backoff.Next(retry)
+}
+
+func NewRetrier(backoff Backoff) Retriable {
+	return &retrier{
+		backoff: backoff,
+	}
+}
+
+// a null object for retriable
+type noRetrier struct{}
+
+func (r *noRetrier) NextInterval(retry uint) time.Duration {
+	return 0 * time.Millisecond
+}
+
+func NewNoRetrier() Retriable {
+	return &noRetrier{}
+}
+
+// Strategy is retry strategy
+type Strategy struct {
+	Attempts   int
+	Retrier    Retriable
+	Conditions []Condition
+}
+
+func NewStrategy(attempts int, retrier Retriable, conditions []Condition) *Strategy {
+	return &Strategy{Attempts: attempts, Retrier: retrier, Conditions: conditions}
+}
+
+func (s *Strategy) JudgeConditions(r Resp) bool {
+	for _, cond := range s.Conditions {
+		if cond.Judge(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -1,0 +1,94 @@
+package retry
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestConstantBackoff(t *testing.T) {
+	initialInterval := 100 * time.Millisecond
+	for _, j := range []int{-1, 0, 1, 50} {
+		maximumJitterInterval := time.Duration(j) * time.Millisecond
+		ej := j
+		if j < 0 {
+			ej = 0
+		}
+		expectMaximumJitterInterval := time.Duration(ej) * time.Millisecond
+		constantBackoff := NewConstantBackoff(initialInterval, maximumJitterInterval)
+		for i := 0; i < 10000; i++ {
+			bo := constantBackoff.Next(uint(i))
+			if !(initialInterval <= bo && bo <= initialInterval+expectMaximumJitterInterval) {
+				t.Errorf("initialInterval:%s,maximumJitterInterval:%s,got:%s\n", initialInterval, maximumJitterInterval, bo)
+			}
+		}
+	}
+}
+
+func TestExponentialBackoff(t *testing.T) {
+	initialInterval := 100 * time.Millisecond
+	maxInterval := 1000 * time.Millisecond
+	for _, j := range []int{-1, 0, 1, 50} {
+		maximumJitterInterval := time.Duration(j) * time.Millisecond
+		ej := j
+		if j < 0 {
+			ej = 0
+		}
+		expectMaximumJitterInterval := time.Duration(ej) * time.Millisecond
+		exponentialBackoff := NewExponentialBackoff(2.0, initialInterval, maxInterval, maximumJitterInterval)
+		for i := 0; i < 10000; i++ {
+			bo := exponentialBackoff.Next(uint(i))
+			if !(time.Duration(math.Min(float64(initialInterval/time.Millisecond)*math.Pow(2.0, float64(i)),
+				float64(maxInterval/time.Millisecond)))*time.Millisecond <= bo && bo <= maxInterval+expectMaximumJitterInterval) {
+				t.Errorf("exponentFactor:2.0,backoffInterval:%s,maxInterval:%s,maximumJitterInterval:%s,got:%s\n", initialInterval, maxInterval, maximumJitterInterval, bo)
+			}
+		}
+	}
+}
+
+func TestRetrierFunc(t *testing.T) {
+	linearRetrier := NewRetrierFunc(func(retry uint) time.Duration {
+		if retry <= 0 {
+			return 0 * time.Millisecond
+		}
+		return time.Duration(retry) * time.Millisecond
+	})
+	for i := 0; i < 10000; i++ {
+		if linearRetrier.NextInterval(uint(i)) != time.Duration(i)*time.Millisecond {
+			t.Errorf("excepted:%s,got%s", time.Duration(i)*time.Millisecond, linearRetrier.NextInterval(uint(i)))
+		}
+	}
+}
+
+func TestRetrier(t *testing.T) {
+	initialInterval := 20 * time.Millisecond
+	maxInterval := 100 * time.Millisecond
+	maximumJitterInterval := time.Duration(5) * time.Millisecond
+
+	constantBackoff := NewConstantBackoff(initialInterval, maximumJitterInterval)
+	constantRetrier := NewRetrier(constantBackoff)
+	bo := constantRetrier.NextInterval(1)
+	if !(initialInterval <= bo) {
+		t.Errorf("initialInterval:%s,maximumJitterInterval:%s,got:%s\n", initialInterval, maximumJitterInterval, bo)
+	}
+	exponentialBackoff := NewExponentialBackoff(2.0, initialInterval, maxInterval, maximumJitterInterval)
+	exponentialRetrier := NewRetrier(exponentialBackoff)
+	bo = exponentialRetrier.NextInterval(1)
+	if !(40*time.Millisecond <= bo && bo <= maxInterval+maximumJitterInterval) {
+		t.Errorf("exponentFactor:2.0,backoffInterval:%s,maxInterval:%s,maximumJitterInterval:%s,got:%s\n", initialInterval, maxInterval, maximumJitterInterval, bo)
+	}
+}
+
+func TestNoRetrier(t *testing.T) {
+	noRetrier := NewNoRetrier()
+	if noRetrier.NextInterval(1) != time.Duration(0) {
+		t.Errorf("excepted:%s,got:%s", time.Duration(0), noRetrier.NextInterval(1))
+	}
+}
+
+func TestStrategy(t *testing.T) {
+	strage := NewStrategy(3, NewNoRetrier(), []Condition{NewByCode(500, 504)})
+	if strage.JudgeConditions(Resp{Code: 400}) {
+		t.Errorf("expected:false,got:true")
+	}
+}

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -91,4 +91,7 @@ func TestStrategy(t *testing.T) {
 	if strage.JudgeConditions(Resp{Code: 400}) {
 		t.Errorf("expected:false,got:true")
 	}
+	if !strage.JudgeConditions(Resp{Code: 500}) {
+		t.Errorf("expected:true,got:false")
+	}
 }

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -154,8 +154,8 @@ func TestDialConn(t *testing.T) {
 func TestWithRetryStrategy(t *testing.T) {
 	attempt := 0
 	ctx := context.Background()
-	cTx, _ := context.WithTimeout(ctx, 10*time.Microsecond)
-
+	cTx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testCases := []map[string]interface{}{
 		{"method": "test-retry-context-timeout", "expected": 1, "context": cTx},
 		{"method": "test-normal-roundtrip", "expected": 1, "context": ctx},

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/go-kratos/kratos/v2/internal/httputil"
 	"github.com/go-kratos/kratos/v2/middleware"
 	"github.com/go-kratos/kratos/v2/registry"
+	"github.com/go-kratos/kratos/v2/retry"
 	"github.com/go-kratos/kratos/v2/selector"
 	"github.com/go-kratos/kratos/v2/selector/wrr"
 	"github.com/go-kratos/kratos/v2/transport"
@@ -34,19 +36,20 @@ type ClientOption func(*clientOptions)
 
 // Client is an HTTP transport client.
 type clientOptions struct {
-	ctx          context.Context
-	tlsConf      *tls.Config
-	timeout      time.Duration
-	endpoint     string
-	userAgent    string
-	encoder      EncodeRequestFunc
-	decoder      DecodeResponseFunc
-	errorDecoder DecodeErrorFunc
-	transport    http.RoundTripper
-	selector     selector.Selector
-	discovery    registry.Discovery
-	middleware   []middleware.Middleware
-	block        bool
+	ctx           context.Context
+	tlsConf       *tls.Config
+	timeout       time.Duration
+	endpoint      string
+	userAgent     string
+	encoder       EncodeRequestFunc
+	decoder       DecodeResponseFunc
+	errorDecoder  DecodeErrorFunc
+	transport     http.RoundTripper
+	selector      selector.Selector
+	discovery     registry.Discovery
+	middleware    []middleware.Middleware
+	block         bool
+	retryStrategy *retry.Strategy
 }
 
 // WithTransport with client transport.
@@ -133,6 +136,13 @@ func WithTLSConfig(c *tls.Config) ClientOption {
 	}
 }
 
+// WithRetryAttempts with retry attempts
+func WithRetryStrategy(rs *retry.Strategy) ClientOption {
+	return func(o *clientOptions) {
+		o.retryStrategy = rs
+	}
+}
+
 // Client is an HTTP client.
 type Client struct {
 	opts     clientOptions
@@ -145,13 +155,14 @@ type Client struct {
 // NewClient returns an HTTP client.
 func NewClient(ctx context.Context, opts ...ClientOption) (*Client, error) {
 	options := clientOptions{
-		ctx:          ctx,
-		timeout:      2000 * time.Millisecond,
-		encoder:      DefaultRequestEncoder,
-		decoder:      DefaultResponseDecoder,
-		errorDecoder: DefaultErrorDecoder,
-		transport:    http.DefaultTransport,
-		selector:     wrr.New(),
+		ctx:           ctx,
+		timeout:       2000 * time.Millisecond,
+		encoder:       DefaultRequestEncoder,
+		decoder:       DefaultResponseDecoder,
+		errorDecoder:  DefaultErrorDecoder,
+		transport:     http.DefaultTransport,
+		selector:      wrr.New(),
+		retryStrategy: retry.NewStrategy(0, retry.NewNoRetrier(), nil),
 	}
 	for _, o := range opts {
 		o(&options)
@@ -231,7 +242,45 @@ func (client *Client) Invoke(ctx context.Context, method, path string, args inte
 
 func (client *Client) invoke(ctx context.Context, req *http.Request, args interface{}, reply interface{}, c callInfo, opts ...CallOption) error {
 	h := func(ctx context.Context, in interface{}) (interface{}, error) {
-		res, err := client.do(req.WithContext(ctx))
+		var (
+			err     error
+			res     *http.Response
+			body    *bytes.Reader
+			reqData []byte
+		)
+		if req.Body != nil {
+			reqData, err = ioutil.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			body = bytes.NewReader(reqData)
+			req.Body = ioutil.NopCloser(body)
+		}
+		defer func() {
+			if res != nil {
+				res.Body.Close()
+			}
+		}()
+		for i := 0; i <= client.opts.retryStrategy.Attempts; i++ {
+			res, err = client.do(req.WithContext(ctx))
+			if i >= client.opts.retryStrategy.Attempts || err == nil {
+				break
+			}
+
+			if !client.opts.retryStrategy.JudgeConditions(retry.Resp{MD: res.Header, Code: errors.Code(err)}) {
+				break
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(client.opts.retryStrategy.Retrier.NextInterval(uint(i))):
+			}
+			if body != nil {
+				_, _ = body.Seek(0, 0)
+			}
+		}
+
 		if res != nil {
 			cs := csAttempt{res: res}
 			for _, o := range opts {
@@ -241,7 +290,7 @@ func (client *Client) invoke(ctx context.Context, req *http.Request, args interf
 		if err != nil {
 			return nil, err
 		}
-		defer res.Body.Close()
+
 		if err := client.opts.decoder(ctx, res, reply); err != nil {
 			return nil, err
 		}
@@ -294,10 +343,7 @@ func (client *Client) do(req *http.Request) (*http.Response, error) {
 	if done != nil {
 		done(req.Context(), selector.DoneInfo{Err: err})
 	}
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
+	return resp, err
 }
 
 // Close tears down the Transport and all underlying connections.

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -267,7 +267,11 @@ func (client *Client) invoke(ctx context.Context, req *http.Request, args interf
 				break
 			}
 
-			if !client.opts.retryStrategy.JudgeConditions(retry.Resp{MD: res.Header, Code: errors.Code(err)}) {
+			header := map[string][]string{}
+			if res != nil {
+				header = res.Header
+			}
+			if !client.opts.retryStrategy.JudgeConditions(retry.Resp{MD: header, Code: errors.Code(err)}) {
 				break
 			}
 

--- a/transport/http/client_test.go
+++ b/transport/http/client_test.go
@@ -375,7 +375,8 @@ func TestWithRetryStrategy(t *testing.T) {
 func TestClientRetry(t *testing.T) {
 	attempt := 0
 	ctx := context.Background()
-	cTx, _ := context.WithTimeout(ctx, 10*time.Microsecond)
+	cTx, cancel := context.WithTimeout(ctx, 10*time.Microsecond)
+	defer cancel()
 	testCases := []map[string]interface{}{
 		{"path": "/test-retry-context-timeout", "expected": 0, "context": cTx},
 		{"path": "/test-normal-roundtrip", "expected": 1, "context": ctx},


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
```go
    // examples
    // http
    client, err := NewClient(ctx, WithRetryStrategy(retry.NewStrategy(
            3,
			retry.NewRetrier(retry.NewConstantBackoff(100*time.Millisecond, 1000*time.Millisecond)),
			[]retry.Condition{retry.NewByCode(500, 504)},
		)))
    // grpc
    conn, err := grpc.DialInsecure(ctx, grpc.WithRetryStrategy(retry.NewStrategy(
            3, 
            retry.NewRetrier(retry.NewConstantBackoff(100*time.Millisecond, 1000*time.Millisecond)),
            []retry.Condition{retry.NewByCode(12, 13)},
        )))
```
#### Which issue(s) this PR fixes (resolves / be part of):
    [Feature]provides client-side request retry logic #2202
