### PR TITLE
fix(contrib/opensergo): incorrect conversion between integer types

### DIFF
--- a/contrib/opensergo/opensergo.go
+++ b/contrib/opensergo/opensergo.go
@@ -97,14 +97,14 @@ func (s *OpenSergo) ReportMetadata(ctx context.Context, app kratos.AppInfo) erro
 		if err != nil {
 			return err
 		}
-		portValue, err := strconv.Atoi(port)
+		portUint64, err := strconv.ParseUint(port, 10, 32)
 		if err != nil {
 			return err
 		}
 		serviceMetadata.Protocols = append(serviceMetadata.Protocols, u.Scheme)
 		serviceMetadata.ListeningAddresses = append(serviceMetadata.ListeningAddresses, &v1.SocketAddress{
 			Address:   host,
-			PortValue: uint32(portValue),
+			PortValue: uint32(portUint64),
 		})
 	}
 	_, err = s.mdClient.ReportMetadata(ctx, &v1.ReportMetadataRequest{

--- a/contrib/polaris/router.go
+++ b/contrib/polaris/router.go
@@ -83,7 +83,6 @@ func (p *Polaris) NodeFilter(opts ...RouterOption) selector.NodeFilter {
 		}
 
 		n := make(map[string]selector.Node, len(nodes))
-
 		for _, node := range nodes {
 			n[node.Address()] = node
 		}

--- a/contrib/polaris/router.go
+++ b/contrib/polaris/router.go
@@ -115,7 +115,7 @@ func buildPolarisInstance(namespace string, nodes []selector.Node) *pb.ServiceIn
 			log.Errorf("split host port failed error: %v", err)
 			return nil
 		}
-		portUint64, err := strconv.ParseUint(port, 10, 32) //nolint:gomnd
+		portUint64, err := strconv.ParseUint(port, 10, 32)
 		if err != nil {
 			log.Errorf("parse port failed error: %v", err)
 			return nil

--- a/contrib/polaris/router.go
+++ b/contrib/polaris/router.go
@@ -112,10 +112,12 @@ func buildPolarisInstance(namespace string, nodes []selector.Node) *pb.ServiceIn
 	for _, node := range nodes {
 		host, port, err := net.SplitHostPort(node.Address())
 		if err != nil {
+			log.Errorf("split host port failed error: %v", err)
 			return nil
 		}
 		portUint64, err := strconv.ParseUint(port, 10, 32) //nolint:gomnd
 		if err != nil {
+			log.Errorf("parse port failed error: %v", err)
 			return nil
 		}
 		ins = append(ins, &v1.Instance{


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
https://github.com/go-kratos/kratos/security/code-scanning/2

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
