### PR TITLE
Fix oneof field in body

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -153,7 +153,7 @@ func buildHTTPRule(g *protogen.GeneratedFile, m *protogen.Method, rule *annotati
 		md.Body = ""
 	} else if body != "" {
 		md.HasBody = true
-		md.Body = fmt.Sprintf(".Get%s()" + camelCaseVars(body))
+		md.Body = fmt.Sprintf(".Get%s()", camelCaseVars(body))
 	} else {
 		md.HasBody = false
 	}

--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -153,7 +153,7 @@ func buildHTTPRule(g *protogen.GeneratedFile, m *protogen.Method, rule *annotati
 		md.Body = ""
 	} else if body != "" {
 		md.HasBody = true
-		md.Body = "." + camelCaseVars(body)
+		md.Body = fmt.Sprintf(".Get%s()" + camelCaseVars(body))
 	} else {
 		md.HasBody = false
 	}

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -32,7 +32,8 @@ func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) fu
 	return func(ctx http.Context) error {
 		var in {{.Request}}
 		{{- if .HasBody}}
-		if err := ctx.Bind(&in{{.Body}}); err != nil {
+		body := in{{.Body}}
+		if err := ctx.Bind(&body); err != nil {
 			return err
 		}
 		


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
The usage of oneof field in http server/client body is wrong, we can not access the field directly, instead, we should use `in.GetXXX()` 


#### Which issue(s) this PR fixes (resolves / be part of):
N/A


#### Other special notes for the reviewers:
N/A
