### PR TITLE
fix(contrib/registry/nacos): Abnormal blocking of the Subscribe and Next methods.

### DIFF
--- a/contrib/registry/nacos/watcher.go
+++ b/contrib/registry/nacos/watcher.go
@@ -41,14 +41,16 @@ func newWatcher(ctx context.Context, cli naming_client.INamingClient, serviceNam
 		Clusters:    clusters,
 		GroupName:   groupName,
 		SubscribeCallback: func(services []model.SubscribeService, err error) {
-			if len(w.watchChan) == 0 {
-				w.watchChan <- struct{}{}
+			select {
+			case w.watchChan <- struct{}{}:
+			default:
 			}
 		},
 	}
 	e := w.cli.Subscribe(w.subscribeParam)
-	if len(w.watchChan) == 0 {
-		w.watchChan <- struct{}{}
+	select {
+	case w.watchChan <- struct{}{}:
+	default:
 	}
 	return w, e
 }

--- a/contrib/registry/nacos/watcher.go
+++ b/contrib/registry/nacos/watcher.go
@@ -41,10 +41,15 @@ func newWatcher(ctx context.Context, cli naming_client.INamingClient, serviceNam
 		Clusters:    clusters,
 		GroupName:   groupName,
 		SubscribeCallback: func(services []model.SubscribeService, err error) {
-			w.watchChan <- struct{}{}
+			if len(w.watchChan) == 0 {
+				w.watchChan <- struct{}{}
+			}
 		},
 	}
 	e := w.cli.Subscribe(w.subscribeParam)
+	if len(w.watchChan) == 0 {
+		w.watchChan <- struct{}{}
+	}
 	return w, e
 }
 


### PR DESCRIPTION
This submission can solve the channel blocking problem during service discovery, as well as the channel message missing problem when the GRPC idle state changes. ﻿

The first scenario is when both the configuration center and registration center are initialized at the same time during service startup, and the SubscribeCallback method will be triggered twice, throwing the error "over time discovering the creation of observers", resulting in a discovery failure. The second scenario occurs after NotLoadCacheAtStart: true. When grpc exits the idle state, calling newWatcher again will not trigger the SubscribeCallback method, causing the Next function to be blocked and the service to be unable to communicate.
