### PR TITLE
fix:go-http plugin path encoding error #2873

### DIFF
--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -240,7 +240,7 @@ func buildPathVars(path string) (res map[string]*string) {
 }
 
 func replacePath(name string, value string, path string) string {
-	pattern := regexp.MustCompile(fmt.Sprintf(`(?i){([\s]*%s[\s]*)=?([^{}]*)}`, name))
+	pattern := regexp.MustCompile(fmt.Sprintf(`(?i){([\s]*%s\b[\s]*)=?([^{}]*)}`, name))
 	idx := pattern.FindStringIndex(path)
 	if len(idx) > 0 {
 		path = fmt.Sprintf("%s{%s:%s}%s",

--- a/cmd/protoc-gen-go-http/http_test.go
+++ b/cmd/protoc-gen-go-http/http_test.go
@@ -85,3 +85,16 @@ func TestIterationMiddle(t *testing.T) {
 		t.Fatal(`replacePath("message.name", "messages/*", path) should be "/test/{message.name:messages/.*}/books"`)
 	}
 }
+func TestReplaceBoundary(t *testing.T) {
+
+	path := "/test/{message.namespace=*}/name/{message.name=*}"
+	vars := buildPathVars(path)
+	for v, s := range vars {
+		if s != nil {
+			path = replacePath(v, *s, path)
+		}
+	}
+	if !reflect.DeepEqual("/test/{message.namespace:.*}/name/{message.name:.*}", path) {
+		t.Fatal(`"/test/{message.namespace=*}/name/{message.name=*}" should be "/test/{message.namespace:.*}/name/{message.name:.*}"`)
+	}
+}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
fix(kratos/cmd/protoc-gen-go-http/http.go:243) go-http plugin path encoding error #2873
```
syntax = "proto3";

package core.v1alpha1;

import "google/protobuf/empty.proto";
import "google/api/annotations.proto";

service BookService{
    rpc Correct(CorrectRequest) returns (google.protobuf.Empty) {
        option (google.api.http) = {
            post: "/api/correct/{meta.namespace=*}/name/{book.name=*}"
            body: "*"
        };
    }
    rpc Incorrect(IncorrectRequest) returns (google.protobuf.Empty) {
        option (google.api.http) = {
            post: "/api/incorrect/{meta.namespace=*}/name/{meta.name=*}"
            body: "*"
        };
    }
}

message Meta {
    string namespace = 1;
    string name = 2;
}

message Book {
    string name = 1;
}

message CorrectRequest {
    Meta meta = 1;
    Book book = 2;
}

message IncorrectRequest {
    Meta meta = 1;
}
```
```
func RegisterBookServiceHTTPServer(s *http.Server, srv BookServiceHTTPServer) {
	r := s.Route("/")
	r.POST("/api/correct/{meta.namespace:.*}/name/{book.name:.*}", _BookService_Correct0_HTTP_Handler(srv))
	r.POST("/api/incorrect/{meta.name:.*}/name/{meta.name=*}", _BookService_Incorrect0_HTTP_Handler(srv))
}
```
**What you expected to happen:**
```
func RegisterBookServiceHTTPServer(s *http.Server, srv BookServiceHTTPServer) {
	r := s.Route("/")
	r.POST("/api/correct/{meta.namespace:.*}/name/{book.name:.*}", _BookService_Correct0_HTTP_Handler(srv))
	r.POST("/api/incorrect/{meta.namespace:.*}/name/{meta.name=*}", _BookService_Incorrect0_HTTP_Handler(srv))
}
```
#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
```
func replacePath(name string, value string, path string) string {
	pattern := regexp.MustCompile(fmt.Sprintf(`(?i){([\s]*%s[\s]*)=?([^{}]*)}`, name))
	idx := pattern.FindStringIndex(path)
	if len(idx) > 0 {
		path = fmt.Sprintf("%s{%s:%s}%s",
			path[:idx[0]], // The start of the match
			name,
			strings.ReplaceAll(value, "*", ".*"),
			path[idx[1]:],
		)
	}
	return path
}
```
Fix the encoding error in the go-http plugin's path. The reason is the boundary configuration in the regular expression. The overlapping part of meta.name and mate.namespace in the path leads to an incorrect index in the line idx := pattern.FindStringIndex(path).

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
