### PR TITLE
fix: watch failure caused instance list not to be updated and add re-registry option

### DIFF
--- a/contrib/registry/consul/registry.go
+++ b/contrib/registry/consul/registry.go
@@ -86,6 +86,13 @@ func WithServiceCheck(checks ...*api.AgentServiceCheck) Option {
 	}
 }
 
+// WithReRegistry re-registry when service is deregistered
+func WithReRegistry() Option {
+	return func(r *Registry) {
+		r.cli.reRegistry = true
+	}
+}
+
 // Config is consul registry config
 type Config struct {
 	*api.Config
@@ -190,7 +197,6 @@ func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, er
 			services:    &atomic.Value{},
 			serviceName: name,
 		}
-		r.registry[name] = set
 	}
 
 	// init watcher
@@ -215,6 +221,9 @@ func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, er
 			return nil, err
 		}
 	}
+
+	r.registry[name] = set
+
 	return w, nil
 }
 


### PR DESCRIPTION
In the main branch code, the consult watch uses a map to save the watch object, but does not consider the case of watch initialization failure. In any case, the watch is saved to the map, 
https://github.com/go-kratos/kratos/blob/bffc1a0989a6f82d0f3f96793df690288c746801/contrib/registry/consul/registry.go#L183
```
// Watch resolve service by name
func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, error) {
	r.lock.Lock()
	defer r.lock.Unlock()
	set, ok := r.registry[name]
	if !ok {
		set = &serviceSet{
			watcher:     make(map[*watcher]struct{}),
			services:    &atomic.Value{},
			serviceName: name,
		}
		r.registry[name] = set
	}

        // do sometring 

	if !ok {
		err := r.resolve(ctx, set)
		if err != nil {
			return nil, err
		}
	}
	return w, nil
}
```
resulting in the inability to obtain instances normally even if the watch is reinitialized, because the `resolve` method only takes effect when the corresponding service watch object does not exist in the map. If the `resolve` fails, the process for obtaining instance changes in the `resolve` will not be executed, resulting in the subsequent use of a new watch object and not re calling the resolve because it already exists in the map
https://github.com/go-kratos/kratos/blob/bffc1a0989a6f82d0f3f96793df690288c746801/contrib/registry/consul/registry.go#L221
```
func (r *Registry) resolve(ctx context.Context, ss *serviceSet) error {
	timeoutCtx, cancel := context.WithTimeout(ctx, r.timeout)
	defer cancel()

	services, idx, err := r.cli.Service(timeoutCtx, ss.serviceName, 0, true)
	if err != nil {
		return err
	}
	if len(services) > 0 {
		ss.broadcast(services)
	}

	go func() {
		ticker := time.NewTicker(time.Second)
		defer ticker.Stop()
		for {
			select {
			case <-ticker.C:
				// do sometring
			case <-ctx.Done():
				return
			}
		}
	}()

	return nil
}
```