### PR TITLE
feat(cmd/protoc-gen-go-http): add comment to http server interface method

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -198,12 +198,17 @@ func buildMethodDesc(g *protogen.GeneratedFile, m *protogen.Method, method, path
 			}
 		}
 	}
+	comment := m.Comments.Leading.String() + m.Comments.Trailing.String()
+	if comment != "" {
+		comment = "// " + m.GoName + strings.TrimPrefix(strings.TrimSuffix(comment, "\n"), "//")
+	}
 	return &methodDesc{
 		Name:         m.GoName,
 		OriginalName: string(m.Desc.Name()),
 		Num:          methodSets[m.GoName],
 		Request:      g.QualifiedGoIdent(m.Input.GoIdent),
 		Reply:        g.QualifiedGoIdent(m.Output.GoIdent),
+		Comment:      comment,
 		Path:         path,
 		Method:       method,
 		HasVars:      len(vars) > 0,

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -16,6 +16,9 @@ const Operation{{$svrType}}{{.OriginalName}} = "/{{$svrName}}/{{.OriginalName}}"
 
 type {{.ServiceType}}HTTPServer interface {
 {{- range .MethodSets}}
+	{{- if ne .Comment ""}}
+	{{.Comment}}
+	{{- end}}
 	{{.Name}}(context.Context, *{{.Request}}) (*{{.Reply}}, error)
 {{- end}}
 }
@@ -114,6 +117,7 @@ type methodDesc struct {
 	Num          int
 	Request      string
 	Reply        string
+	Comment      string
 	// http_rule
 	Path         string
 	Method       string


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
  add comment to http server interface, we can find the method use. 

#### Which issue(s) this PR fixes (resolves / be part of):
easy to find what is the http server method use.

#### Other special notes for the reviewers:
nothing
