### PR TITLE
fix: Use ResponseRecorder.Result to get an accuracy response.

### DIFF
--- a/transport/http/redirect_test.go
+++ b/transport/http/redirect_test.go
@@ -15,10 +15,11 @@ func TestRedirect(t *testing.T) {
 	w := httptest.NewRecorder()
 	_ = DefaultResponseEncoder(w, r, NewRedirect(redirectURL, redirectCode))
 
-	if w.Code != redirectCode {
-		t.Fatalf("want %d but got %d", redirectCode, w.Code)
+	resp := w.Result()
+	if resp.StatusCode != redirectCode {
+		t.Fatalf("want %d but got %d", redirectCode, resp.StatusCode)
 	}
-	if v := w.Header().Get("Location"); v != redirectURL {
+	if v := resp.Header.Get("Location"); v != redirectURL {
 		t.Fatalf("want %s but got %s", redirectURL, v)
 	}
 }


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

ResponseRecorder recommend that users should call `Result` to get response info for testing purpose.

References:

* [doc of ResponseRecorder.Header](https://pkg.go.dev/net/http/httptest#ResponseRecorder.Header)
* [doc of ResponseRecorder.Code](https://pkg.go.dev/net/http/httptest#ResponseRecorder)

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
