### PR TITLE
feat(log): std logger removing duplicate keys

### DIFF
--- a/log/filter_test.go
+++ b/log/filter_test.go
@@ -103,7 +103,7 @@ func TestFilterFuncWitchLoggerPrefix(t *testing.T) {
 		},
 		{
 			logger: NewFilter(With(NewStdLogger(buf), "caller", "caller"), FilterFunc(testFilterFuncWithLoggerPrefix)),
-			want:   "INFO caller=caller msg=msg\n",
+			want:   `{"caller":"caller","level":"INFO","msg":"msg"}` + "\n",
 		},
 	}
 

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -54,36 +54,36 @@ func TestGlobalLog(t *testing.T) {
 		switch tc.level {
 		case LevelDebug:
 			Debug(msg)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "DEBUG", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "DEBUG", msg))
 			Debugf(tc.content[0].(string), tc.content[1:]...)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "DEBUG", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "DEBUG", msg))
 			Debugw("log", msg)
-			expected = append(expected, fmt.Sprintf("%s log=%s", "DEBUG", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","log":"%s"}`, "DEBUG", msg))
 		case LevelInfo:
 			Info(msg)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "INFO", msg))
 			Infof(tc.content[0].(string), tc.content[1:]...)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "INFO", msg))
 			Infow("log", msg)
-			expected = append(expected, fmt.Sprintf("%s log=%s", "INFO", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","log":"%s"}`, "INFO", msg))
 		case LevelWarn:
 			Warn(msg)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "WARN", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "WARN", msg))
 			Warnf(tc.content[0].(string), tc.content[1:]...)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "WARN", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "WARN", msg))
 			Warnw("log", msg)
-			expected = append(expected, fmt.Sprintf("%s log=%s", "WARN", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","log":"%s"}`, "WARN", msg))
 		case LevelError:
 			Error(msg)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "ERROR", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "ERROR", msg))
 			Errorf(tc.content[0].(string), tc.content[1:]...)
-			expected = append(expected, fmt.Sprintf("%s msg=%s", "ERROR", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "ERROR", msg))
 			Errorw("log", msg)
-			expected = append(expected, fmt.Sprintf("%s log=%s", "ERROR", msg))
+			expected = append(expected, fmt.Sprintf(`{"level":"%s","log":"%s"}`, "ERROR", msg))
 		}
 	}
 	Log(LevelInfo, DefaultMessageKey, "test log")
-	expected = append(expected, fmt.Sprintf("%s msg=%s", "INFO", "test log"))
+	expected = append(expected, fmt.Sprintf(`{"level":"%s","msg":"%s"}`, "INFO", "test log"))
 
 	expected = append(expected, "")
 
@@ -103,7 +103,7 @@ func TestGlobalLogUpdate(t *testing.T) {
 	l.SetLogger(NewStdLogger(buffer))
 	LOG.Info("Log to buffer")
 
-	expected := "INFO msg=Log to buffer\n"
+	expected := `{"level":"INFO","msg":"Log to buffer"}` + "\n"
 	if buffer.String() != expected {
 		t.Errorf("Expected: %s, got: %s", expected, buffer.String())
 	}
@@ -113,7 +113,9 @@ func TestGlobalContext(t *testing.T) {
 	buffer := &bytes.Buffer{}
 	SetLogger(NewStdLogger(buffer))
 	Context(context.Background()).Infof("111")
-	if buffer.String() != "INFO msg=111\n" {
-		t.Errorf("Expected:%s, got:%s", "INFO msg=111", buffer.String())
+
+	expected := `{"level":"INFO","msg":"111"}` + "\n"
+	if buffer.String() != expected {
+		t.Errorf("Expected:%s, got:%s", expected, buffer.String())
 	}
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -9,6 +9,7 @@ func TestInfo(t *testing.T) {
 	logger := DefaultLogger
 	logger = With(logger, "ts", DefaultTimestamp)
 	logger = With(logger, "caller", DefaultCaller)
+	logger = With(logger, "caller", Caller(1))
 	_ = logger.Log(LevelInfo, "key1", "value1")
 }
 

--- a/log/std.go
+++ b/log/std.go
@@ -2,9 +2,11 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"strconv"
 	"sync"
 )
 
@@ -29,21 +31,74 @@ func NewStdLogger(w io.Writer) Logger {
 
 // Log print the kv pairs log.
 func (l *stdLogger) Log(level Level, keyvals ...interface{}) error {
-	if len(keyvals) == 0 {
-		return nil
-	}
-	if (len(keyvals) & 1) == 1 {
+	if len(keyvals)&1 == 1 {
 		keyvals = append(keyvals, "KEYVALS UNPAIRED")
 	}
-	buf := l.pool.Get().(*bytes.Buffer)
-	buf.WriteString(level.String())
+
+	kvMap := make(map[string]interface{}, len(keyvals)/2+1)
+	kvMap[level.Key()] = level.String()
 	for i := 0; i < len(keyvals); i += 2 {
-		_, _ = fmt.Fprintf(buf, " %s=%v", keyvals[i], keyvals[i+1])
+		key, val := toString(keyvals[i]), toString(keyvals[i+1])
+		kvMap[key] = val
 	}
+	b, err := json.Marshal(kvMap)
+	if err != nil {
+		return err
+	}
+
+	buf := l.pool.Get().(*bytes.Buffer)
+	_, _ = buf.Write(append(b, '\n'))
 	_ = l.log.Output(4, buf.String()) //nolint:gomnd
 	buf.Reset()
 	l.pool.Put(buf)
 	return nil
+}
+
+func toString(v interface{}) string {
+	var str string
+	if v == nil {
+		return str
+	}
+	switch v := v.(type) {
+	case float64:
+		str = strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		str = strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case int:
+		str = strconv.Itoa(v)
+	case uint:
+		str = strconv.FormatUint(uint64(v), 10)
+	case int8:
+		str = strconv.Itoa(int(v))
+	case uint8:
+		str = strconv.FormatUint(uint64(v), 10)
+	case int16:
+		str = strconv.Itoa(int(v))
+	case uint16:
+		str = strconv.FormatUint(uint64(v), 10)
+	case int32:
+		str = strconv.Itoa(int(v))
+	case uint32:
+		str = strconv.FormatUint(uint64(v), 10)
+	case int64:
+		str = strconv.FormatInt(v, 10)
+	case uint64:
+		str = strconv.FormatUint(v, 10)
+	case string:
+		str = v
+	case bool:
+		str = strconv.FormatBool(v)
+	case []byte:
+		str = string(v)
+	case error:
+		str = v.Error()
+	case fmt.Stringer:
+		str = v.String()
+	default:
+		newValue, _ := json.Marshal(v)
+		str = string(newValue)
+	}
+	return str
 }
 
 func (l *stdLogger) Close() error {

--- a/log/std_test.go
+++ b/log/std_test.go
@@ -10,6 +10,7 @@ func TestStdLogger(t *testing.T) {
 	_ = logger.Log(LevelInfo, "msg", "test info")
 	_ = logger.Log(LevelInfo, "msg", "test warn")
 	_ = logger.Log(LevelInfo, "msg", "test error")
+	_ = logger.Log(LevelInfo, "repeat", "1", "repeat", "2") // should print: "repeat":"2"
 	_ = logger.Log(LevelDebug, "singular")
 
 	logger2 := DefaultLogger


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
- [x] (De duplication of duplicate log key values)
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
resolves #2347
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
