### PR TITLE
feat: add Host func in http.client

### DIFF
--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -332,7 +332,7 @@ func (client *Client) Host() (string, error) {
 		if client.insecure {
 			schema = "http"
 		}
-		return schema + node.Address(), nil
+		return schema + ":" + node.Address(), nil
 	}
 
 	return host, errors.ServiceUnavailable("NODE_IS_NIL", "NODE_IS_NIL")

--- a/transport/http/client.go
+++ b/transport/http/client.go
@@ -318,6 +318,26 @@ func (client *Client) do(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
+func (client *Client) Host() (string, error) {
+	var host string
+	if client.r != nil {
+		var (
+			err  error
+			node selector.Node
+		)
+		if node, _, err = client.selector.Select(context.Background(), selector.WithNodeFilter(client.opts.nodeFilters...)); err != nil {
+			return host, errors.ServiceUnavailable("NODE_NOT_FOUND", err.Error())
+		}
+		schema := "https"
+		if client.insecure {
+			schema = "http"
+		}
+		return schema + node.Address(), nil
+	}
+
+	return host, errors.ServiceUnavailable("NODE_IS_NIL", "NODE_IS_NIL")
+}
+
 // Close tears down the Transport and all underlying connections.
 func (client *Client) Close() error {
 	if client.r != nil {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
使用http服务发现后，我们只想要得到服务器的地址，而不是被封装的httpClient（被封装的httpClient格式化和局限了返回值），我们希望能够暴露出一个接口将地址返回给其他httpClient进行操作。kratos很好的支持了http服务发现，并且做了负载均衡和watch，新增加一个Host函数能够直接拿出服务发现的地址。