### PR TITLE
feat(middleware): redacter interface for logging

### DIFF
--- a/middleware/logging/logging.go
+++ b/middleware/logging/logging.go
@@ -11,6 +11,11 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 )
 
+// Redacter defines how to log an object
+type Redacter interface {
+	Redact() string
+}
+
 // Server is an server logging middleware.
 func Server(logger log.Logger) middleware.Middleware {
 	return func(handler middleware.Handler) middleware.Handler {
@@ -85,6 +90,9 @@ func Client(logger log.Logger) middleware.Middleware {
 
 // extractArgs returns the string of the req
 func extractArgs(req interface{}) string {
+	if redacter, ok := req.(Redacter); ok {
+		return redacter.Redact()
+	}
 	if stringer, ok := req.(fmt.Stringer); ok {
 		return stringer.String()
 	}

--- a/middleware/logging/logging_test.go
+++ b/middleware/logging/logging_test.go
@@ -105,19 +105,49 @@ type (
 	dummyStringer struct {
 		field string
 	}
+	dummyStringerRedacter struct {
+		field string
+	}
 )
 
 func (d *dummyStringer) String() string {
 	return "my value"
 }
 
-func TestExtractArgs(t *testing.T) {
-	if extractArgs(&dummyStringer{field: ""}) != "my value" {
-		t.Errorf(`The stringified dummyStringer structure must be equal to "my value", %v given`, extractArgs(&dummyStringer{field: ""}))
-	}
+func (d *dummyStringerRedacter) String() string {
+	return "my value"
+}
 
-	if extractArgs(&dummy{field: "value"}) != "&{field:value}" {
-		t.Errorf(`The stringified dummy structure must be equal to "&{field:value}", %v given`, extractArgs(&dummy{field: "value"}))
+func (d *dummyStringerRedacter) Redact() string {
+	return "my value redacted"
+}
+
+func TestExtractArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      interface{}
+		expected string
+	}{
+		{
+			name:     "dummyStringer",
+			req:      &dummyStringer{field: ""},
+			expected: "my value",
+		}, {
+			name:     "dummy",
+			req:      &dummy{field: "value"},
+			expected: "&{field:value}",
+		}, {
+			name:     "dummyStringerRedacter",
+			req:      &dummyStringerRedacter{field: ""},
+			expected: "my value redacted",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if value := extractArgs(test.req); value != test.expected {
+				t.Errorf(`The stringified %s structure must be equal to "%s", %v given`, test.name, test.expected, value)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

The **logging middleware** is logging sensitive data from requests, one strategy to fix it is by implementing the `fmt.Stringer` interface, but when we use the gRPC generators the `String` method is already implemented and there is no other alternative to filter sensitive data from the request object.

this PR adds a `Redacter` interface wich in case of being implemented for the request object will have more priority than the `fmt.Stringer`, giving the option to provide a string version of the request only for loging without affecting the auto-generated code.


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
