### PR TITLE
fix: when entering idle mode, the old resolve-related resources have …

### DIFF
--- a/contrib/registry/consul/registry.go
+++ b/contrib/registry/consul/registry.go
@@ -190,7 +190,6 @@ func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, er
 			services:    &atomic.Value{},
 			serviceName: name,
 		}
-		set.ctx, set.cancel = context.WithCancel(context.Background())
 		r.registry[name] = set
 	}
 
@@ -209,10 +208,8 @@ func (r *Registry) Watch(ctx context.Context, name string) (registry.Watcher, er
 		// otherwise the initial data may be blocked forever during the watch.
 		w.event <- struct{}{}
 	}
-	if !ok {
-		if err := r.resolve(set.ctx, set); err != nil {
-			return nil, err
-		}
+	if err := r.resolve(ctx, set); err != nil {
+		return nil, err
 	}
 	return w, nil
 }
@@ -248,9 +245,6 @@ func (r *Registry) resolve(ctx context.Context, ss *serviceSet) error {
 				}
 				idx = tmpIdx
 			case <-ctx.Done():
-				r.lock.Lock()
-				delete(r.registry, ss.serviceName)
-				r.lock.Unlock()
 				return
 			}
 		}

--- a/contrib/registry/consul/registry_test.go
+++ b/contrib/registry/consul/registry_test.go
@@ -432,10 +432,17 @@ func TestRegistry_IdleAndWatch(t *testing.T) {
 		Version:   "v0.0.1",
 		Endpoints: []string{fmt.Sprintf("tcp://%s?isSecure=false", addr)},
 	}
+	instance2 := &registry.ServiceInstance{
+		ID:        "1",
+		Name:      "server-1",
+		Version:   "v0.0.2",
+		Endpoints: []string{fmt.Sprintf("tcp://%s?isSecure=false", addr)},
+	}
 
 	type args struct {
-		ctx      context.Context
-		instance *registry.ServiceInstance
+		ctx            context.Context
+		instance       *registry.ServiceInstance
+		changeInstance *registry.ServiceInstance
 	}
 
 	tests := []struct {
@@ -447,8 +454,9 @@ func TestRegistry_IdleAndWatch(t *testing.T) {
 		{
 			name: "many client, one idle",
 			args: args{
-				ctx:      context.Background(),
-				instance: instance1,
+				ctx:            context.Background(),
+				instance:       instance1,
+				changeInstance: instance2,
 			},
 			want:    []*registry.ServiceInstance{instance1},
 			wantErr: false,
@@ -506,9 +514,7 @@ func TestRegistry_IdleAndWatch(t *testing.T) {
 				}
 			}
 			time.Sleep(2 * time.Second)
-			change := tt.args.instance
-			change.Version = "v0.0.2"
-			err = r.Register(tt.args.ctx, change)
+			err = r.Register(tt.args.ctx, tt.args.changeInstance)
 			if err != nil {
 				t.Error(err)
 			}
@@ -576,7 +582,7 @@ func TestRegistry_IdleAndWatch2(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			for i := 0; i < 10; i++ {
 				stopCtx, stopCancel := context.WithCancel(ctx)
-				watch, err1 := r.Watch(context.Background(), tt.args.instance.Name)
+				watch, err1 := r.Watch(stopCtx, tt.args.instance.Name)
 				if err1 != nil {
 					t.Error(err1)
 				}
@@ -587,10 +593,6 @@ func TestRegistry_IdleAndWatch2(t *testing.T) {
 						t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
 						t.Errorf("GetService() got = %v", service)
 						return
-					}
-					_, err2 = watch.Next()
-					if err2 == nil {
-						t.Errorf("watch exit exception:%d ", i)
 					}
 				}(i)
 				go func() {
@@ -628,6 +630,136 @@ func TestRegistry_IdleAndWatch2(t *testing.T) {
 			}
 			if !reflect.DeepEqual(service, tt.want) {
 				t.Errorf("GetService() got = %v, want %v", service, tt.want)
+			}
+		})
+	}
+}
+
+func TestRegistry_ExitOldResolverAndReWatch(t *testing.T) {
+	addr := fmt.Sprintf("%s:9091", getIntranetIP())
+
+	time.Sleep(time.Millisecond * 100)
+	cli, err := api.NewClient(&api.Config{Address: "127.0.0.1:8500", WaitTime: 2 * time.Second})
+	if err != nil {
+		t.Fatalf("create consul client failed: %v", err)
+	}
+
+	instance1 := &registry.ServiceInstance{
+		ID:        "1",
+		Name:      "server-1",
+		Version:   "v0.0.1",
+		Endpoints: []string{fmt.Sprintf("tcp://%s?isSecure=false", addr)},
+	}
+	instance2 := &registry.ServiceInstance{
+		ID:        "2",
+		Name:      "server-1",
+		Version:   "v0.0.2",
+		Endpoints: []string{fmt.Sprintf("tcp://%s?isSecure=false", addr)},
+	}
+	type args struct {
+		ctx             context.Context
+		opts            []Option
+		instance        *registry.ServiceInstance
+		initialInstance *registry.ServiceInstance
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		want    []*registry.ServiceInstance
+		wantErr bool
+	}{
+		{
+			name: "When it has entered idle mode, but the old resolver has not completely exited, the watch will be re-established due to new requests coming in.",
+			args: args{
+				ctx:             context.Background(),
+				initialInstance: instance1,
+				instance:        instance2,
+				opts: []Option{
+					WithHealthCheck(false),
+					WithTimeout(time.Second * 2),
+				},
+			},
+			want:    []*registry.ServiceInstance{instance2},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := New(cli, tt.args.opts...)
+
+			err = r.Register(tt.args.ctx, tt.args.initialInstance)
+			if err != nil {
+				t.Error(err)
+			}
+			// first watch
+			ctx, cancel := context.WithCancel(context.Background())
+			watch, err := r.Watch(ctx, tt.args.instance.Name)
+			if err != nil {
+				t.Error(err)
+			}
+			service, err := watch.Next()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetService() got = %v", service)
+			}
+
+			time.Sleep(time.Second * 3)
+			// The simulation entered idle mode first, but the old resolver was not closed yet, and new requests triggered a new Watch.
+			watchCtx := context.Background()
+			// old resolver cancel
+			err = watch.Stop()
+			if err != nil {
+				t.Errorf("watch stop err:%v", err)
+			}
+			cancel()
+			// If it sleeps for a period of time, the old resolve goroutine will exit before the new Watch is processed, and there will be no problems at this time.
+			// time.Sleep(time.Second * 8)
+			newWatch, err := r.Watch(watchCtx, tt.args.instance.Name)
+			if err != nil {
+				t.Error(err)
+			}
+			service, err = newWatch.Next()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetService() got = %v", service)
+			}
+			// change register info
+			time.Sleep(time.Second * 1)
+			err = r.Deregister(tt.args.ctx, tt.args.initialInstance)
+			if err != nil {
+				t.Error(err)
+			}
+			time.Sleep(time.Second * 5)
+			err = r.Register(tt.args.ctx, tt.args.instance)
+			if err != nil {
+				t.Error(err)
+			}
+
+			time.Sleep(time.Second * 2)
+
+			newWatchCtx, newWatchCancel := context.WithCancel(context.Background())
+			c := make(chan struct{}, 1)
+
+			go func() {
+				service, err = newWatch.Next()
+				if (err != nil) != tt.wantErr {
+					t.Errorf("GetService() error = %v, wantErr %v", err, tt.wantErr)
+					t.Errorf("GetService() got = %v", service)
+					return
+				}
+				if !reflect.DeepEqual(service, tt.want) {
+					t.Errorf("GetService() got = %v, want %v", service, tt.want)
+				}
+				c <- struct{}{}
+			}()
+			time.AfterFunc(time.Second*10, newWatchCancel)
+			select {
+			case <-newWatchCtx.Done():
+				t.Errorf("Timeout getservice. May be no new resolve goroutine to obtain the latest service information")
+			case <-c:
+				return
 			}
 		})
 	}

