### PR TITLE
feat(log): Add method `log.WithReplace` to enhance `log.With`

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -39,6 +39,16 @@ func With(l Logger, kv ...interface{}) Logger {
 	if !ok {
 		return &logger{logger: l, prefix: kv, hasValuer: containsValuer(kv), ctx: context.Background()}
 	}
+	kvl := len(kv)
+	// at lest one kv pair, or else return itself
+	if kvl < 2 {
+		return l
+	}
+	// If len is an odd number, the last element is discard.
+	if kvl&1 == 1 {
+		kv = kv[:kvl-1]
+	}
+
 	kvs := make([]interface{}, 0, len(c.prefix)+len(kv))
 	kvs = append(kvs, c.prefix...)
 	kvs = append(kvs, kv...)
@@ -56,6 +66,11 @@ func WithReplace(l Logger, kv ...interface{}) Logger {
 	if !ok {
 		return &logger{logger: l, prefix: kv, hasValuer: containsValuer(kv), ctx: context.Background()}
 	}
+	// at lest one kv pair, or else return itself
+	if len(kv) < 2 {
+		return l
+	}
+
 	ca := len(c.prefix) + len(kv)
 	kvs := make([]interface{}, 0, ca)
 	filter := make(map[interface{}]bool, ca)
@@ -91,11 +106,11 @@ func WithContext(ctx context.Context, l Logger) Logger {
 
 func appendWithFilter(src []interface{}, to []interface{}, filter map[interface{}]bool) []interface{} {
 	// If len is an odd number, the last element is discard.
-	vl := len(src)
-	if vl&1 == 1 {
-		vl--
+	l := len(src)
+	if l&1 == 1 {
+		l--
 	}
-	for i := vl - 1; i > 0; i = i - 2 {
+	for i := l - 1; i > 0; i = i - 2 {
 		// exists key, skip kv
 		if b, ok := filter[src[i-1]]; b && ok {
 			i = i - 2

--- a/log/log.go
+++ b/log/log.go
@@ -58,11 +58,11 @@ func WithReplace(l Logger, kv ...interface{}) Logger {
 	}
 	ca := len(c.prefix) + len(kv)
 	kvs := make([]interface{}, 0, ca)
-	m := make(map[interface{}]bool, ca)
+	filter := make(map[interface{}]bool, ca)
 
 	// Add in reverse order, and the later will cover the earlier
-	kvs = appendWithFilter(kv, kvs, m)
-	kvs = appendWithFilter(c.prefix, kvs, m)
+	kvs = appendWithFilter(kv, kvs, filter)
+	kvs = appendWithFilter(c.prefix, kvs, filter)
 	// Reverse to asc order
 	kvs = reverse(kvs)
 

--- a/log/log.go
+++ b/log/log.go
@@ -33,6 +33,9 @@ func (c *logger) Log(level Level, keyvals ...interface{}) error {
 	return nil
 }
 
+// MinLen At lest one kv pair
+const MinLen = 2
+
 // With logger fields.
 func With(l Logger, kv ...interface{}) Logger {
 	c, ok := l.(*logger)
@@ -41,7 +44,7 @@ func With(l Logger, kv ...interface{}) Logger {
 	}
 	kvl := len(kv)
 	// at lest one kv pair, or else return itself
-	if kvl < 2 {
+	if kvl < MinLen {
 		return l
 	}
 	// If len is an odd number, the last element is discard.
@@ -67,7 +70,7 @@ func WithReplace(l Logger, kv ...interface{}) Logger {
 		return &logger{logger: l, prefix: kv, hasValuer: containsValuer(kv), ctx: context.Background()}
 	}
 	// at lest one kv pair, or else return itself
-	if len(kv) < 2 {
+	if len(kv) < MinLen {
 		return l
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -33,7 +33,7 @@ func (c *logger) Log(level Level, keyvals ...interface{}) error {
 	return nil
 }
 
-// With with logger fields.
+// With logger fields.
 func With(l Logger, kv ...interface{}) Logger {
 	c, ok := l.(*logger)
 	if !ok {
@@ -42,6 +42,30 @@ func With(l Logger, kv ...interface{}) Logger {
 	kvs := make([]interface{}, 0, len(c.prefix)+len(kv))
 	kvs = append(kvs, c.prefix...)
 	kvs = append(kvs, kv...)
+	return &logger{
+		logger:    c.logger,
+		prefix:    kvs,
+		hasValuer: containsValuer(kvs),
+		ctx:       c.ctx,
+	}
+}
+
+// WithReplace : Add logger fields, and, if the key already exists, replace the older value with the new value.
+func WithReplace(l Logger, kv ...interface{}) Logger {
+	c, ok := l.(*logger)
+	if !ok {
+		return &logger{logger: l, prefix: kv, hasValuer: containsValuer(kv), ctx: context.Background()}
+	}
+	ca := len(c.prefix) + len(kv)
+	kvs := make([]interface{}, 0, ca)
+	m := make(map[interface{}]bool, ca)
+
+	// Add in reverse order, and the later will cover the earlier
+	kvs = appendWithFilter(kv, kvs, m)
+	kvs = appendWithFilter(c.prefix, kvs, m)
+	// Reverse to asc order
+	kvs = reverse(kvs)
+
 	return &logger{
 		logger:    c.logger,
 		prefix:    kvs,
@@ -63,4 +87,33 @@ func WithContext(ctx context.Context, l Logger) Logger {
 		hasValuer: c.hasValuer,
 		ctx:       ctx,
 	}
+}
+
+func appendWithFilter(src []interface{}, to []interface{}, filter map[interface{}]bool) []interface{} {
+	// If len is an odd number, the last element is discard.
+	vl := len(src)
+	if vl&1 == 1 {
+		vl--
+	}
+	for i := vl - 1; i > 0; i = i - 2 {
+		// exists key, skip kv
+		if b, ok := filter[src[i-1]]; b && ok {
+			i = i - 2
+			continue
+		}
+		// append val
+		to = append(to, src[i])
+		// append key
+		to = append(to, src[i-1])
+		// save key to filter
+		filter[src[i-1]] = true
+	}
+	return to
+}
+
+func reverse(slice []interface{}) []interface{} {
+	for i, j := 0, len(slice)-1; i < j; i, j = i+1, j-1 {
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	return slice
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"context"
 	"testing"
+	"time"
 )
 
 func TestInfo(t *testing.T) {
@@ -14,4 +15,11 @@ func TestInfo(t *testing.T) {
 
 func TestWithContext(t *testing.T) {
 	WithContext(context.Background(), nil)
+}
+
+func TestWithReplace(t *testing.T) {
+	logger := DefaultLogger
+	logger = WithReplace(logger, "ts", DefaultTimestamp, "caller", DefaultCaller, "test_error_key_val_pair")
+	logger = WithReplace(logger, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "test_error_key_val_pair")
+	_ = logger.Log(LevelInfo, "key1", "value1")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInfo(t *testing.T) {
@@ -14,14 +12,16 @@ func TestInfo(t *testing.T) {
 	l = With(l)
 	l = With(l, "unpaired_key")
 	c, ok := l.(*logger)
-	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 2)
+	if !ok || len(c.prefix) != 2 {
+		t.Error("test failed")
+	}
 
 	l = With(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "unpaired_key")
 	l = With(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "unpaired_key")
 	c, ok = l.(*logger)
-	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 14)
+	if !ok || len(c.prefix) != 14 {
+		t.Error("test failed")
+	}
 
 	_ = l.Log(LevelInfo, "key1", "value1")
 }
@@ -36,14 +36,16 @@ func TestWithReplace(t *testing.T) {
 	l = WithReplace(l)
 	l = WithReplace(l, "unpaired_key")
 	c, ok := l.(*logger)
-	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 2)
+	if !ok || len(c.prefix) != 2 {
+		t.Error("test failed")
+	}
 
 	l = WithReplace(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "unpaired_key")
 	l = WithReplace(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "unpaired_key")
 	c, ok = l.(*logger)
-	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 6)
+	if !ok || len(c.prefix) != 6 {
+		t.Error("test failed")
+	}
 
 	_ = l.Log(LevelInfo, "key1", "value1")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -11,16 +11,17 @@ import (
 func TestInfo(t *testing.T) {
 	l := DefaultLogger
 	l = With(l)
-	l = With(l, "error_key")
+	l = With(l)
+	l = With(l, "unpaired_key")
 	c, ok := l.(*logger)
 	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 0)
+	assert.True(t, len(c.prefix) == 2)
 
-	l = With(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "error_key1")
-	l = With(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "error_key2")
+	l = With(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "unpaired_key")
+	l = With(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "unpaired_key")
 	c, ok = l.(*logger)
 	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 8)
+	assert.True(t, len(c.prefix) == 14)
 
 	_ = l.Log(LevelInfo, "key1", "value1")
 }
@@ -32,16 +33,17 @@ func TestWithContext(t *testing.T) {
 func TestWithReplace(t *testing.T) {
 	l := DefaultLogger
 	l = WithReplace(l)
-	l = WithReplace(l, "error_key")
+	l = WithReplace(l)
+	l = WithReplace(l, "unpaired_key")
 	c, ok := l.(*logger)
 	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 0)
+	assert.True(t, len(c.prefix) == 2)
 
-	l = WithReplace(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "error_key1")
-	l = WithReplace(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "error_key2")
+	l = WithReplace(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "unpaired_key")
+	l = WithReplace(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "unpaired_key")
 	c, ok = l.(*logger)
 	assert.True(t, ok)
-	assert.True(t, len(c.prefix) == 4)
+	assert.True(t, len(c.prefix) == 6)
 
 	_ = l.Log(LevelInfo, "key1", "value1")
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,13 +4,25 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInfo(t *testing.T) {
-	logger := DefaultLogger
-	logger = With(logger, "ts", DefaultTimestamp)
-	logger = With(logger, "caller", DefaultCaller)
-	_ = logger.Log(LevelInfo, "key1", "value1")
+	l := DefaultLogger
+	l = With(l)
+	l = With(l, "error_key")
+	c, ok := l.(*logger)
+	assert.True(t, ok)
+	assert.True(t, len(c.prefix) == 0)
+
+	l = With(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "error_key1")
+	l = With(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "error_key2")
+	c, ok = l.(*logger)
+	assert.True(t, ok)
+	assert.True(t, len(c.prefix) == 8)
+
+	_ = l.Log(LevelInfo, "key1", "value1")
 }
 
 func TestWithContext(t *testing.T) {
@@ -18,8 +30,18 @@ func TestWithContext(t *testing.T) {
 }
 
 func TestWithReplace(t *testing.T) {
-	logger := DefaultLogger
-	logger = WithReplace(logger, "ts", DefaultTimestamp, "caller", DefaultCaller, "test_error_key_val_pair")
-	logger = WithReplace(logger, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "test_error_key_val_pair")
-	_ = logger.Log(LevelInfo, "key1", "value1")
+	l := DefaultLogger
+	l = WithReplace(l)
+	l = WithReplace(l, "error_key")
+	c, ok := l.(*logger)
+	assert.True(t, ok)
+	assert.True(t, len(c.prefix) == 0)
+
+	l = WithReplace(l, "ts", DefaultTimestamp, "caller", DefaultCaller, "error_key1")
+	l = WithReplace(l, "ts", Timestamp(time.ANSIC), "caller", Caller(-1), "error_key2")
+	c, ok = l.(*logger)
+	assert.True(t, ok)
+	assert.True(t, len(c.prefix) == 4)
+
+	_ = l.Log(LevelInfo, "key1", "value1")
 }


### PR DESCRIPTION
Add method `log.WithReplace` to enhance `log.With` : Add logger fields, and, if the key already exists, replace the older value with the new value.

#### Description (what this PR does / why we need it):
增加 log.WithReplace 方法，用以增强log.With方法，解决诸如Caller重复的问题。

#### Which issue(s) this PR fixes (resolves / be part of):
resolves #2347 

#### Other special notes for the reviewers:
原先提交的直接修改log.With方法的PR（#2350）已经关闭，新增log.WithReplace方法供用户选择，后者会去掉重复Key的旧值。

