### PR TITLE
feat: Add a Close interface for the implementation of third-party log…

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -13,6 +13,11 @@ type Logger interface {
 	Log(level Level, keyvals ...interface{}) error
 }
 
+// Closeable is a logger that can be closed.
+type Closeable interface {
+	Close() error
+}
+
 type logger struct {
 	logger    Logger
 	prefix    []interface{}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -15,3 +15,11 @@ func TestInfo(_ *testing.T) {
 func TestWithContext(_ *testing.T) {
 	WithContext(context.Background(), nil)
 }
+
+func TestClosedLogger(t *testing.T) {
+	logger := DefaultLogger
+
+	if l, ok := logger.(Closeable); ok {
+		_ = l.Close()
+	}
+}


### PR DESCRIPTION
## Example

```go
package main

import "github.com/go-kratos/kratos/v2/log"

func main() {
	logger := log.DefaultLogger
	defer func() {
		if l, ok := logger.(log.Closeable); ok {
			_ = l.Close()
		}
	}()
	
	// ……
}
```

> I have multiple environment requirements, different environments use different log drivers, but some drivers have Close, so I hope to add a Close interface to achieve universality.