### PR TITLE
test: supplement the unit testing of transport/grpc

### DIFF
--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -3,7 +3,7 @@ package grpc
 import (
 	"reflect"
 	"testing"
-	
+
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -3,7 +3,7 @@ package grpc
 import (
 	"reflect"
 	"testing"
-
+	
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -17,7 +17,6 @@ func TestCodec(t *testing.T) {
 	if err != nil {
 		t.Errorf("grpc codec marshal error:%v", err)
 	}
-	_ = data
 	out := &structpb.Struct{}
 	err = c.Unmarshal(data, out)
 	if err != nil {

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -1,0 +1,29 @@
+package grpc
+
+import (
+	"reflect"
+	"testing"
+	
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestCodec(t *testing.T) {
+	in, err := structpb.NewStruct(map[string]interface{}{"Golang": "Kratos"})
+	if err != nil {
+		t.Errorf("grpc codec create input data error:%v", err)
+	}
+	c := codec{}
+	data, err := c.Marshal(in)
+	if err != nil {
+		t.Errorf("grpc codec marshal error:%v", err)
+	}
+	_ = data
+	out := &structpb.Struct{}
+	err = c.Unmarshal(data, out)
+	if err != nil {
+		t.Errorf("grpc codec unmarshal error:%v", err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("grpc codec want %v, got %v", in, out)
+	}
+}


### PR DESCRIPTION
Description (what this PR does / why we need it):
supplement the unit testing of transport/grpc, increase coverage to 92.7% from 89.8%.

Which issue(s) this PR fixes (resolves / be part of):
part of https://github.com/go-kratos/kratos/issues/2354