### PR TITLE
deps: upgrade kratos version to v2.8.0

### DIFF
--- a/cmd/kratos/version.go
+++ b/cmd/kratos/version.go
@@ -1,4 +1,4 @@
 package main
 
 // release is the current kratos tool version.
-const release = "v2.7.3"
+const release = "v2.8.0"

--- a/cmd/protoc-gen-go-errors/version.go
+++ b/cmd/protoc-gen-go-errors/version.go
@@ -1,4 +1,4 @@
 package main
 
 // release is the current protoc-gen-go-errors version.
-const release = "v2.7.3"
+const release = "v2.8.0"

--- a/cmd/protoc-gen-go-http/version.go
+++ b/cmd/protoc-gen-go-http/version.go
@@ -1,4 +1,4 @@
 package main
 
 // release is the current protoc-gen-go-http version.
-const release = "v2.7.3"
+const release = "v2.8.0"

--- a/contrib/config/apollo/go.mod
+++ b/contrib/config/apollo/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/apolloconfig/agollo/v4 v4.3.1
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 )
 
 require (

--- a/contrib/config/consul/go.mod
+++ b/contrib/config/consul/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/config/consul/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/hashicorp/consul/api v1.26.1
 )
 

--- a/contrib/config/etcd/go.mod
+++ b/contrib/config/etcd/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/config/etcd/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	go.etcd.io/etcd/client/v3 v3.5.11
 	google.golang.org/grpc v1.61.1
 )

--- a/contrib/config/kubernetes/go.mod
+++ b/contrib/config/kubernetes/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/config/kubernetes/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	k8s.io/api v0.26.3
 	k8s.io/apimachinery v0.26.3
 	k8s.io/client-go v0.26.3

--- a/contrib/config/nacos/go.mod
+++ b/contrib/config/nacos/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/config/nacos/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/nacos-group/nacos-sdk-go v1.0.9
 )
 

--- a/contrib/config/polaris/go.mod
+++ b/contrib/config/polaris/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/config/polaris/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/polarismesh/polaris-go v1.1.0
 )
 

--- a/contrib/encoding/msgpack/go.mod
+++ b/contrib/encoding/msgpack/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/encoding/msgpack/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 

--- a/contrib/log/aliyun/go.mod
+++ b/contrib/log/aliyun/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/aliyun/aliyun-log-go-sdk v0.1.75
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	google.golang.org/protobuf v1.33.0
 )
 

--- a/contrib/log/fluent/go.mod
+++ b/contrib/log/fluent/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/fluent/fluent-logger-golang v1.9.0
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 )
 
 require (

--- a/contrib/log/logrus/go.mod
+++ b/contrib/log/logrus/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/log/logrus/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/sirupsen/logrus v1.8.1
 )
 

--- a/contrib/log/tencent/go.mod
+++ b/contrib/log/tencent/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/log/tencent/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/tencentcloud/tencentcloud-cls-sdk-go v1.0.2
 	google.golang.org/protobuf v1.33.0
 )

--- a/contrib/log/zap/go.mod
+++ b/contrib/log/zap/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/log/zap/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	go.uber.org/zap v1.26.0
 )
 

--- a/contrib/log/zerolog/go.mod
+++ b/contrib/log/zerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/log/zerolog/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/rs/zerolog v1.30.0
 )
 

--- a/contrib/opensergo/go.mod
+++ b/contrib/opensergo/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/opensergo/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/opensergo/opensergo-go v0.0.0-20220331070310-e5b01fee4d1c
 	golang.org/x/net v0.24.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240102182953-50ed04b92917

--- a/contrib/polaris/go.mod
+++ b/contrib/polaris/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/go-kratos/aegis v0.2.0
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/google/uuid v1.4.0
 	github.com/polarismesh/polaris-go v1.3.0
 	google.golang.org/protobuf v1.33.0

--- a/contrib/registry/consul/go.mod
+++ b/contrib/registry/consul/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/consul/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/hashicorp/consul/api v1.26.1
 )
 

