### PR TITLE
feat(transport/grpc): custom healthchecks

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -42,7 +42,7 @@ func (r *mockRegistry) Deregister(ctx context.Context, service *registry.Service
 
 func TestApp(t *testing.T) {
 	hs := http.NewServer()
-	gs := grpc.NewServer()
+	gs := grpc.NewServer(nil)
 	app := New(
 		Name("kratos"),
 		Version("v1.0.0"),

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -72,6 +72,7 @@ func TestServer(t *testing.T) {
 	ctx := context.Background()
 	ctx = context.WithValue(ctx, testKey{}, "test")
 	srv := NewServer(
+		nil,
 		Middleware(
 			func(handler middleware.Handler) middleware.Handler {
 				return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
@@ -178,7 +179,7 @@ func TestNetwork(t *testing.T) {
 
 func TestAddress(t *testing.T) {
 	v := "abc"
-	o := NewServer(Address(v))
+	o := NewServer(nil, Address(v))
 	if !reflect.DeepEqual(v, o.address) {
 		t.Errorf("expect %s, got %s", v, o.address)
 	}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
Currently, it is not possible to define custom health checks. This PR should solve that.
If the server is not defined, the default server is used.


#### Which issue(s) this PR fixes (resolves / be part of):
resolves #1397 
