### PR TITLE
chore: replace deprecated command with environment file

### DIFF
--- a/hack/resolve-modules.sh
+++ b/hack/resolve-modules.sh
@@ -35,4 +35,4 @@ for mod in $all_modules; do
 	fi
 done
 
-echo "::set-output name=matrix::{\"include\":[${PATHS%?}]}"
+echo "matrix={\"include\":[${PATHS%?}]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

Update `hack/resolve-modules.sh` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

**AS-IS**

```yaml
echo "::set-output name=matrix::{\"include\":[${PATHS%?}]}"
```

**TO-BE**

```yaml
echo "matrix={\"include\":[${PATHS%?}]}" >> $GITHUB_OUTPUT
```

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

None

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->

None
