### PR TITLE
cleanup: replace grpc resolver.Target deprecated field

### DIFF
--- a/transport/grpc/resolver/discovery/builder_test.go
+++ b/transport/grpc/resolver/discovery/builder_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -74,8 +75,10 @@ func TestBuilder_Build(t *testing.T) {
 	b := NewBuilder(&mockDiscovery{}, DisableDebugLog())
 	_, err := b.Build(
 		resolver.Target{
-			Scheme:   resolver.GetDefaultScheme(),
-			Endpoint: "gprc://authority/endpoint",
+			URL: url.URL{
+				Scheme: resolver.GetDefaultScheme(),
+				Path:   "grpc://authority/endpoint",
+			},
 		},
 		&mockConn{},
 		resolver.BuildOptions{},
@@ -87,8 +90,10 @@ func TestBuilder_Build(t *testing.T) {
 	timeoutBuilder := NewBuilder(&mockDiscovery{}, WithTimeout(0))
 	_, err = timeoutBuilder.Build(
 		resolver.Target{
-			Scheme:   resolver.GetDefaultScheme(),
-			Endpoint: "gprc://authority/endpoint",
+			URL: url.URL{
+				Scheme: resolver.GetDefaultScheme(),
+				Path:   "grpc://authority/endpoint",
+			},
 		},
 		&mockConn{},
 		resolver.BuildOptions{},


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
replace grpc resolver.Target deprecated field

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
<img width="672" alt="image" src="https://user-images.githubusercontent.com/27986239/190836893-9f0949be-c535-4534-a182-986bc6e8e85a.png">
