### PR TITLE
fix:polaris_config_watch

### DIFF
--- a/contrib/polaris/config.go
+++ b/contrib/polaris/config.go
@@ -1,6 +1,7 @@
 package polaris
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 
@@ -110,7 +111,7 @@ func (w *ConfigWatcher) Next() ([]*config.KeyValue, error) {
 		}
 		return w.cfg, nil
 	}
-	return w.cfg, nil
+	return w.cfg, context.Canceled
 }
 
 func (w *ConfigWatcher) Stop() error {


### PR DESCRIPTION
the high CPU usage issue caused by watching the Polaris config, particularly in situations when config events are closed.

If the configuration connection has already been closed, the configuration file monitoring should be canceled.