### PR TITLE
feat(cmd): add KRATOS_HOME environment

### DIFF
--- a/cmd/kratos/internal/base/path.go
+++ b/cmd/kratos/internal/base/path.go
@@ -27,7 +27,13 @@ func kratosHome() string {
 }
 
 func kratosHomeWithDir(dir string) string {
-	home := path.Join(kratosHome(), dir)
+	var home string
+	kHome := os.Getenv("KRATOS_HOME")
+	if kHome == "" {
+		home = path.Join(kratosHome(), dir)
+	} else {
+		home = path.Join(kHome, dir)
+	}
 	if _, err := os.Stat(home); os.IsNotExist(err) {
 		if err := os.MkdirAll(home, 0o700); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

- 解决问题:  支持通过环境变量KRATOS_HOME变更kratos默认目录。
- 原       因:  在某些特殊情况下(零信任环境)，kratos new project时，kratos home默认在~/.kratos出现权限或者其它问题，需要支持自定义kratos home。

#### Which issue(s) this PR fixes (resolves / be part of):

#### Other special notes for the reviewers:
