### PR TITLE
feat(reader.go): reader支持配置的key本身含有点的情况

### DIFF
--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -90,6 +90,14 @@ a:
     X: 1
     Y: "lol"
     z: true
+    S: 
+      - S0
+      - S1
+    Sm:
+      - k1: smk1
+    m.k1: mk1
+    m.k2: 
+      v: mkv
 `
 	tests := []struct {
 		name string
@@ -99,7 +107,7 @@ a:
 			name: "json value",
 			kv: KeyValue{
 				Key:    "config",
-				Value:  []byte(`{"a": {"b": {"X": 1, "Y": "lol", "z": true}}}`),
+				Value:  []byte(`{"a":{"b":{"X":1,"Y":"lol","z":true,"S":["S0","S1"],"Sm":[{"k1":"smk1"}],"m.k1":"mk1","m.k2":{"v":"mkv"}}}}`),
 				Format: "json",
 			},
 		},
@@ -167,6 +175,82 @@ a:
 			}
 
 			_, ok = r.Value("a.b.Y.")
+			if ok {
+				t.Fatal(`ok is true`)
+			}
+
+			vv, ok = r.Value("a.b.S")
+			if !ok {
+				t.Fatal(`ok is false`)
+			}
+			vvSlice, err := vv.Slice()
+			if err != nil {
+				t.Fatal(`err is not nil`)
+			}
+			vvStrSlice := make([]string, 2)
+			for k, v := range vvSlice {
+				v, err := v.String()
+				if err != nil {
+					t.Fatal(`err is not nil`)
+				}
+				vvStrSlice[k] = v
+			}
+			if len(vvStrSlice) != 2 || vvStrSlice[0] != "S0" || vvStrSlice[1] != "S1" {
+				t.Fatal(`vvSlice is not equal to ["S0", "S1"]`)
+			}
+			vv, ok = r.Value("a.b.S.1")
+			if !ok {
+				t.Fatal(`ok is false`)
+			}
+			vvS, err := vv.String()
+			if err != nil {
+				t.Fatal(`err is not nil`)
+			}
+			if vvS != "S1" {
+				t.Fatal(`vvS is not equal to "S1"`)
+			}
+			_, ok = r.Value("a.b.S.3")
+			if ok {
+				t.Fatal(`ok is true`)
+			}
+
+			vv, ok = r.Value("a.b.m.k1")
+			if !ok {
+				t.Fatal(`ok is false`)
+			}
+			vvm, err := vv.String()
+			if err != nil {
+				t.Fatal(`err is not nil`)
+			}
+			if vvm != "mk1" {
+				t.Fatal(`vvm is not equal to "mk1"`)
+			}
+
+			vv, ok = r.Value("a.b.m.k2.v")
+			if !ok {
+				t.Fatal(`ok is false`)
+			}
+			vvmkv, err := vv.String()
+			if err != nil {
+				t.Fatal(`err is not nil`)
+			}
+			if vvmkv != "mkv" {
+				t.Fatal(`vvmkv is not equal to "mkv"`)
+			}
+
+			vv, ok = r.Value("a.b.Sm.0.k1")
+			if !ok {
+				t.Fatal(`ok is false`)
+			}
+			vvsmk, err := vv.String()
+			if err != nil {
+				t.Fatal(`err is not nil`)
+			}
+			if vvsmk != "smk1" {
+				t.Fatal(`vvsmk is not equal to "smk1"`)
+			}
+
+			_, ok = r.Value("")
 			if ok {
 				t.Fatal(`ok is true`)
 			}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
当配置文件中的key本身含有`.`分隔符时，无法正常获取配置，如：
```
users:
  james.smith:
    country: American
    age: 69
```
如上配置，目前使用`users.james.smith`还是`users.james.smith.country`都无法获取配置内容

#### Which issue(s) this PR fixes (resolves / be part of):
fixes/resolves ##2382

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
