### PR TITLE
fix(registry/polaris): fix concurrent map iteration and map write #3361

### DIFF
--- a/contrib/polaris/registry.go
+++ b/contrib/polaris/registry.go
@@ -138,7 +138,7 @@ func (r *Registry) Register(_ context.Context, instance *registry.ServiceInstanc
 					Weight:       &weight,
 					Priority:     &r.opt.Priority,
 					Version:      &instance.Version,
-					Metadata:     instance.Metadata,
+					Metadata:     rmd,
 					Healthy:      &r.opt.Healthy,
 					Isolate:      &r.opt.Isolate,
 					TTL:          &r.opt.TTL,
@@ -380,7 +380,7 @@ func instancesToServiceInstances(instances map[string][]model.Instance) []*regis
 	return serviceInstances
 }
 
-// Clone returns a copy of m.  This is a shallow clone:
+// Clone returns a copy of m. This is a shallow clone:
 // the new keys and values are set using ordinary assignment.
 func mapClone[M ~map[K]V, K comparable, V any](m M) M {
 	// Preserve nil in case it matters.

--- a/contrib/polaris/registry.go
+++ b/contrib/polaris/registry.go
@@ -3,6 +3,7 @@ package polaris
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 	"net/url"
 	"strconv"
@@ -115,15 +116,16 @@ func (r *Registry) Register(_ context.Context, instance *registry.ServiceInstanc
 		}
 
 		// metadata
-		if instance.Metadata == nil {
-			instance.Metadata = make(map[string]string)
+		rmd := maps.Clone(instance.Metadata)
+		if rmd == nil {
+			rmd = make(map[string]string)
 		}
-		instance.Metadata["merge"] = id
-		if _, ok := instance.Metadata["weight"]; !ok {
-			instance.Metadata["weight"] = strconv.Itoa(r.opt.Weight)
+		rmd["merge"] = id
+		if _, ok := rmd["weight"]; !ok {
+			rmd["weight"] = strconv.Itoa(r.opt.Weight)
 		}
 
-		weight, _ := strconv.Atoi(instance.Metadata["weight"])
+		weight, _ := strconv.Atoi(rmd["weight"])
 
 		_, err = r.provider.RegisterInstance(
 			&polaris.InstanceRegisterRequest{

--- a/contrib/polaris/registry.go
+++ b/contrib/polaris/registry.go
@@ -3,7 +3,6 @@ package polaris
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net"
 	"net/url"
 	"strconv"
@@ -116,7 +115,7 @@ func (r *Registry) Register(_ context.Context, instance *registry.ServiceInstanc
 		}
 
 		// metadata
-		rmd := maps.Clone(instance.Metadata)
+		rmd := mapClone(instance.Metadata)
 		if rmd == nil {
 			rmd = make(map[string]string)
 		}
@@ -379,4 +378,19 @@ func instancesToServiceInstances(instances map[string][]model.Instance) []*regis
 		}
 	}
 	return serviceInstances
+}
+
+// Clone returns a copy of m.  This is a shallow clone:
+// the new keys and values are set using ordinary assignment.
+func mapClone[M ~map[K]V, K comparable, V any](m M) M {
+	// Preserve nil in case it matters.
+	if m == nil {
+		return nil
+	}
+	// Make a shallow copy of the map.
+	m2 := make(M, len(m))
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
 }

--- a/contrib/polaris/registry_test.go
+++ b/contrib/polaris/registry_test.go
@@ -2,6 +2,7 @@ package polaris
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -28,6 +29,9 @@ func TestRegistry(t *testing.T) {
 		WithRegistryTTL(1000),
 	)
 
+	mm := map[string]string{
+		"test1": "test1",
+	}
 	ins := &registry.ServiceInstance{
 		ID:      "test-ut",
 		Name:    "test-ut",
@@ -36,7 +40,18 @@ func TestRegistry(t *testing.T) {
 			"grpc://127.0.0.1:8080",
 			"http://127.0.0.1:9090",
 		},
+		Metadata: mm,
 	}
+
+	go func() {
+		for i := 0; true; i++ {
+			str := "test" + strconv.Itoa(i)
+			_ = mm[str]
+			if i > 100 {
+				i = 0
+			}
+		}
+	}()
 
 	err = r.Register(context.Background(), ins)
 


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
fix concurrent map iteration and map write

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
#3361

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
