### PR TITLE
feat: tracing add custom report err func

### DIFF
--- a/middleware/tracing/tracer.go
+++ b/middleware/tracing/tracer.go
@@ -62,9 +62,13 @@ func (t *Tracer) Start(ctx context.Context, operation string, carrier propagatio
 // End finish tracing span
 func (t *Tracer) End(_ context.Context, span trace.Span, m interface{}, err error) {
 	if err != nil {
-		span.RecordError(err)
-		if e := errors.FromError(err); e != nil {
-			span.SetAttributes(attribute.Key("rpc.status_code").Int64(int64(e.Code)))
+		if t.opt.customReportErr != nil {
+			t.opt.customReportErr(span, err)
+		} else {
+			span.RecordError(err)
+			if e := errors.FromError(err); e != nil {
+				span.SetAttributes(attribute.Key("rpc.status_code").Int64(int64(e.Code)))
+			}
 		}
 		span.SetStatus(codes.Error, err.Error())
 	} else {

--- a/middleware/tracing/tracing.go
+++ b/middleware/tracing/tracing.go
@@ -15,10 +15,14 @@ import (
 // Option is tracing option.
 type Option func(*options)
 
+// customReportErrFunc custom report err func handler
+type customReportErrFunc func(span trace.Span, err error)
+
 type options struct {
-	tracerName     string
-	tracerProvider trace.TracerProvider
-	propagator     propagation.TextMapPropagator
+	tracerName      string
+	tracerProvider  trace.TracerProvider
+	propagator      propagation.TextMapPropagator
+	customReportErr customReportErrFunc
 }
 
 // WithPropagator with tracer propagator.
@@ -40,6 +44,13 @@ func WithTracerProvider(provider trace.TracerProvider) Option {
 func WithTracerName(tracerName string) Option {
 	return func(opts *options) {
 		opts.tracerName = tracerName
+	}
+}
+
+// WithCustomReportErr with custom report err func
+func WithCustomReportErr(f customReportErrFunc) Option {
+	return func(o *options) {
+		o.customReportErr = f
 	}
 }
 


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
By default, when an error occurs, the following action is taken:
```
span.RecordError(err)
if e := errors.FromError(err); e != nil {
	span.SetAttributes(attribute.Key("rpc.status_code").Int64(int64(e.Code)))
}
```
The exception.type in RecordError is the type of the error, which doesn't contain much information. To collect more details, we can customize the action and add new attributes.

Here is an example of how to customize error handling and collect more information:
```
var (
	errCode int32
)

if st, ok := status.FromError(err); ok {
	errCode = int32(st.Code())
} else {
	errCode = 0
}

span.AddEvent("exception", otelTrace.WithAttributes(
	attribute.Key("exception.type").String(fmt.Sprintf("%T", err)),
	attribute.Key("exception.message").String(err.Error()),
))
span.SetAttributes(attribute.Key("rpc.grpc.status_code").Int64(int64(errCode)))
```
By doing this, we can collect and record more detailed error information, which helps in better monitoring and debugging of the application.
#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
the default grpc error code in opentelmetry library is `rpc.grpc.status_code` not `rpc.status_code`, we can use the custom method to compatible that