### PR TITLE
fix logging middle don't get trace_id value when logger is filterLogger

### DIFF
--- a/log/filter.go
+++ b/log/filter.go
@@ -1,5 +1,7 @@
 package log
 
+import "context"
+
 // FilterOption is filter option.
 type FilterOption func(*Filter)
 
@@ -39,6 +41,7 @@ func FilterFunc(f func(level Level, keyvals ...interface{}) bool) FilterOption {
 
 // Filter is a logger filter.
 type Filter struct {
+	ctx    context.Context
 	logger Logger
 	level  Level
 	key    map[interface{}]struct{}
@@ -67,6 +70,9 @@ func (f *Filter) Log(level Level, keyvals ...interface{}) error {
 	// prefixkv contains the slice of arguments defined as prefixes during the log initialization
 	var prefixkv []interface{}
 	l, ok := f.logger.(*logger)
+	if ok {
+		l.ctx = f.ctx
+	}
 	if ok && len(l.prefix) > 0 {
 		prefixkv = make([]interface{}, 0, len(l.prefix))
 		prefixkv = append(prefixkv, l.prefix...)

--- a/log/filter_test.go
+++ b/log/filter_test.go
@@ -144,8 +144,8 @@ func testFilterFuncWithLoggerPrefix(level Level, keyvals ...interface{}) bool {
 }
 
 func TestFilterWithContext(t *testing.T) {
-	var ctxKey = struct{}{}
-	var ctxValue = "filter test value"
+	ctxKey := struct{}{}
+	ctxValue := "filter test value"
 
 	v1 := func() Valuer {
 		return func(ctx context.Context) interface{} {
@@ -153,7 +153,7 @@ func TestFilterWithContext(t *testing.T) {
 		}
 	}
 
-	var info =&bytes.Buffer{}
+	info := &bytes.Buffer{}
 
 	logger := With(NewStdLogger(info), "request_id", v1())
 	filter := NewFilter(logger, FilterLevel(LevelError))
@@ -171,5 +171,4 @@ func TestFilterWithContext(t *testing.T) {
 	if !strings.Contains(info.String(), ctxValue) {
 		t.Error("don't read ctx value")
 	}
-
 }

--- a/log/log.go
+++ b/log/log.go
@@ -51,13 +51,27 @@ func With(l Logger, kv ...interface{}) Logger {
 // to ctx. The provided ctx must be non-nil.
 func WithContext(ctx context.Context, l Logger) Logger {
 	c, ok := l.(*logger)
-	if !ok {
-		return &logger{logger: l, ctx: ctx}
+	if ok {
+		return &logger{
+			logger:    c.logger,
+			prefix:    c.prefix,
+			hasValuer: c.hasValuer,
+			ctx:       ctx,
+		}
 	}
-	return &logger{
-		logger:    c.logger,
-		prefix:    c.prefix,
-		hasValuer: c.hasValuer,
-		ctx:       ctx,
+
+	f, ok := l.(*Filter)
+	if ok {
+		f.ctx = ctx
+		return &Filter{
+			ctx:    ctx,
+			logger: f.logger,
+			level:  f.level,
+			key:    f.key,
+			value:  f.value,
+			filter: f.filter,
+		}
 	}
+
+	return &logger{logger: l, ctx: ctx}
 }

--- a/middleware/tracing/tracing_test.go
+++ b/middleware/tracing/tracing_test.go
@@ -1,12 +1,10 @@
 package tracing
 
 import (
-	"bytes"
 	"context"
 	"net/http"
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel/propagation"
@@ -178,71 +176,6 @@ func TestServer(t *testing.T) {
 	if childTraceID != "" {
 		t.Errorf("expected empty, got %v", childTraceID)
 	}
-}
-
-func TestServerWithFilter(t *testing.T) {
-	tr := &mockTransport{
-		kind:      transport.KindHTTP,
-		endpoint:  "server:2233",
-		operation: "/test.server/hello",
-		header:    headerCarrier{},
-	}
-
-	tracer := NewTracer(
-		trace.SpanKindClient,
-		WithTracerProvider(tracesdk.NewTracerProvider()),
-	)
-
-	var b = &bytes.Buffer{}
-
-	logger := log.NewStdLogger(b)
-	logger = log.With(logger, "span_id", SpanID())
-	logger = log.With(logger, "trace_id", TraceID())
-
-	var (
-		childSpanID  string
-		childTraceID string
-	)
-	next := func(ctx context.Context, req interface{}) (interface{}, error) {
-		_ = log.WithContext(ctx, logger).Log(log.LevelInfo,
-			"kind", "server",
-		)
-
-		childSpanID = SpanID()(ctx).(string)
-		childTraceID = TraceID()(ctx).(string)
-		return req.(string) + "https://go-kratos.dev", nil
-	}
-
-	var ctx context.Context
-	ctx, span := tracer.Start(
-		transport.NewServerContext(context.Background(), tr),
-		tr.Operation(),
-		tr.RequestHeader(),
-	)
-
-	_, err := Server(
-		WithTracerProvider(tracesdk.NewTracerProvider()),
-		WithPropagator(propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})),
-	)(next)(ctx, "test server: ")
-
-	span.End()
-	if err != nil {
-		t.Errorf("expected nil, got %v", err)
-	}
-	if childSpanID == "" {
-		t.Errorf("expected empty, got %v", childSpanID)
-	}
-	if reflect.DeepEqual(span.SpanContext().SpanID().String(), childSpanID) {
-		t.Errorf("span.SpanContext().SpanID().String()(%v)  is not equal to childSpanID(%v)", span.SpanContext().SpanID().String(), childSpanID)
-	}
-	if !reflect.DeepEqual(span.SpanContext().TraceID().String(), childTraceID) {
-		t.Errorf("expected %v, got %v", childTraceID, span.SpanContext().TraceID().String())
-	}
-
-	if strings.Contains(b.String(), childSpanID) {
-		t.Errorf("filter is don't working")
-	}
-
 }
 
 func TestClient(t *testing.T) {


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
fix logging middle don't get trace_id value when logger is filterLogger


#### Which issue(s) this PR fixes (resolves / be part of):
#2570 
#2571 
