### PR TITLE
feat(log): Prevent log.Helper sprintf from running early #3209

### DIFF
--- a/log/helper.go
+++ b/log/helper.go
@@ -66,9 +66,13 @@ func (h *Helper) WithContext(ctx context.Context) *Helper {
 	}
 }
 
-func (h *Helper) preCheckLevel(level Level) bool {
-	l, ok := h.logger.(*Filter)
-	return ok && level < l.level
+// Enabled returns true if the given level above this level.
+// It delegates to the underlying *Filter.
+func (h *Helper) Enabled(level Level) bool {
+	if l, ok := h.logger.(*Filter); ok {
+		return level >= l.level
+	}
+	return true
 }
 
 // Log Print log by level and keyvals.
@@ -78,7 +82,7 @@ func (h *Helper) Log(level Level, keyvals ...interface{}) {
 
 // Debug logs a message at debug level.
 func (h *Helper) Debug(a ...interface{}) {
-	if h.preCheckLevel(LevelDebug) {
+	if !h.Enabled(LevelDebug) {
 		return
 	}
 	_ = h.logger.Log(LevelDebug, h.msgKey, h.sprint(a...))
@@ -86,7 +90,7 @@ func (h *Helper) Debug(a ...interface{}) {
 
 // Debugf logs a message at debug level.
 func (h *Helper) Debugf(format string, a ...interface{}) {
-	if h.preCheckLevel(LevelDebug) {
+	if !h.Enabled(LevelDebug) {
 		return
 	}
 	_ = h.logger.Log(LevelDebug, h.msgKey, h.sprintf(format, a...))
@@ -99,7 +103,7 @@ func (h *Helper) Debugw(keyvals ...interface{}) {
 
 // Info logs a message at info level.
 func (h *Helper) Info(a ...interface{}) {
-	if h.preCheckLevel(LevelInfo) {
+	if !h.Enabled(LevelInfo) {
 		return
 	}
 	_ = h.logger.Log(LevelInfo, h.msgKey, h.sprint(a...))
@@ -107,7 +111,7 @@ func (h *Helper) Info(a ...interface{}) {
 
 // Infof logs a message at info level.
 func (h *Helper) Infof(format string, a ...interface{}) {
-	if h.preCheckLevel(LevelInfo) {
+	if !h.Enabled(LevelInfo) {
 		return
 	}
 	_ = h.logger.Log(LevelInfo, h.msgKey, h.sprintf(format, a...))
@@ -120,7 +124,7 @@ func (h *Helper) Infow(keyvals ...interface{}) {
 
 // Warn logs a message at warn level.
 func (h *Helper) Warn(a ...interface{}) {
-	if h.preCheckLevel(LevelWarn) {
+	if !h.Enabled(LevelWarn) {
 		return
 	}
 	_ = h.logger.Log(LevelWarn, h.msgKey, h.sprint(a...))
@@ -128,7 +132,7 @@ func (h *Helper) Warn(a ...interface{}) {
 
 // Warnf logs a message at warnf level.
 func (h *Helper) Warnf(format string, a ...interface{}) {
-	if h.preCheckLevel(LevelWarn) {
+	if !h.Enabled(LevelWarn) {
 		return
 	}
 	_ = h.logger.Log(LevelWarn, h.msgKey, h.sprintf(format, a...))
@@ -141,7 +145,7 @@ func (h *Helper) Warnw(keyvals ...interface{}) {
 
 // Error logs a message at error level.
 func (h *Helper) Error(a ...interface{}) {
-	if h.preCheckLevel(LevelError) {
+	if !h.Enabled(LevelError) {
 		return
 	}
 	_ = h.logger.Log(LevelError, h.msgKey, h.sprint(a...))
@@ -149,7 +153,7 @@ func (h *Helper) Error(a ...interface{}) {
 
 // Errorf logs a message at error level.
 func (h *Helper) Errorf(format string, a ...interface{}) {
-	if h.preCheckLevel(LevelError) {
+	if !h.Enabled(LevelError) {
 		return
 	}
 	_ = h.logger.Log(LevelError, h.msgKey, h.sprintf(format, a...))

--- a/log/helper.go
+++ b/log/helper.go
@@ -66,6 +66,11 @@ func (h *Helper) WithContext(ctx context.Context) *Helper {
 	}
 }
 
+func (h *Helper) preCheckLevel(level Level) bool {
+	l, ok := h.logger.(*Filter)
+	return ok && level < l.level
+}
+
 // Log Print log by level and keyvals.
 func (h *Helper) Log(level Level, keyvals ...interface{}) {
 	_ = h.logger.Log(level, keyvals...)
@@ -73,11 +78,17 @@ func (h *Helper) Log(level Level, keyvals ...interface{}) {
 
 // Debug logs a message at debug level.
 func (h *Helper) Debug(a ...interface{}) {
+	if h.preCheckLevel(LevelDebug) {
+		return
+	}
 	_ = h.logger.Log(LevelDebug, h.msgKey, h.sprint(a...))
 }
 
 // Debugf logs a message at debug level.
 func (h *Helper) Debugf(format string, a ...interface{}) {
+	if h.preCheckLevel(LevelDebug) {
+		return
+	}
 	_ = h.logger.Log(LevelDebug, h.msgKey, h.sprintf(format, a...))
 }
 
@@ -88,11 +99,17 @@ func (h *Helper) Debugw(keyvals ...interface{}) {
 
 // Info logs a message at info level.
 func (h *Helper) Info(a ...interface{}) {
+	if h.preCheckLevel(LevelInfo) {
+		return
+	}
 	_ = h.logger.Log(LevelInfo, h.msgKey, h.sprint(a...))
 }
 
 // Infof logs a message at info level.
 func (h *Helper) Infof(format string, a ...interface{}) {
+	if h.preCheckLevel(LevelInfo) {
+		return
+	}
 	_ = h.logger.Log(LevelInfo, h.msgKey, h.sprintf(format, a...))
 }
 
@@ -103,11 +120,17 @@ func (h *Helper) Infow(keyvals ...interface{}) {
 
 // Warn logs a message at warn level.
 func (h *Helper) Warn(a ...interface{}) {
+	if h.preCheckLevel(LevelWarn) {
+		return
+	}
 	_ = h.logger.Log(LevelWarn, h.msgKey, h.sprint(a...))
 }
 
 // Warnf logs a message at warnf level.
 func (h *Helper) Warnf(format string, a ...interface{}) {
+	if h.preCheckLevel(LevelWarn) {
+		return
+	}
 	_ = h.logger.Log(LevelWarn, h.msgKey, h.sprintf(format, a...))
 }
 
@@ -118,11 +141,17 @@ func (h *Helper) Warnw(keyvals ...interface{}) {
 
 // Error logs a message at error level.
 func (h *Helper) Error(a ...interface{}) {
+	if h.preCheckLevel(LevelError) {
+		return
+	}
 	_ = h.logger.Log(LevelError, h.msgKey, h.sprint(a...))
 }
 
 // Errorf logs a message at error level.
 func (h *Helper) Errorf(format string, a ...interface{}) {
+	if h.preCheckLevel(LevelError) {
+		return
+	}
 	_ = h.logger.Log(LevelError, h.msgKey, h.sprintf(format, a...))
 }
 

--- a/log/helper_test.go
+++ b/log/helper_test.go
@@ -46,8 +46,22 @@ func BenchmarkHelperPrint(b *testing.B) {
 	}
 }
 
+func BenchmarkHelperPrintFilterLevel(b *testing.B) {
+	log := NewHelper(NewFilter(NewStdLogger(io.Discard), FilterLevel(LevelDebug)))
+	for i := 0; i < b.N; i++ {
+		log.Debug("test")
+	}
+}
+
 func BenchmarkHelperPrintf(b *testing.B) {
 	log := NewHelper(NewStdLogger(io.Discard))
+	for i := 0; i < b.N; i++ {
+		log.Debugf("%s", "test")
+	}
+}
+
+func BenchmarkHelperPrintfFilterLevel(b *testing.B) {
+	log := NewHelper(NewFilter(NewStdLogger(io.Discard), FilterLevel(LevelInfo)))
 	for i := 0; i < b.N; i++ {
 		log.Debugf("%s", "test")
 	}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

log 在在开发中会使用很多 Debug / Debugf 日志，在生产服务中可能会配置为 Info 级以上  
但 log.Helper 函数中会在进入
```go
h.logger.Log(LevelDebug, h.msgKey, h.sprintf...  )
``` 
提前运行了 `fmt.Sprint`、`fmt.Sprintf` 在较高并发的情况下，带来了非常高的字符串拼接耗损。

<img width="638" alt="307262318-7376dd08-d8c9-4ee0-be41-dba6e2ea4901" src="https://github.com/go-kratos/kratos/assets/5404542/ed987eac-a1c9-43ed-8bef-d1d8f549d67e">


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

fixes/resolves #3209


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
