### PR TITLE
feat[middleware]: grpc server中间件 单飞

### DIFF
--- a/middleware/singleflight/singleflight.go
+++ b/middleware/singleflight/singleflight.go
@@ -1,0 +1,46 @@
+package singleflight
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-kratos/kratos/v2/transport"
+
+	"github.com/go-kratos/kratos/v2/middleware"
+	"golang.org/x/sync/singleflight"
+)
+
+var singleflightGroup singleflight.Group
+
+// 单飞 middleware.
+/*
+	//只在grpc服务端下使用，通过传入op名称，使用单飞：
+	singleflight.SingleFlight(
+			"/service.test1/GetCityName",
+			"/service.test2/GetAllCityName",
+			)
+*/
+func SingleFlight(ops... string) middleware.Middleware {
+	return func(handler middleware.Handler) middleware.Handler {
+		return func(ctx context.Context, req interface{}) (reply interface{}, err error) {
+			if tr, ok := transport.FromServerContext(ctx); ok {
+				if Contains(ops,tr.Operation()){
+					cacheKey:=fmt.Sprintf("%s %s",tr.Operation(),req)
+					reply, err, _ = singleflightGroup.Do(cacheKey, func() (interface{}, error) {
+						return handler(ctx, req)
+					})
+					return reply,err
+				}
+			}
+			return handler(ctx, req)
+		}
+	}
+}
+
+func Contains(elems []string, elem string) bool {
+	for _, e := range elems {
+		if elem == e {
+			return true
+		}
+	}
+	return false
+}

--- a/middleware/singleflight/singleflight_test.go
+++ b/middleware/singleflight/singleflight_test.go
@@ -1,0 +1,132 @@
+package singleflight
+
+import (
+	"context"
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/go-kratos/kratos/v2/transport/grpc"
+	"sync"
+	"testing"
+	"time"
+	"xiaozhu/pkg/convert"
+
+	"github.com/go-kratos/kratos/v2/middleware"
+)
+
+type testVali struct {
+	in  string
+	out int
+}
+
+type Transport2 struct {
+	grpc.Transport
+	op string
+}
+
+func (t Transport2) Operation()string{
+	return t.op
+}
+
+//测试使用单飞时
+func TestUse(t *testing.T) {
+	var mu    sync.Mutex
+	var callNum int
+
+	var mock middleware.Handler = func(ctx context.Context, req interface{}) (interface{}, error) {
+		in := req.(testVali)
+		mu.Lock()
+		callNum++
+		mu.Unlock()
+		time.Sleep(1*time.Second)
+		return in.out, nil
+	}
+
+	tests := []testVali{
+		{"1",1},
+		{"2",2},
+		{"2",2},
+		{"3",3},
+		{"3",3},
+		{"3",3},
+	}
+	var wg sync.WaitGroup
+	for _, test := range tests {
+		wg.Add(1)
+		go func(te testVali) {
+			t.Run(te.in, func(t *testing.T) {
+				v := SingleFlight("test")(mock)//注册
+				tr := &Transport2{op:"test"}
+				ctx:=transport.NewServerContext(context.Background(),tr)
+				re, err := v(ctx, te)
+				if err!=nil{
+					t.Error(err)
+				}
+				if re!=te.out{
+					t.Errorf("err: %v",te)
+				}
+				wg.Done()
+			})
+		}(test)
+	}
+
+	wg.Wait()
+
+	//最后计算总调用次数
+	t.Run("callNum", func(t *testing.T) {
+		if callNum!=3{
+			t.Errorf("callNum err: %v",callNum)
+		}
+	})
+}
+
+
+//测试不使用单飞时
+func TestNoUse(t *testing.T) {
+	var mu    sync.Mutex
+	var callNum int
+
+	var mock middleware.Handler = func(ctx context.Context, req interface{}) (interface{}, error) {
+		in := req.(testVali)
+		mu.Lock()
+		callNum++
+		mu.Unlock()
+		time.Sleep(1*time.Second)
+		return convert.ToInt(in.in), nil
+	}
+
+	tests := []testVali{
+		{"1",1},
+		{"2",2},
+		{"2",2},
+		{"3",3},
+		{"3",3},
+		{"3",3},
+	}
+	var wg sync.WaitGroup
+	for _, test := range tests {
+		wg.Add(1)
+		go func(te testVali) {
+			t.Run(te.in, func(t *testing.T) {
+				v := SingleFlight()(mock)//移除注册
+				tr := &Transport2{op:"test"}
+				ctx:=transport.NewServerContext(context.Background(),tr)
+				re, err := v(ctx, te)
+				if err!=nil{
+					t.Error(err)
+				}
+				if re!=te.out{
+					t.Errorf("err: %v",te)
+				}
+				wg.Done()
+			})
+		}(test)
+	}
+
+	wg.Wait()
+
+	//最后计算总调用次数
+	t.Run("callNum", func(t *testing.T) {
+		if callNum!=6{
+			t.Errorf("callNum err: %v",callNum)
+		}
+	})
+}


### PR DESCRIPTION
基于singleflight库，这个库的主要作用就是将一组相同的请求合并成一个请求，实际上只会去请求一次，然后对所有的请求返回相同的结果。

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR 请求！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果请购单未完成，您可能需要将其标记为 WIP（在制品）PR 或 draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->

<!--
-->

#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
