### PR TITLE
fix(registry): goroutine leak of etcd watcher when ctx is done

### DIFF
--- a/contrib/registry/etcd/watcher.go
+++ b/contrib/registry/etcd/watcher.go
@@ -6,6 +6,7 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/registry"
 )
 
@@ -52,7 +53,16 @@ func (w *watcher) Next() ([]*registry.ServiceInstance, error) {
 	case <-w.ctx.Done():
 		return nil, w.ctx.Err()
 	case watchResp, ok := <-w.watchChan:
-		if !ok || watchResp.Err() != nil {
+		// Refer https://github.com/etcd-io/etcd/blob/5d45a88ab73cc5461ccf23e4df70598d8d433ff0/client/v3/watch.go#L65
+		if !ok && watchResp.Err() == nil {
+			// ctx is canceled or timed out
+			return nil, w.ctx.Err()
+		}
+		if watchResp.Err() != nil {
+			// If revisions waiting to be sent over the watch are compacted,
+			// then the watch will be canceled by the server,
+			// the client will post a compacted error watch response, and the channel will close.
+			log.Infow("func", "registry/etcd/watcher.Next()", "do", "rewatch", "respErr", watchResp.Err())
 			time.Sleep(time.Second)
 			err := w.reWatch()
 			if err != nil {


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->


#### Description (what this PR does / why we need it):

The watcher will call the `reWatch()` method when the ctx is done,
which is unintended and will result in a goroutine leak.

See https://github.com/etcd-io/etcd/blob/5d45a88ab73cc5461ccf23e4df70598d8d433ff0/client/v3/watch.go#L65:

> If the context "ctx" is canceled or timed out, returned "WatchChan" is closed,
> and "WatchResponse" from this closed channel has zero events and nil "Err()".

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
