### PR TITLE
adds Set-Cookie method to the HTTP transport.

### DIFF
--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -296,6 +296,7 @@ func (s *Server) filter() mux.MiddlewareFunc {
 				reqHeader:    headerCarrier(req.Header),
 				replyHeader:  headerCarrier(w.Header()),
 				request:      req,
+				response:     w,
 			}
 			if s.endpoint != nil {
 				tr.endpoint = s.endpoint.String()

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -23,6 +23,7 @@ type Transport struct {
 	reqHeader    headerCarrier
 	replyHeader  headerCarrier
 	request      *http.Request
+	response     http.ResponseWriter
 	pathTemplate string
 }
 
@@ -66,6 +67,17 @@ func SetOperation(ctx context.Context, op string) {
 	if tr, ok := transport.FromServerContext(ctx); ok {
 		if tr, ok := tr.(*Transport); ok {
 			tr.operation = op
+		}
+	}
+}
+
+// SetCookie adds a Set-Cookie header to the provided [ResponseWriter]'s headers.
+// The provided cookie must have a valid Name. Invalid cookies may be
+// silently dropped.
+func SetCookie(ctx context.Context, cookie *http.Cookie) {
+	if tr, ok := transport.FromServerContext(ctx); ok {
+		if tr, ok := tr.(*Transport); ok {
+			http.SetCookie(tr.response, cookie)
 		}
 	}
 }


### PR DESCRIPTION
```go
cookie := http.Cookie{
        Name:     "exampleCookie",
        Value:    "Hello world!",
        Path:     "/",
        MaxAge:   3600,
        HttpOnly: true,
        Secure:   true,
        SameSite: http.SameSiteLaxMode,
    }
 // Use the http.SetCookie() function to send the cookie to the client.
http.SetCookie(ctx, cookie)
```