### PR TITLE
feat(middleware): redacter interface for logging

### DIFF
--- a/middleware/logging/logging.go
+++ b/middleware/logging/logging.go
@@ -11,6 +11,11 @@ import (
 	"github.com/go-kratos/kratos/v2/transport"
 )
 
+// Redacter defines how to log an object
+type Redacter interface {
+	Redact() string
+}
+
 // Server is an server logging middleware.
 func Server(logger log.Logger) middleware.Middleware {
 	return func(handler middleware.Handler) middleware.Handler {
@@ -85,6 +90,9 @@ func Client(logger log.Logger) middleware.Middleware {
 
 // extractArgs returns the string of the req
 func extractArgs(req interface{}) string {
+	if redacter, ok := req.(Redacter); ok {
+		return redacter.Redact()
+	}
 	if stringer, ok := req.(fmt.Stringer); ok {
 		return stringer.String()
 	}

--- a/middleware/logging/logging_test.go
+++ b/middleware/logging/logging_test.go
@@ -105,19 +105,49 @@ type (
 	dummyStringer struct {
 		field string
 	}
+	dummyStringerRedacter struct {
+		field string
+	}
 )
 
 func (d *dummyStringer) String() string {
 	return "my value"
 }
 
-func TestExtractArgs(t *testing.T) {
-	if extractArgs(&dummyStringer{field: ""}) != "my value" {
-		t.Errorf(`The stringified dummyStringer structure must be equal to "my value", %v given`, extractArgs(&dummyStringer{field: ""}))
-	}
+func (d *dummyStringerRedacter) String() string {
+	return "my value"
+}
 
-	if extractArgs(&dummy{field: "value"}) != "&{field:value}" {
-		t.Errorf(`The stringified dummy structure must be equal to "&{field:value}", %v given`, extractArgs(&dummy{field: "value"}))
+func (d *dummyStringerRedacter) Redact() string {
+	return "my value redacted"
+}
+
+func TestExtractArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      interface{}
+		expected string
+	}{
+		{
+			name:     "dummyStringer",
+			req:      &dummyStringer{field: ""},
+			expected: "my value",
+		}, {
+			name:     "dummy",
+			req:      &dummy{field: "value"},
+			expected: "&{field:value}",
+		}, {
+			name:     "dummyStringerRedacter",
+			req:      &dummyStringerRedacter{field: ""},
+			expected: "my value redacted",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if value := extractArgs(test.req); value != test.expected {
+				t.Errorf(`The stringified %s structure must be equal to "%s", %v given`, test.name, test.expected, value)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The **logging middleware** is logging sensitive data from requests, one strategy to fix it is by implementing the `fmt.Stringer` interface, but when we use the gRPC generators the `String` method is already implemented and there is no other alternative to filter sensitive data from the request object.

this PR adds a `Redacter` interface wich in case of being implemented for the request object will have more priority than the `fmt.Stringer`, giving the option to provide a string version of the request only for loging without affecting the auto-generated code.