### PR TITLE
fix: Log print duplicate key val

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -3,7 +3,6 @@ package log
 import (
 	"context"
 	"log"
-	"reflect"
 )
 
 // DefaultLogger is default logger.
@@ -15,10 +14,11 @@ type Logger interface {
 }
 
 type logger struct {
-	logger    Logger
-	prefix    []interface{}
-	hasValuer bool
-	ctx       context.Context
+	logger     Logger
+	prefix     []interface{}
+	prefixUniq map[string]int
+	hasValuer  bool
+	ctx        context.Context
 }
 
 func (c *logger) Log(level Level, keyvals ...interface{}) error {
@@ -28,38 +28,13 @@ func (c *logger) Log(level Level, keyvals ...interface{}) error {
 		bindValues(c.ctx, kvs)
 	}
 	kvs = append(kvs, keyvals...)
-	if err := c.logger.Log(level, uniqKeys(kvs)...); err != nil {
+	if err := c.logger.Log(level, kvs...); err != nil {
 		return err
 	}
 	return nil
 }
 
-// uniqKeys Under the same key, the Val corresponding to the last key shall prevail
-func uniqKeys(kvs []interface{}) []interface{} {
-	if len(kvs) == 0 {
-		return kvs
-	}
-	if len(kvs)&1 == 1 {
-		kvs = append(kvs, "KEYVALS UNPAIRED") // key missing val, add a virtual value
-	}
-	uniqMap := make(map[reflect.Value]interface{})
-	keys := make([]interface{}, 0, len(kvs))
-	for i := 0; i < len(kvs); i = i + 2 {
-		key, val := kvs[i], kvs[i+1]
-		rvKey := reflect.ValueOf(key) // key missing val, map cannot be stored log.Valuer, so reflect.Value is used as the key here
-		if _, ok := uniqMap[rvKey]; !ok {
-			keys = append(keys, key) // ensure the data sequence is consistent
-		}
-		uniqMap[rvKey] = val // ensure that the val corresponding to the key is the latest
-	}
-	uniq := make([]interface{}, 0, 2*len(keys))
-	for _, key := range keys {
-		uniq = append(uniq, key, uniqMap[reflect.ValueOf(key)])
-	}
-	return uniq
-}
-
-// With with logger fields.
+// With logger fields.
 func With(l Logger, kv ...interface{}) Logger {
 	c, ok := l.(*logger)
 	if !ok {
@@ -73,6 +48,43 @@ func With(l Logger, kv ...interface{}) Logger {
 		prefix:    kvs,
 		hasValuer: containsValuer(kvs),
 		ctx:       c.ctx,
+	}
+}
+
+// WithUniq with uniq key logger fields.
+// if the key is the same, the last used val
+func WithUniq(l Logger, key string, val interface{}) Logger {
+	c, ok := l.(*logger)
+	if !ok {
+		kv := []interface{}{key, val}
+		return &logger{
+			logger:     l,
+			prefix:     kv,
+			prefixUniq: map[string]int{key: len(kv) - 1},
+			hasValuer:  containsValuer(kv),
+			ctx:        context.Background(),
+		}
+	}
+
+	kvs := make([]interface{}, 0, len(c.prefix)+2)
+	kvs = append(kvs, c.prefix...)
+	kiMap := make(map[string]int, len(c.prefixUniq)+1)
+	for k, v := range c.prefixUniq {
+		kiMap[k] = v
+	}
+	if i, ok := kiMap[key]; ok {
+		kvs[i] = val
+	} else {
+		kvs = append(kvs, key, val)
+		kiMap[key] = len(kvs) - 1
+	}
+
+	return &logger{
+		logger:     c.logger,
+		prefix:     kvs,
+		prefixUniq: kiMap,
+		hasValuer:  containsValuer(kvs),
+		ctx:        c.ctx,
 	}
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"log"
+	"reflect"
 )
 
 // DefaultLogger is default logger.
@@ -27,10 +28,35 @@ func (c *logger) Log(level Level, keyvals ...interface{}) error {
 		bindValues(c.ctx, kvs)
 	}
 	kvs = append(kvs, keyvals...)
-	if err := c.logger.Log(level, kvs...); err != nil {
+	if err := c.logger.Log(level, uniqKeys(kvs)...); err != nil {
 		return err
 	}
 	return nil
+}
+
+// uniqKeys Under the same key, the Val corresponding to the last key shall prevail
+func uniqKeys(kvs []interface{}) []interface{} {
+	if len(kvs) == 0 {
+		return kvs
+	}
+	if len(kvs)&1 == 1 {
+		kvs = append(kvs, "KEYVALS UNPAIRED") // key missing val, add a virtual value
+	}
+	uniqMap := make(map[reflect.Value]interface{})
+	keys := make([]interface{}, 0, len(kvs))
+	for i := 0; i < len(kvs); i = i + 2 {
+		key, val := kvs[i], kvs[i+1]
+		rvKey := reflect.ValueOf(key) // key missing val, map cannot be stored log.Valuer, so reflect.Value is used as the key here
+		if _, ok := uniqMap[rvKey]; !ok {
+			keys = append(keys, key) // ensure the data sequence is consistent
+		}
+		uniqMap[rvKey] = val // ensure that the val corresponding to the key is the latest
+	}
+	uniq := make([]interface{}, 0, 2*len(keys))
+	for _, key := range keys {
+		uniq = append(uniq, key, uniqMap[reflect.ValueOf(key)])
+	}
+	return uniq
 }
 
 // With with logger fields.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -2,13 +2,22 @@ package log
 
 import (
 	"context"
+	"reflect"
 	"testing"
 )
+
+func TestUniqKeys(t *testing.T) {
+	uniq := uniqKeys([]interface{}{"k1", "v1", "k1", "vv1", "k1", "vvv1", "k2", "v2"})
+	if !reflect.DeepEqual(uniq, []interface{}{"k1", "vvv1", "k2", "v2"}) {
+		t.Error("inconsistent data after deduplication")
+	}
+}
 
 func TestInfo(t *testing.T) {
 	logger := DefaultLogger
 	logger = With(logger, "ts", DefaultTimestamp)
 	logger = With(logger, "caller", DefaultCaller)
+	logger = With(logger, "caller", Caller(1))
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }
 

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -2,22 +2,29 @@ package log
 
 import (
 	"context"
-	"reflect"
 	"testing"
 )
 
-func TestUniqKeys(t *testing.T) {
-	uniq := uniqKeys([]interface{}{"k1", "v1", "k1", "vv1", "k1", "vvv1", "k2", "v2"})
-	if !reflect.DeepEqual(uniq, []interface{}{"k1", "vvv1", "k2", "v2"}) {
-		t.Error("inconsistent data after deduplication")
+func TestWithUniq(t *testing.T) {
+	l := DefaultLogger
+	l = WithUniq(l, "caller", 10)
+	l = WithUniq(l, "caller", 11)
+	c, ok := l.(*logger)
+	if !ok {
+		t.Error("Interface Logger is not implemented")
+	}
+	if v, ok := c.prefixUniq["caller"]; !ok {
+		t.Error("prefix uniq map err")
+	} else if c.prefix[v] != 11 {
+		t.Error("prefix map does not save the last key")
 	}
 }
 
 func TestInfo(t *testing.T) {
 	logger := DefaultLogger
 	logger = With(logger, "ts", DefaultTimestamp)
-	logger = With(logger, "caller", DefaultCaller)
-	logger = With(logger, "caller", Caller(1))
+	logger = WithUniq(logger, "caller", DefaultCaller)
+	logger = WithUniq(logger, "caller", Caller(1))
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }
 


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
- [x] (De duplication of duplicate log key values)
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
- [x] fix issues: #2347
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
I don't think it is necessary to de duplicate data by using `func With(l Logger, kv ...interface{})`, which may cause the output to be inconsistent with expectations.
`func WithUniq(l Logger, key string, val interface{})` can be used to ensure that the key and val are not duplicated. Users can select this function according to their needs

我认为没有必要在使用 `With` 时消除重复数据，这可能会导致输出与预期不一致。
`WithUniq` 可用于确保 KEY 不重复，并且保证 KEY 对应的 VAL 是最新的，用户可以根据需要自行选择此功能。