### PR TITLE
feat: consul监听service变更，而不是定时同步

### DIFF
--- a/contrib/registry/consul/registry.go
+++ b/contrib/registry/consul/registry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/consul/api"
@@ -166,41 +165,7 @@ func (r *Registry) ListServices() (allServices map[string][]*registry.ServiceIns
 
 // Watch resolve service by name
 func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, error) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	set, ok := r.registry[name]
-	if !ok {
-		set = &serviceSet{
-			watcher:     make(map[*watcher]struct{}),
-			services:    &atomic.Value{},
-			serviceName: name,
-		}
-		r.registry[name] = set
-	}
-
-	// 初始化watcher
-	w := &watcher{
-		event: make(chan struct{}, 1),
-	}
-	w.ctx, w.cancel = context.WithCancel(context.Background())
-	w.set = set
-	set.lock.Lock()
-	set.watcher[w] = struct{}{}
-	set.lock.Unlock()
-	ss, _ := set.services.Load().([]*registry.ServiceInstance)
-	if len(ss) > 0 {
-		// If the service has a value, it needs to be pushed to the watcher,
-		// otherwise the initial data may be blocked forever during the watch.
-		w.event <- struct{}{}
-	}
-
-	if !ok {
-		err := r.resolve(set)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return w, nil
+	return newWatcher(ctx, name, r)
 }
 
 func (r *Registry) resolve(ss *serviceSet) error {

--- a/contrib/registry/consul/service.go
+++ b/contrib/registry/consul/service.go
@@ -20,7 +20,7 @@ func (s *serviceSet) broadcast(ss []*registry.ServiceInstance) {
 	defer s.lock.RUnlock()
 	for k := range s.watcher {
 		select {
-		case k.event <- struct{}{}:
+		case k.ch <- s.serviceName:
 		default:
 		}
 	}

--- a/contrib/registry/consul/watcher.go
+++ b/contrib/registry/consul/watcher.go
@@ -4,36 +4,83 @@ import (
 	"context"
 
 	"github.com/go-kratos/kratos/v2/registry"
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/consul/api/watch"
 )
 
 type watcher struct {
-	event chan struct{}
-	set   *serviceSet
+	r  *Registry
+	ch chan string
+	wp *watch.Plan
 
 	// for cancel
 	ctx    context.Context
 	cancel context.CancelFunc
 }
 
+func newWatcher(ctx context.Context, serviceName string, r *Registry) (*watcher, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	w := &watcher{
+		r:  r,
+		ch: make(chan string),
+
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	wp, err := watch.Parse(map[string]interface{}{
+		"type":    "service",
+		"service": serviceName,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	wp.Handler = w.handle
+	w.wp = wp
+
+	// wp.Run is a blocking call and will prevent newWatcher from returning
+	go func() {
+		err := wp.RunWithClientAndHclog(r.cli.cli, nil)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	return w, nil
+}
+
+func (w *watcher) handle(idx uint64, data interface{}) {
+	if data == nil {
+		return
+	}
+
+	m := make(map[string]struct{})
+	switch d := data.(type) {
+	case []*api.ServiceEntry:
+		for _, i := range d {
+			if i.Checks.AggregatedStatus() == api.HealthPassing {
+				m[i.Service.Service] = struct{}{}
+			}
+		}
+	}
+
+	for name := range m {
+		w.ch <- name
+	}
+}
+
 func (w *watcher) Next() (services []*registry.ServiceInstance, err error) {
 	select {
+	case name := <-w.ch:
+		return w.r.GetService(context.Background(), name)
 	case <-w.ctx.Done():
-		err = w.ctx.Err()
-	case <-w.event:
+		return nil, w.ctx.Err()
 	}
-
-	ss, ok := w.set.services.Load().([]*registry.ServiceInstance)
-
-	if ok {
-		services = append(services, ss...)
-	}
-	return
 }
 
 func (w *watcher) Stop() error {
+	w.wp.Stop()
 	w.cancel()
-	w.set.lock.Lock()
-	defer w.set.lock.Unlock()
-	delete(w.set.watcher, w)
 	return nil
 }


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

使用consul作为注册中心时，`Watch` 是定时同步的方式，现在改为监听的方式，与其它配置中心插件的实现相同，可以减少consul压力。

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
