### PR TITLE
fix(cli): update cli `Project creation succeeded` prompt

### DIFF
--- a/cmd/kratos/internal/project/add.go
+++ b/cmd/kratos/internal/project/add.go
@@ -59,7 +59,7 @@ func (p *Project) Add(ctx context.Context, dir string, layout string, branch str
 	fmt.Print("💻 Use the following command to add a project 👇:\n\n")
 
 	fmt.Println(color.WhiteString("$ cd %s", p.Name))
-	fmt.Println(color.WhiteString("$ go generate ./..."))
+	fmt.Println(color.WhiteString("$ make generate"))
 	fmt.Println(color.WhiteString("$ go build -o ./bin/ ./... "))
 	fmt.Println(color.WhiteString("$ ./bin/%s -conf ./configs\n", p.Name))
 	fmt.Println("			🤝 Thanks for using Kratos")

--- a/cmd/kratos/internal/project/new.go
+++ b/cmd/kratos/internal/project/new.go
@@ -55,7 +55,7 @@ func (p *Project) New(ctx context.Context, dir string, layout string, branch str
 	fmt.Print("💻 Use the following command to start the project 👇:\n\n")
 
 	fmt.Println(color.WhiteString("$ cd %s", p.Name))
-	fmt.Println(color.WhiteString("$ go generate ./..."))
+	fmt.Println(color.WhiteString("$ make generate"))
 	fmt.Println(color.WhiteString("$ go build -o ./bin/ ./... "))
 	fmt.Println(color.WhiteString("$ ./bin/%s -conf ./configs\n", p.Name))
 	fmt.Println("			🤝 Thanks for using Kratos")


### PR DESCRIPTION
<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
update cli `Project creation succeeded` prompt.
`go generate ./...`  ->`make generate`

Running `Kratos run` on the latest version results in issue  [kratos-layout#143](https://github.com/go-kratos/kratos-layout/issues/143). 
I think it's a Prompt issue, I reproduce this operation using `make generate`, which solves issue  [kratos-layout#143](https://github.com/go-kratos/kratos-layout/issues/143).  Because `make generate` includes` go generate` inside and solves the problem of wire generation.
~~but it's not perfect, it needs to work with [Kratos-layout](https://github.com/go-kratos/kratos-layout) to modify the content of `make Generate`.~~

~~For example, you need to add go mod tidy. at the end of make Generate again to make it work.~~

~~Meanwhile, I'll request the issue requester to create the corresponding PR, or I'll create one.~~


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

resolves [kratos-layout#143](https://github.com/go-kratos/kratos-layout/issues/143)


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
