### PR TITLE
#3110  bugfix  instead throw errors  when too much err happend  not to cover errors

### DIFF
--- a/app.go
+++ b/app.go
@@ -143,7 +143,11 @@ func (a *App) Run() error {
 		if err != nil {
 			log.Warnf("%s", err)
 		}
-		err = fn(sctx)
+
+		fnErr := fn(sctx)
+		if fnErr != nil {
+			err = fnErr
+		}
 	}
 	return err
 }
@@ -155,7 +159,10 @@ func (a *App) Stop() (err error) {
 		if err != nil {
 			log.Warnf("%s", err)
 		}
-		err = fn(sctx)
+		fnErr := fn(sctx)
+		if fnErr != nil {
+			err = fnErr
+		}
 	}
 
 	a.mu.Lock()

--- a/app.go
+++ b/app.go
@@ -140,6 +140,9 @@ func (a *App) Run() error {
 		return err
 	}
 	for _, fn := range a.opts.afterStop {
+		if err != nil {
+			log.Warnf("%s", err)
+		}
 		err = fn(sctx)
 	}
 	return err
@@ -149,6 +152,9 @@ func (a *App) Run() error {
 func (a *App) Stop() (err error) {
 	sctx := NewContext(a.ctx, a)
 	for _, fn := range a.opts.beforeStop {
+		if err != nil {
+			log.Warnf("%s", err)
+		}
 		err = fn(sctx)
 	}
 


### PR DESCRIPTION
https://github.com/go-kratos/kratos/issues/3110

when too much errors happened ,print history err;
如果发生过error，就把发生过的error一并返回；而不是通过重复赋值将error =nil进行掩盖。