### PR TITLE
chore: fix typo variable in shell script

### DIFF
--- a/hack/resolve-modules.sh
+++ b/hack/resolve-modules.sh
@@ -8,15 +8,15 @@ set -o errexit
 
 echo "Resolving modules in $(pwd)"
 
-KRAOTS_HOME=$(
+KRATOS_HOME=$(
 	cd "$(dirname "${BASH_SOURCE[0]}")" &&
 		cd .. &&
 		pwd
 )
 
-source "${KRAOTS_HOME}/hack/util.sh"
+source "${KRATOS_HOME}/hack/util.sh"
 
-FAILURE_FILE=${KRAOTS_HOME}/hack/.lintcheck_failures
+FAILURE_FILE=${KRATOS_HOME}/hack/.lintcheck_failures
 
 all_modules=$(util::find_modules)
 failing_modules=()

--- a/hack/tools.sh
+++ b/hack/tools.sh
@@ -8,18 +8,18 @@ set -o nounset
 set -o pipefail
 
 GO111MODULE=on
-KRAOTS_HOME=$(
+KRATOS_HOME=$(
 	cd "$(dirname "${BASH_SOURCE[0]}")" &&
 		cd .. &&
 		pwd
 )
 
-source "${KRAOTS_HOME}/hack/util.sh"
+source "${KRATOS_HOME}/hack/util.sh"
 
-LINTER=${KRAOTS_HOME}/bin/golangci-lint
-LINTER_CONFIG=${KRAOTS_HOME}/.golangci.yml
-FAILURE_FILE=${KRAOTS_HOME}/hack/.lintcheck_failures
-IGNORED_FILE=${KRAOTS_HOME}/hack/.test_ignored_files
+LINTER=${KRATOS_HOME}/bin/golangci-lint
+LINTER_CONFIG=${KRATOS_HOME}/.golangci.yml
+FAILURE_FILE=${KRATOS_HOME}/hack/.lintcheck_failures
+IGNORED_FILE=${KRATOS_HOME}/hack/.test_ignored_files
 
 all_modules=$(util::find_modules)
 failing_modules=()


### PR DESCRIPTION
<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
Fix a typo variable in the shell script. Like `KRATOS` NOT `KRAOTS`.
This PR is Pass to [CI Test](https://github.com/Mo3et/kratos/actions?query=event%3Apull_request) in my fork repo.

#### Which issue(s) this PR fixes (resolves / be part of):
none.


#### Other special notes for the reviewers:
none.