### PR TITLE
chore: remove the dependency of grpc_testing module

### DIFF
--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -9,7 +9,6 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/test/grpc_testing"
 )
 
 type TestError struct{ message string }
@@ -56,7 +55,7 @@ func TestErrors(t *testing.T) {
 		t.Errorf("got %+v want %+v", se, err)
 	}
 
-	gs2, _ := status.New(codes.InvalidArgument, "bad request").WithDetails(&grpc_testing.Empty{})
+	gs2 := status.New(codes.InvalidArgument, "bad request")
 	se2 := FromError(gs2.Err())
 	// codes.InvalidArgument should convert to http.StatusBadRequest
 	if se2.Code != http.StatusBadRequest {


### PR DESCRIPTION
google.golang.org/grpc v1.55.0 已经移除了grpc_tesing模块，errors单元测试看起来也没有必要依赖这个包，因此移除依赖 
