### PR TITLE
feat(transport/http): remove wrapper.w and add Unwrap method for acce…

### DIFF
--- a/transport/http/context_test.go
+++ b/transport/http/context_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -153,14 +154,16 @@ func TestContextResult(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expected %v, got %v", nil, err)
 			}
-			if res.Code != tc.code {
-				t.Fatalf("expected %d, got %d", tc.code, res.Code)
+
+			resp := res.Result()
+			if resp.StatusCode != tc.code {
+				t.Fatalf("expected %d, got %d", tc.code, resp.StatusCode)
 			}
-			if s := res.Header().Get("X-Foo"); s != tc.header {
+			if s := resp.Header.Get("X-Foo"); s != tc.header {
 				t.Fatalf("expected %q, got %q", tc.header, s)
 			}
-			if s := res.Body.String(); s != "body" {
-				t.Fatalf("expected %s, resp.Body: %v", "body", s)
+			if bs, _ := io.ReadAll(res.Body); string(bs) != "body" {
+				t.Fatalf("expected %s, got: %s", "body", bs)
 			}
 		})
 	}

--- a/transport/http/context_test.go
+++ b/transport/http/context_test.go
@@ -156,6 +156,7 @@ func TestContextResult(t *testing.T) {
 			}
 
 			resp := res.Result()
+			defer resp.Body.Close()
 			if resp.StatusCode != tc.code {
 				t.Fatalf("expected %d, got %d", tc.code, resp.StatusCode)
 			}

--- a/transport/http/context_test.go
+++ b/transport/http/context_test.go
@@ -105,7 +105,7 @@ func TestContextResult(t *testing.T) {
 		{
 			name: "normal",
 			enc: func(rw http.ResponseWriter, r *http.Request, v interface{}) error {
-				rw.Header().Add("X-Foo", "foo")
+				rw.Header().Set("X-Foo", "foo")
 				_, err := rw.Write([]byte(v.(string)))
 				return err
 			},
@@ -115,7 +115,7 @@ func TestContextResult(t *testing.T) {
 		{
 			name: "writeHeader",
 			enc: func(rw http.ResponseWriter, r *http.Request, v interface{}) error {
-				rw.Header().Add("X-Foo", "foo")
+				rw.Header().Set("X-Foo", "foo")
 				rw.WriteHeader(500)
 				_, err := rw.Write([]byte(v.(string)))
 				return err
@@ -132,7 +132,7 @@ func TestContextResult(t *testing.T) {
 				}
 
 				w := u.Unwrap()
-				w.Header().Add("X-Foo", "foo")
+				w.Header().Set("X-Foo", "foo")
 				w.WriteHeader(500)
 
 				_, err := w.Write([]byte(v.(string)))


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

1. Remove wrapper.w to avoid confused of ResponseWriter.
2. Add unwrap method for accessing wrapped ResponseWriter.
3. Create testing code for wrapper.Result.

Now users can use followed code to get custom ResponseWriter they passed:

```go
if u, ok := w.(interface { Unwrap() http.ResponseWriter }); ok {
	if cw, ok := w.Unwrap().(*CustomResponseWriter); ok {
		// do something with CustomResponseWriter
	}
}
```

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

fixes/resolves #3174

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->

Rename "responseWriter" to "wrappedWriter" for better semantics.