### PR TITLE
feat(middleware/circuitbreaker): add  WithCircuitBreaker option API

### DIFF
--- a/middleware/circuitbreaker/circuitbreaker.go
+++ b/middleware/circuitbreaker/circuitbreaker.go
@@ -26,6 +26,16 @@ func WithGroup(g *group.Group) Option {
 	}
 }
 
+// WithCircuitBreaker with a circuit breaker.
+func WithCircuitBreaker(breaker circuitbreaker.CircuitBreaker) Option {
+	g := group.NewGroup(func() interface{} {
+		return breaker
+	})
+	return func(o *options) {
+		o.group = g
+	}
+}
+
 type options struct {
 	group *group.Group
 }

--- a/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/middleware/circuitbreaker/circuitbreaker_test.go
@@ -57,6 +57,20 @@ func Test_WithGroup(t *testing.T) {
 	}
 }
 
+func  Test_WithCircuitBreaker(t *testing.T)  {
+	o := options{
+		group: group.NewGroup(func() interface{} {
+			return ""
+		}),
+	}
+
+	WithCircuitBreaker(new(circuitBreakerMock))(&o)
+	_, ok := o.group.Get("pass").(*circuitBreakerMock)
+	if !ok {
+		t.Error("The circuit breaker didn't set rightly.")
+	}
+}
+
 func Test_Server(t *testing.T) {
 	nextValid := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return "Hello valid", nil

--- a/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/middleware/circuitbreaker/circuitbreaker_test.go
@@ -57,7 +57,7 @@ func Test_WithGroup(t *testing.T) {
 	}
 }
 
-func  Test_WithCircuitBreaker(t *testing.T)  {
+func Test_WithCircuitBreaker(t *testing.T) {
 	o := options{
 		group: group.NewGroup(func() interface{} {
 			return ""


### PR DESCRIPTION
Add  `WithCircuitBreaker` option API to support custom circuit breaker.

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

For now, group.Group is internal package, but `middleware/circuitbreaker` provide an Option:

```go
// WithGroup with circuit breaker group.
// NOTE: implements generics circuitbreaker.CircuitBreaker
func WithGroup(g *group.Group) Option {
	return func(o *options) {
		o.group = g
	}
}
```

For developers, we could not provide `gourp.Group` instance, so add a new option API:

```go
// WithCircuitBreaker with a circuit breaker.
func WithCircuitBreaker(breaker circuitbreaker.CircuitBreaker) Option {
	g := group.NewGroup(func() interface{} {
		return breaker
	})
	return func(o *options) {
		o.group = g
	}
}
```

so that, we have ability to register a custom CircuitBreaker

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
resolves  #2369

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
