### PR TITLE
fix: log val err output

### DIFF
--- a/log/log_test.go
+++ b/log/log_test.go
@@ -8,7 +8,6 @@ import (
 func TestInfo(t *testing.T) {
 	logger := DefaultLogger
 	logger = With(logger, "ts", DefaultTimestamp)
-	logger = With(logger, "caller")
 	logger = With(logger, "caller", DefaultCaller)
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -8,6 +8,7 @@ import (
 func TestInfo(t *testing.T) {
 	logger := DefaultLogger
 	logger = With(logger, "ts", DefaultTimestamp)
+	logger = With(logger, "caller")
 	logger = With(logger, "caller", DefaultCaller)
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }

--- a/log/value.go
+++ b/log/value.go
@@ -48,7 +48,7 @@ func Timestamp(layout string) Valuer {
 }
 
 func bindValues(ctx context.Context, keyvals []interface{}) {
-	for i := 1; i < len(keyvals); i += 2 {
+	for i := 0; i < len(keyvals); i++ {
 		if v, ok := keyvals[i].(Valuer); ok {
 			keyvals[i] = v(ctx)
 		}
@@ -56,7 +56,7 @@ func bindValues(ctx context.Context, keyvals []interface{}) {
 }
 
 func containsValuer(keyvals []interface{}) bool {
-	for i := 1; i < len(keyvals); i += 2 {
+	for i := 0; i < len(keyvals); i++ {
 		if _, ok := keyvals[i].(Valuer); ok {
 			return true
 		}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
err output: `INFO ts=2022-09-05T12:56:11+08:00 caller=caller %!s(log.Valuer=0x10ea120)=key1 value1=KEYVALS UNPAIRED`
`%!s(log.Valuer=0x10ea120)` log.Valuer func is error translated


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