--- a/contrib/registry/consul/service.go
+++ b/contrib/registry/consul/service.go
@@ -1,7 +1,6 @@
 package consul
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 
@@ -13,9 +12,6 @@ type serviceSet struct {
 	watcher     map[*watcher]struct{}
 	services    *atomic.Value
 	lock        sync.RWMutex
-
-	ctx    context.Context
-	cancel context.CancelFunc
 }
 
 func (s *serviceSet) broadcast(ss []*registry.ServiceInstance) {

--- a/contrib/registry/consul/watcher.go
+++ b/contrib/registry/consul/watcher.go
@@ -36,9 +36,5 @@ func (w *watcher) Stop() error {
 	w.set.lock.Lock()
 	defer w.set.lock.Unlock()
 	delete(w.set.watcher, w)
-	// close resolve
-	if len(w.set.watcher) == 0 {
-		w.set.cancel()
-	}
 	return nil
 }


### PR DESCRIPTION
…not been completely processed, and an exception occurs when exiting idle mode immediately.

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
![image1](https://github.com/user-attachments/assets/0615ebc1-1c69-4467-9189-026eef4447f8)
![image2](https://github.com/user-attachments/assets/e296be12-b67a-470d-90c6-7f810dec9fe0)
 When grpc quickly enters and exits idle mode, there is a situation where it no longer obtains the latest service information. Previously, it was fixed that when the grpc client enters idle mode, the consul package will no longer watch service information again (https://github.com/go-kratos/kratos/pull/3162). 
 Recently, I found that it was not in idle mode. The target service was updated, but the client service discovery information was not updated. After investigation, it was found that there were problems with the previous modifications. A logic was added before. Every time it enters idle mode, if the number of watch objects in the serviceset reaches 0, it will try to recycle the serviceset. However, there is a certain delay in recycling the serviceset, and it may be blocked by a tick. Please see the code for details. When the serviceset has not been recycled, it will exit the idle mode immediately. When watching again, the resolve method will no longer be called. If the target service is no longer updated in the future, the client will no longer be able to obtain the latest service information because the goroutine for obtaining service information is no longer available.
What was changed?
1. Removed serviceset recycling
2. Added test case for this situation
3. No longer determine whether the serviceset exists before calling resolve.

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