--- a/contrib/registry/discovery/go.mod
+++ b/contrib/registry/discovery/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/discovery/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/pkg/errors v0.9.1
 )

--- a/contrib/registry/etcd/go.mod
+++ b/contrib/registry/etcd/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/etcd/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	go.etcd.io/etcd/client/v3 v3.5.11
 	google.golang.org/grpc v1.61.1
 )

--- a/contrib/registry/eureka/go.mod
+++ b/contrib/registry/eureka/go.mod
@@ -2,6 +2,6 @@ module github.com/go-kratos/kratos/contrib/registry/eureka/v2
 
 go 1.19
 
-require github.com/go-kratos/kratos/v2 v2.7.3
+require github.com/go-kratos/kratos/v2 v2.8.0
 
 replace github.com/go-kratos/kratos/v2 => ../../../

--- a/contrib/registry/kubernetes/go.mod
+++ b/contrib/registry/kubernetes/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/kubernetes/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/json-iterator/go v1.1.12
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3

--- a/contrib/registry/nacos/go.mod
+++ b/contrib/registry/nacos/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/nacos/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/nacos-group/nacos-sdk-go v1.0.9
 )
 

--- a/contrib/registry/polaris/go.mod
+++ b/contrib/registry/polaris/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/polaris/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/polarismesh/polaris-go v1.3.0
 )
 

--- a/contrib/registry/zookeeper/go.mod
+++ b/contrib/registry/zookeeper/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kratos/kratos/contrib/registry/zookeeper/v2
 go 1.19
 
 require (
-	github.com/go-kratos/kratos/v2 v2.7.3
+	github.com/go-kratos/kratos/v2 v2.8.0
 	github.com/go-zookeeper/zk v1.0.3
 	golang.org/x/sync v0.7.0
 )

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package kratos
 
 // Release is the current kratos version.
-const Release = "v2.7.3"
+const Release = "v2.8.0"


### PR DESCRIPTION
### Breaking Changes
- break(metrics): refactor kratos metrics with otel metrics (#3256)
### New Features
- feat: parsing config input and convert to match the type (#3306)
### Bug Fixes
- fix(contrib/registry/nacos): Abnormal blocking of the Subscribe and Next methods. (#3320)
- fix(contrib/opensergo): incorrect conversion between integer types (#3309)
- fix(contrib/polaris): incorrect conversion between integer types (#3300)
- fix: com patile both map[kratos] and map.kratos for a map type in the query parameters (#3284)
### Chores
- chore(middleware/metrics): if requests and seconds are nil, return directly (#3298)
### Others
- chroe: chore update (#3367)
- build(deps): bump golang.org/x/net from 0.19.0 to 0.23.0 (#3295)
- build(deps): bump golang.org/x/net in /contrib/registry/servicecomb (#3285)
- build(deps): bump golang.org/x/net in /contrib/config/etcd (#3293)
- adds Set-Cookie method to the HTTP transport. (#3353)
- build(deps): bump actions/setup-go from 5.0.0 to 5.0.1 (#3315)
- build(deps): bump golangci/golangci-lint-action from 5 to 6 (#3340)
- The issue that the response header is not assigned a value is fixed (#3327)
- build(deps): bump golangci/golangci-lint-action from 4 to 5 (#3305)
- faat(encoding/form): allow change the default form encoder and decoder tag name (#3328)
- build(deps): bump github.com/aliyun/aliyun-log-go-sdk (#3332)
- build(deps): bump golang.org/x/net in /contrib/polaris (#3296)
- build(deps): bump Yikun/hub-mirror-action from 1.3 to 1.4 (#3307)
- build(deps): bump google.golang.org/protobuf (#3238)
- build(deps): bump github.com/aliyun/aliyun-log-go-sdk (#3270)
- build(deps): bump golang.org/x/net in /contrib/opensergo (#3277)
- build(deps): bump golang.org/x/sync in /contrib/registry/zookeeper (#3274)
- dep: change library name of mergo #3149 (#3297)
- security: upgrade google.golang.org/protobuf to 1.33.0 (#3264)