### PR TITLE
fix(metadata): sort services by lexicographical order on ListServices

### DIFF
--- a/api/metadata/server.go
+++ b/api/metadata/server.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"sync"
 
 	"github.com/go-kratos/kratos/v2/log"
@@ -114,6 +115,8 @@ func (s *Server) ListServices(ctx context.Context, in *ListServicesRequest) (*Li
 			reply.Methods = append(reply.Methods, fmt.Sprintf("/%s/%s", name, method))
 		}
 	}
+	sort.Strings(reply.Services)
+	sort.Strings(reply.Methods)
 	return reply, nil
 }
 


### PR DESCRIPTION
It's out of order on the reply of ListServices, which is so complex for human reading.

![image](https://user-images.githubusercontent.com/3887050/191670162-64925425-ebb4-4de8-9519-4d4025ea20a6.png)
