### PR TITLE
fix(registry): add zookeeper exists watcher when the node does not exist

### DIFF
--- a/contrib/registry/zookeeper/watcher.go
+++ b/contrib/registry/zookeeper/watcher.go
@@ -40,13 +40,21 @@ func (w *watcher) watch(ctx context.Context) {
 		// 每次 watch 只有一次有效期 所以循环 watch
 		_, _, ch, err := w.conn.ChildrenW(w.prefix)
 		if err != nil {
-			w.event <- zk.Event{Err: err}
+			// If the target service has not been registered
+			if errors.Is(err, zk.ErrNoNode) {
+				// Add watcher for the node exists
+				_, _, ch, err = w.conn.ExistsW(w.prefix)
+			}
+			if err != nil {
+				w.event <- zk.Event{Err: err}
+				return
+			}
 		}
 		select {
 		case <-ctx.Done():
 			return
-		default:
-			w.event <- <-ch
+		case ev := <-ch:
+			w.event <- ev
 		}
 	}
 }

--- a/contrib/registry/zookeeper/watcher.go
+++ b/contrib/registry/zookeeper/watcher.go
@@ -40,7 +40,7 @@ func (w *watcher) watch(ctx context.Context) {
 		// 每次 watch 只有一次有效期 所以循环 watch
 		_, _, ch, err := w.conn.ChildrenW(w.prefix)
 		if err != nil {
-			// If the target service has not been registered
+			// If the target service node has not been created
 			if errors.Is(err, zk.ErrNoNode) {
 				// Add watcher for the node exists
 				_, _, ch, err = w.conn.ExistsW(w.prefix)


### PR DESCRIPTION


#### Description (what this PR does / why we need it):
解决以下问题：
* 使用zookeeper做服务发现时，如果目标服务的节点未创建，导致watcher停止的问题。


#### Which issue(s) this PR fixes (resolves / be part of):


#### Other special notes for the reviewers:

* 当服务A依赖服务B，在第一次运行时，如果服务A先于B之前启动
* 以下截图部分代码会导致服务A当前的watcher停止（ErrWatcherStopped），服务A必须重启之后才能获得服务B的实例。
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/13197092/204847916-da0c9016-48bd-4a83-b0bf-35da0d4fa046.png">
<img width="822" alt="image" src="https://user-images.githubusercontent.com/13197092/204847977-97d08ae9-b5c8-43d0-8ad0-7292ab2fd5b3.png">

