### PR TITLE
set default caller depth to 5

### DIFF
--- a/log/global.go
+++ b/log/global.go
@@ -18,17 +18,13 @@ type loggerAppliance struct {
 }
 
 func init() {
-	global.SetLogger(With(DefaultLogger, "caller", Caller(5)))
+	global.SetLogger(DefaultLogger)
 }
 
 func (a *loggerAppliance) SetLogger(in Logger) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	a.Logger = in
-}
-
-func (a *loggerAppliance) Log(level Level, keyvals ...interface{}) error {
-	return a.Logger.Log(level, keyvals...)
 }
 
 // SetLogger should be called before any other log call.

--- a/log/global.go
+++ b/log/global.go
@@ -18,7 +18,7 @@ type loggerAppliance struct {
 }
 
 func init() {
-	global.SetLogger(DefaultLogger)
+	global.SetLogger(With(DefaultLogger, "caller", Caller(5)))
 }
 
 func (a *loggerAppliance) SetLogger(in Logger) {

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -117,3 +117,16 @@ func TestGlobalContext(t *testing.T) {
 		t.Errorf("Expected:%s, got:%s", "INFO msg=111", buffer.String())
 	}
 }
+
+func TestGlobalLoggerCaller(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	logger := NewStdLogger(buffer)
+	logger = With(logger, "caller", Caller(5))
+	SetLogger(logger)
+	Info("test", "logger")
+	content := buffer.String()
+	t.Log(content)
+	if !strings.Contains(content, "global_test.go:126") {
+		t.Errorf("Expected:%q, got:%q", "global_test.go:126", buffer.String())
+	}
+}

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -121,7 +121,7 @@ func TestGlobalContext(t *testing.T) {
 func TestGlobalLoggerCaller(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	logger := NewStdLogger(buffer)
-	logger = With(logger, "caller", Caller(5))
+	logger = With(logger, "caller", DefaultCaller)
 	SetLogger(logger)
 	Info("test", "logger")
 	content := buffer.String()


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

Set default global logger caller depth to 5.


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

Related https://github.com/go-kratos/kratos/pull/2272.


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
