### PR TITLE
让通用协议支持获取请求路径

### DIFF
--- a/transport/grpc/transport.go
+++ b/transport/grpc/transport.go
@@ -42,6 +42,11 @@ func (tr *Transport) ReplyHeader() transport.Header {
 	return tr.replyHeader
 }
 
+// PathTemplate returns the grpc operation.
+func (tr *Transport) PathTemplate() string {
+	return tr.operation
+}
+
 // SelectFilters returns the client select filters.
 func (tr *Transport) SelectFilters() []selector.Filter {
 	return tr.filters

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -52,6 +52,11 @@ type Transporter interface {
 	// http: http.Header
 	// grpc: metadata.MD
 	ReplyHeader() Header
+	// PathTemplate returns the request path.
+	// only valid for server transport
+	// http: http.path
+	// grpc: grpc.operation
+	PathTemplate() string
 }
 
 // Kind defines the type of Transport


### PR DESCRIPTION
为了从transport中获取请求路径，用于记录日志。这里添加了一个接口方法。