### PR TITLE
fix(lint): Using deprecated package `io/ioutil` cause lint interrupte…

### DIFF
--- a/contrib/config/polaris/config_test.go
+++ b/contrib/config/polaris/config_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -38,7 +38,7 @@ func makeJSONRequest(uri string, data string, method string, headers map[string]
 		return nil, err
 	}
 	defer res.Body.Close()
-	return ioutil.ReadAll(res.Body)
+	return io.ReadAll(res.Body)
 }
 
 type commonRes struct {

--- a/contrib/opensergo/opensergo.go
+++ b/contrib/opensergo/opensergo.go
@@ -2,7 +2,6 @@ package opensergo
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -52,7 +51,7 @@ func New(opts ...Option) (*OpenSergo, error) {
 		}
 	}
 	if v := os.Getenv("OPENSERGO_BOOTSTRAP_CONFIG"); v != "" {
-		b, err := ioutil.ReadFile(v)
+		b, err := os.ReadFile(v)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +88,7 @@ func (s *OpenSergo) ReportMetadata(ctx context.Context, app kratos.AppInfo) erro
 	}
 
 	for _, endpoint := range app.Endpoint() {
-		u, err := url.Parse(endpoint) //nolint
+		u, err := url.Parse(endpoint) // nolint
 		if err != nil {
 			return err
 		}

--- a/contrib/opensergo/opensergo_test.go
+++ b/contrib/opensergo/opensergo_test.go
@@ -1,7 +1,6 @@
 package opensergo
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -337,7 +336,7 @@ func TestOpenSergo(t *testing.T) {
 			},
 			preFunc: func(t *testing.T) {
 				fileContent := `{"endpoint": "127.0.0.1:9090"}`
-				err := ioutil.WriteFile("test.json", []byte(fileContent), 0o644)
+				err := os.WriteFile("test.json", []byte(fileContent), 0o644)
 				if err != nil {
 					t.Fatalf("ioutil.WriteFile error:%s", err)
 				}

--- a/contrib/registry/eureka/client.go
+++ b/contrib/registry/eureka/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"strings"
@@ -323,12 +322,12 @@ func (e *Client) do(ctx context.Context, method string, params []string, input i
 			continue
 		}
 		defer func() {
-			_, _ = io.Copy(ioutil.Discard, resp.Body)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			resp.Body.Close()
 		}()
 
 		if output != nil && resp.StatusCode/100 == 2 {
-			data, err := ioutil.ReadAll(resp.Body)
+			data, err := io.ReadAll(resp.Body)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
…d, change to `os` or `io` package.

#### Description (what this PR does / why we need it):
Using deprecated package `io/ioutil` cause **lint interrupted**,  change to `os` or `io` package.

#### Which issue(s) this PR fixes (resolves / be part of):
fixes/resolves #2351


#### Other special notes for the reviewers:
No.
