### PR TITLE
feat(cmd): Support proto incremental generation to implement the code…

### DIFF
--- a/cmd/kratos/internal/proto/server/template.go
+++ b/cmd/kratos/internal/proto/server/template.go
@@ -8,6 +8,7 @@ import (
 //nolint:lll
 var serviceTemplate = `
 {{- /* delete empty line */ -}}
+{{- if eq .ExistFile false }}
 package service
 
 import (
@@ -31,6 +32,8 @@ type {{ .Service }}Service struct {
 func New{{ .Service }}Service() *{{ .Service }}Service {
 	return &{{ .Service }}Service{}
 }
+
+{{- end }}
 
 {{- $s1 := "google.protobuf.Empty" }}
 {{ range .Methods }}
@@ -103,6 +106,7 @@ type Service struct {
 
 	UseIO      bool
 	UseContext bool
+	ExistFile  bool
 }
 
 // Method is a proto method.


### PR DESCRIPTION
 
## Example
1. Generate a greeter.go file in "./internal/service".
  `kratos proto server api/helloworld/v1/greeter.proto -t ./internal/service `
2. Add some rpc interface to proto.
  ` rpc Layout (HelloRequest) returns (HelloReply) { ... }`
3. Repeat the first command.
  `kratos proto server api/helloworld/v1/greeter.proto -t ./internal/service `
4. You can see the new interface code in the original greeter.go.
  
## Feature
* It mainly solves the problem of adding interfaces to proto and appending them to the generated service code.

I've used `make lint` and `make test` before filing my PR.
