### PR TITLE
fix(log): DefaultCaller doesn't returns "pkg/file:line", it returns "…

### DIFF
--- a/log/value.go
+++ b/log/value.go
@@ -32,6 +32,10 @@ func Caller(depth int) Valuer {
 	return func(context.Context) interface{} {
 		_, file, line, _ := runtime.Caller(depth)
 		idx := strings.LastIndexByte(file, '/')
+		if idx == -1 {
+			return file[idx+1:] + ":" + strconv.Itoa(line)
+		}
+		idx = strings.LastIndexByte(file[:idx], '/')
 		return file[idx+1:] + ":" + strconv.Itoa(line)
 	}
 }


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
DefaultCaller doesn't returns "pkg/file:line", it returns "file:line" now. For example, both biz/user.go and data/user.go  are printed as "user.go" in logger. It's not clear.
With this PR, the log changed from
```go
"caller":"user.go:277"
```
to 
```go
"caller":"biz/user.go:277"
```

#### Which issue(s) this PR fixes (resolves / be part of):
None


#### Other special notes for the reviewers:

