### PR TITLE
feat(transport): expose server implementation on transport

### DIFF
--- a/app.go
+++ b/app.go
@@ -102,7 +102,7 @@ func (a *App) Run() error {
 		server := srv
 		eg.Go(func() error {
 			<-ctx.Done() // wait for stop signal
-			stopCtx := octx
+			stopCtx := context.WithoutCancel(octx)
 			if a.opts.stopTimeout > 0 {
 				var cancel context.CancelFunc
 				stopCtx, cancel = context.WithTimeout(stopCtx, a.opts.stopTimeout)

--- a/encoding/form/proto_encode.go
+++ b/encoding/form/proto_encode.go
@@ -21,10 +21,7 @@ func EncodeValues(msg any) (url.Values, error) {
 	if v, ok := msg.(proto.Message); ok {
 		u := make(url.Values)
 		err := encodeByField(u, "", v.ProtoReflect())
-		if err != nil {
-			return nil, err
-		}
-		return u, nil
+		return u, err
 	}
 	return encoder.Encode(msg)
 }
@@ -56,7 +53,6 @@ func encodeByField(u url.Values, path string, m protoreflect.Message) (finalErr 
 				list, err := encodeRepeatedField(fd, v.List())
 				if err != nil {
 					finalErr = err
-					return false
 				}
 				for _, item := range list {
 					u.Add(newPath, item)
@@ -67,7 +63,6 @@ func encodeByField(u url.Values, path string, m protoreflect.Message) (finalErr 
 				m, err := encodeMapField(fd, v.Map())
 				if err != nil {
 					finalErr = err
-					return false
 				}
 				for k, value := range m {
 					u.Set(fmt.Sprintf("%s[%s]", newPath, k), value)
@@ -81,13 +76,11 @@ func encodeByField(u url.Values, path string, m protoreflect.Message) (finalErr 
 			}
 			if err = encodeByField(u, newPath, v.Message()); err != nil {
 				finalErr = err
-				return false
 			}
 		default:
 			value, err := EncodeField(fd, v)
 			if err != nil {
 				finalErr = err
-				return false
 			}
 			u.Set(newPath, value)
 		}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

Expose the server implementation on `Transporter`, similar to what's available in GRPC interceptors. This gives middlewares the ability to make decisions or delegate functionality to the server/handlers that do the work.

Example middleware that delegates authentication checks to the server handler:

```golang
func Server() middleware.Middleware {
	return func(handler middleware.Handler) middleware.Handler {
		return func(ctx context.Context, req any) (any, error) {
			if tr, ok := transport.FromServerContext(ctx); !ok {
				return nil, errors.Unauthorized()
			} else if auth, ok := tr.Server().(Authenticator); !ok {
				return nil, errors.Unauthorized()
			} else if ctx, err := auth.Authenticate(ctx, tr); err != nil {
				return nil, err
			} else {
				return handler(ctx, req)
			}
		}
	}
}
```

This is an additive change that requires HTTP servers to be regenerated since they need to call `http.SetServer` alongside the existing `http.SetOperation`.
