### PR TITLE
fix(app): use a new context with timeout for afterStop

### DIFF
--- a/app.go
+++ b/app.go
@@ -142,7 +142,7 @@ func (a *App) Run() error {
 	}
 	err = nil
 
-	asCtx, cancel := context.WithTimeout(NewContext(context.Background(), a), a.opts.afterStopTimeout)
+	asCtx, cancel := context.WithTimeout(NewContext(a.opts.ctx, a), a.opts.afterStopTimeout)
 	defer cancel()
 	for _, fn := range a.opts.afterStop {
 		err = fn(asCtx)

--- a/app.go
+++ b/app.go
@@ -42,7 +42,7 @@ func New(opts ...Option) *App {
 		sigs:             []os.Signal{syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT},
 		registrarTimeout: 10 * time.Second,
 		stopTimeout:      10 * time.Second,
-		afterStopTimeout: 5 * time.Second,
+		afterStopTimeout: 0 * time.Second,
 	}
 	if id, err := uuid.NewUUID(); err == nil {
 		o.id = id.String()

--- a/app.go
+++ b/app.go
@@ -42,6 +42,7 @@ func New(opts ...Option) *App {
 		sigs:             []os.Signal{syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT},
 		registrarTimeout: 10 * time.Second,
 		stopTimeout:      10 * time.Second,
+		afterStopTimeout: 5 * time.Second,
 	}
 	if id, err := uuid.NewUUID(); err == nil {
 		o.id = id.String()
@@ -140,8 +141,11 @@ func (a *App) Run() error {
 		return err
 	}
 	err = nil
+
+	asCtx, cancel := context.WithTimeout(NewContext(context.Background(), a), a.opts.afterStopTimeout)
+	defer cancel()
 	for _, fn := range a.opts.afterStop {
-		err = fn(sctx)
+		err = fn(asCtx)
 	}
 	return err
 }

--- a/options.go
+++ b/options.go
@@ -36,6 +36,8 @@ type options struct {
 	beforeStop  []func(context.Context) error
 	afterStart  []func(context.Context) error
 	afterStop   []func(context.Context) error
+
+	afterStopTimeout time.Duration
 }
 
 // ID with service id.
@@ -125,5 +127,13 @@ func AfterStart(fn func(context.Context) error) Option {
 func AfterStop(fn func(context.Context) error) Option {
 	return func(o *options) {
 		o.afterStop = append(o.afterStop, fn)
+	}
+}
+
+// AfterStopTimeout specifies the total duration for the AfterStop funcs to complete.
+// It is 5s by default.
+func AfterStopTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.afterStopTimeout = timeout
 	}
 }

--- a/options.go
+++ b/options.go
@@ -131,7 +131,7 @@ func AfterStop(fn func(context.Context) error) Option {
 }
 
 // AfterStopTimeout specifies the total duration for the AfterStop funcs to complete.
-// It is 5s by default.
+// If not specified, kratos will pass a canceled context to AfterStop functions to ensure compatibility.
 func AfterStopTimeout(timeout time.Duration) Option {
 	return func(o *options) {
 		o.afterStopTimeout = timeout

--- a/options_test.go
+++ b/options_test.go
@@ -153,6 +153,15 @@ func TestStopTimeout(t *testing.T) {
 	}
 }
 
+func TestAfterStopTimeout(t *testing.T) {
+	o := &options{}
+	v := time.Duration(123)
+	AfterStopTimeout(v)(o)
+	if !reflect.DeepEqual(v, o.afterStopTimeout) {
+		t.Fatal("o.afterStopTimeout is not equal to v")
+	}
+}
+
 func TestBeforeStart(t *testing.T) {
 	o := &options{}
 	v := func(_ context.Context) error {


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
`App` will always use a cancelled `context.Context` for `afterStop` functions. This PR uses a new context with a default timeout (5s) for `afterStop` functions and provides a new option for setting that timeout.

#### Which issue(s) this PR fixes (resolves / be part of):
fix #3226 