### PR TITLE
Make bootstrap supports logging context infomations.

### DIFF
--- a/transport/grpc/server.go
+++ b/transport/grpc/server.go
@@ -184,7 +184,7 @@ func (s *Server) Start(ctx context.Context) error {
 		return s.err
 	}
 	s.baseCtx = ctx
-	s.log.Infof("[gRPC] server listening on: %s", s.lis.Addr().String())
+	s.log.Context(ctx).Infof("[gRPC] server listening on: %s", s.lis.Addr().String())
 	s.health.Resume()
 	return s.Serve(s.lis)
 }
@@ -193,7 +193,7 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) Stop(ctx context.Context) error {
 	s.health.Shutdown()
 	s.GracefulStop()
-	s.log.Info("[gRPC] server stopping")
+	s.log.Context(ctx).Info("[gRPC] server stopping")
 	return nil
 }
 

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -239,7 +239,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.BaseContext = func(net.Listener) context.Context {
 		return ctx
 	}
-	s.log.Infof("[HTTP] server listening on: %s", s.lis.Addr().String())
+	s.log.Context(ctx).Infof("[HTTP] server listening on: %s", s.lis.Addr().String())
 	var err error
 	if s.tlsConf != nil {
 		err = s.ServeTLS(s.lis, "", "")
@@ -254,7 +254,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 // Stop stop the HTTP server.
 func (s *Server) Stop(ctx context.Context) error {
-	s.log.Info("[HTTP] server stopping")
+	s.log.Context(ctx).Info("[HTTP] server stopping")
 	return s.Shutdown(ctx)
 }
 


### PR DESCRIPTION
Make bootstrap(http/grpc server) supports logging context infomations.