### PR TITLE
fix: proto message  unable to bind path param 

### DIFF
--- a/encoding/form/proto_encode.go
+++ b/encoding/form/proto_encode.go
@@ -168,7 +168,7 @@ func encodeMessage(msgDescriptor protoreflect.MessageDescriptor, value protorefl
 			return "", nil
 		}
 		for i, v := range m.Paths {
-			m.Paths[i] = jsonCamelCase(v)
+			m.Paths[i] = JsonCamelCase(v)
 		}
 		return strings.Join(m.Paths, ","), nil
 	default:
@@ -198,10 +198,10 @@ func EncodeFieldMask(m protoreflect.Message) (query string) {
 	return
 }
 
-// jsonCamelCase converts a snake_case identifier to a camelCase identifier,
+// JsonCamelCase converts a snake_case identifier to a camelCase identifier,
 // according to the protobuf JSON specification.
 // references: https://github.com/protocolbuffers/protobuf-go/blob/master/encoding/protojson/well_known_types.go#L842
-func jsonCamelCase(s string) string {
+func JsonCamelCase(s string) string {
 	var b []byte
 	var wasUnderscore bool
 	for i := 0; i < len(s); i++ { // proto identifiers are always ASCII

--- a/encoding/form/proto_encode_test.go
+++ b/encoding/form/proto_encode_test.go
@@ -72,7 +72,7 @@ func TestJsonCamelCase(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.snakeCase, func(t *testing.T) {
-			camel := jsonCamelCase(test.snakeCase)
+			camel := JsonCamelCase(test.snakeCase)
 			if camel != test.camelCase {
 				t.Errorf("want: %s, got: %s", test.camelCase, camel)
 			}

--- a/transport/http/binding/encode.go
+++ b/transport/http/binding/encode.go
@@ -18,18 +18,22 @@ func EncodeURL(pathTemplate string, msg interface{}, needQuery bool) string {
 	}
 	queryParams, _ := form.EncodeValues(msg)
 	pathParams := make(map[string]struct{})
+	protoMsg, isProtoMsg := msg.(proto.Message)
 	path := reg.ReplaceAllStringFunc(pathTemplate, func(in string) string {
 		// it's unreachable because the reg means that must have more than one char in {}
 		// if len(in) < 4 { //nolint:gomnd // **  explain the 4 number here :-) **
 		//	return in
 		// }
 		key := in[1 : len(in)-1]
+		if !queryParams.Has(key) && isProtoMsg {
+			key = form.JsonCamelCase(key)
+		}
 		pathParams[key] = struct{}{}
 		return queryParams.Get(key)
 	})
 	if !needQuery {
-		if v, ok := msg.(proto.Message); ok {
-			if query := form.EncodeFieldMask(v.ProtoReflect()); query != "" {
+		if isProtoMsg {
+			if query := form.EncodeFieldMask(protoMsg.ProtoReflect()); query != "" {
 				return path + "?" + query
 			}
 		}

--- a/transport/http/binding/encode_test.go
+++ b/transport/http/binding/encode_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEncodeURL(t *testing.T) {
+	kratosName := "kratos"
 	tests := []struct {
 		pathTemplate string
 		request      *binding.HelloRequest
@@ -116,6 +117,18 @@ func TestEncodeURL(t *testing.T) {
 			request:      &binding.HelloRequest{Sub: &binding.Sub{Name: "kratos"}},
 			needQuery:    false,
 			want:         "http://helloworld.Greeter/helloworld/{}/[]/[kratos]",
+		},
+		{
+			pathTemplate: "http://helloworld.Greeter/helloworld/{optString}",
+			request:      &binding.HelloRequest{OptString: &kratosName},
+			needQuery:    false,
+			want:         "http://helloworld.Greeter/helloworld/kratos",
+		},
+		{
+			pathTemplate: "http://helloworld.Greeter/helloworld/{opt_string}",
+			request:      &binding.HelloRequest{OptString: &kratosName},
+			needQuery:    false,
+			want:         "http://helloworld.Greeter/helloworld/kratos",
 		},
 	}
 


### PR DESCRIPTION
 


#### Description (what this PR does / why we need it):
proto-gen-go-http 在调用时使用binding.EncodeURL 进行参数绑定，path中使用snakeCase命名方法会导致参数绑定失败,使用camelCase则正常。
proto 的命名规范为snakeCase。
例如
```go
pathTemplate := "/v1/enterprise/{enterprise_id}"
in := &pcv1.GetEnterpriseInfoReq{
EnterpriseId: "123",
}
path := binding.EncodeURL(pathTemplate, in, true)
fmt.Println(path) // 输出： /v1/enterprise/?enterpriseId=123
path = binding.EncodeURL("/v1/enterprise/{enterpriseId}", in, true)
fmt.Println(path) // 输出： /v1/enterprise/123
```

#### Which issue(s) this PR fixes (resolves / be part of):
原因：
form.EncodeValues读取字段的值如果是proto类型的使用的是protobuf中的json字段命名camelCase。
后续匹配path参数(命名规则为snakeCase)则无法匹配到。
解决方法：
绑定参数时候判断是否为proto 消息，如果是proto消息并且未匹配到参数直接修改key为camelCase 进行匹配

 
