### PR TITLE
feat: Added `Set()` and `Get()` for `Context`

### DIFF
--- a/transport/http/context.go
+++ b/transport/http/context.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -40,6 +41,8 @@ type Context interface {
 	Blob(int, string, []byte) error
 	Stream(int, string, io.Reader) error
 	Reset(http.ResponseWriter, *http.Request)
+	Set(key, value interface{}) error
+	Get(key interface{}) interface{}
 }
 
 type responseWriter struct {
@@ -183,4 +186,18 @@ func (c *wrapper) Value(key interface{}) interface{} {
 		return nil
 	}
 	return c.req.Context().Value(key)
+}
+
+func (c *wrapper) Set(key, value interface{}) error {
+	if c.req == nil {
+		return errors.New("request is nil")
+	}
+
+	c.req = c.req.WithContext(context.WithValue(c.req.Context(), key, value))
+
+	return nil
+}
+
+func (c *wrapper) Get(key interface{}) interface{} {
+	return c.Value(key)
 }

--- a/transport/http/context_test.go
+++ b/transport/http/context_test.go
@@ -221,3 +221,49 @@ func TestContextCtx(t *testing.T) {
 		t.Errorf("expected %v, got %v", nil, v)
 	}
 }
+
+func TestContextSetAndGet(t *testing.T) {
+	w := wrapper{
+		router: testRouter,
+		req:    &http.Request{},
+		res:    nil,
+		w:      responseWriter{},
+	}
+	if w.Set("test", "test") != nil {
+		t.Errorf("expected %v, got %v", nil, w.Set("test", "test"))
+	}
+
+	v := w.Get("test")
+	if w.Get("test") != "test" {
+		t.Errorf("expected %v, got %v", "test", v)
+	}
+
+	// test reset
+	w = wrapper{
+		router: testRouter,
+		req:    &http.Request{},
+		res:    nil,
+		w:      responseWriter{},
+	}
+
+	v = w.Get("test")
+	if v != nil {
+		t.Errorf("expected %v, got %v", nil, v)
+	}
+
+	// nil
+	w = wrapper{
+		router: testRouter,
+		req:    nil,
+		res:    nil,
+		w:      responseWriter{},
+	}
+
+	if w.Set("test", "test") == nil {
+		t.Errorf("expected %v, got %v", "error", nil)
+	}
+
+	if w.Get("test") != nil {
+		t.Errorf("expected %v, got %v", nil, w.Get("test"))
+	}
+}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

In order to facilitate the implementation of context assignment and value.

**Example:**

```go
w := wrapper{
		router: testRouter,
		req:    &http.Request{},
		res:    nil,
		w:      responseWriter{},
}

w.Set("test", "test")
w.Get("test")
```