### PR TITLE
fix(internal/host): Extract can't return the minium index ip

### DIFF
--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -59,7 +59,6 @@ func Extract(hostPort string, lis net.Listener) (string, error) {
 		if iface.Index >= minIndex && result != nil {
 			continue
 		}
-		minIndex = iface.Index
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue
@@ -75,6 +74,7 @@ func Extract(hostPort string, lis net.Listener) (string, error) {
 				continue
 			}
 			if isValidIP(ip.String()) {
+				minIndex = iface.Index
 				result = ip
 				break
 			}

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -2,7 +2,6 @@ package host
 
 import (
 	"fmt"
-	"math"
 	"net"
 	"strconv"
 )
@@ -51,7 +50,7 @@ func Extract(hostPort string, lis net.Listener) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	minIndex := math.MaxInt
+	minIndex := int(^uint(0) >> 1)
 	var result net.IP
 	for _, iface := range ifaces {
 		if (iface.Flags & net.FlagUp) == 0 {

--- a/internal/host/host.go
+++ b/internal/host/host.go
@@ -2,6 +2,7 @@ package host
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 )
@@ -50,18 +51,16 @@ func Extract(hostPort string, lis net.Listener) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	lowest := int(^uint(0) >> 1)
+	minIndex := math.MaxInt
 	var result net.IP
 	for _, iface := range ifaces {
 		if (iface.Flags & net.FlagUp) == 0 {
 			continue
 		}
-		if iface.Index < lowest || result == nil {
-			lowest = iface.Index
-		}
-		if result != nil {
+		if iface.Index >= minIndex && result != nil {
 			continue
 		}
+		minIndex = iface.Index
 		addrs, err := iface.Addrs()
 		if err != nil {
 			continue
@@ -78,6 +77,7 @@ func Extract(hostPort string, lis net.Listener) (string, error) {
 			}
 			if isValidIP(ip.String()) {
 				result = ip
+				break
 			}
 		}
 	}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

- fix bug #2297 
- rename: `lowest` -> `minIndex`
- ~~use const `math.MaxInt` replace `int(^uint(0) >> 1)`~~
https://go.dev/doc/go1.17
![image](https://user-images.githubusercontent.com/25560763/185780690-4e97afdc-e366-42e7-bc12-3e2fe26920d1.png)


#### Which issue(s) this PR fixes (resolves / be part of):

https://github.com/go-kratos/kratos/issues/2297
