### PR TITLE
fix(config): when namespace application not set anything, occur panic

### DIFF
--- a/contrib/config/apollo/apollo.go
+++ b/contrib/config/apollo/apollo.go
@@ -126,7 +126,6 @@ func (e *apollo) load() []*config.KeyValue {
 			// occur panic while KeyValue is nil
 			continue
 		}
-
 		// serialize the namespace content KeyValue into bytes.
 		kv = append(kv, &config.KeyValue{
 			Key:    ns,

--- a/contrib/config/apollo/apollo.go
+++ b/contrib/config/apollo/apollo.go
@@ -123,7 +123,10 @@ func (e *apollo) load() []*config.KeyValue {
 		value, err := e.client.GetConfigCache(ns).Get("content")
 		if err != nil {
 			log.Warnw("apollo get config failed", "err", err)
+			// occur panic while KeyValue is nil
+			continue
 		}
+
 		// serialize the namespace content KeyValue into bytes.
 		kv = append(kv, &config.KeyValue{
 			Key:    ns,


### PR DESCRIPTION
问题：
apollo 中默认的namespace 中没有设置值时，获取的值为 nil ，导致强制类型转换时，出现panic。
虽然这个情况较小可能发生，代码中既然判断了错误，不处理 ？？？
apollo.go  line: 124
