### PR TITLE
feat: 通过context传递logger

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -64,3 +64,27 @@ func WithContext(ctx context.Context, l Logger) Logger {
 		ctx:       ctx,
 	}
 }
+
+type loggerKey struct{}
+
+// NewContext returns a new Context that carries logger.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return context.WithValue(ctx, loggerKey{}, logger)
+}
+
+// FromContext returns the logger value stored in ctx, if not exist, return global logger.
+func FromContext(ctx context.Context) Logger {
+	if ctx == nil {
+		return global
+	}
+
+	if logger, ok := ctx.Value(loggerKey{}).(Logger); ok {
+		return logger
+	}
+
+	return global
+}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

将 Logger 存储在 Context中，可以很方便的传递日志的上下文内容，而且大多数函数的第一个参数都是 Context。

