### PR TITLE
Revert "Global logger"

### DIFF
--- a/log/global.go
+++ b/log/global.go
@@ -27,8 +27,8 @@ func (a *loggerAppliance) SetLogger(in Logger) {
 	a.Logger = in
 }
 
-func (a *loggerAppliance) Log(level Level, keyvals ...interface{}) error {
-	return a.Logger.Log(level, keyvals...)
+func (a *loggerAppliance) GetLogger() Logger {
+	return a.Logger
 }
 
 // SetLogger should be called before any other log call.
@@ -39,7 +39,7 @@ func SetLogger(logger Logger) {
 
 // GetLogger returns global logger appliance as logger in current process.
 func GetLogger() Logger {
-	return global
+	return global.GetLogger()
 }
 
 // Log Print log by level and keyvals.

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -14,7 +14,7 @@ func TestGlobalLog(t *testing.T) {
 	logger := NewStdLogger(buffer)
 	SetLogger(logger)
 
-	if global.Logger != logger {
+	if GetLogger() != logger {
 		t.Error("GetLogger() is not equal to logger")
 	}
 


### PR DESCRIPTION
Reverts go-kratos/kratos#2265

```go
func (a *loggerAppliance) Log(level Level, keyvals ...interface{}) error {
	return a.Logger.Log(level, keyvals...)
}
```
It changed the call depth of global logger.

Before:
![截屏2022-08-12 14 44 25](https://user-images.githubusercontent.com/12043634/184303555-bd12bf79-35f0-4673-b718-730becba834e.png)
```json
{"level":"debug","ts":"2022-08-12T14:58:56.879397+08:00","caller":"config/config.go:103","msg":"config loaded: config.yaml format: yaml"}
```

After:
![截屏2022-08-12 14 46 40](https://user-images.githubusercontent.com/12043634/184303591-c6af70b1-0588-4c39-a5e5-3652c4dc5e84.png)
```json
{"level":"debug","ts":"2022-08-12T14:59:41.046804+08:00","caller":"log/global.go:62","msg":"config loaded: config.yaml format: yaml"}
```
