### PR TITLE
build(lint): upgrade `golangci/golangci-lint-action`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           version: v1.54.2
           working-directory: ${{ matrix.workdir }}


### PR DESCRIPTION
Upgrade `golangci/golangci-lint-action` from v3 to v4