### PR TITLE
fix(log): GetLogger doesn't returns the same logger that was set before.

### DIFF
--- a/log/global_test.go
+++ b/log/global_test.go
@@ -107,26 +107,26 @@ func TestGlobalContext(t *testing.T) {
 	}
 }
 
-type traceIdKey struct{}
+type tidKey struct{}
 
 func TestValuerUnderGlobalValue(t *testing.T) {
 	defaultLogger := GetLogger()
 	t.Cleanup(func() { SetLogger(defaultLogger) })
 
-	var traceIdValuer Valuer = func(ctx context.Context) any {
-		return ctx.Value(traceIdKey{})
+	var tidValuer Valuer = func(ctx context.Context) any {
+		return ctx.Value(tidKey{})
 	}
 
 	var buf bytes.Buffer
 	l1 := NewStdLogger(&buf)
-	l2 := With(l1, "traceId", traceIdValuer)
+	l2 := With(l1, "traceId", tidValuer)
 
 	SetLogger(l2)
 	l3 := GetLogger()
 
-	ctx := context.WithValue(context.Background(), traceIdKey{}, "123")
+	ctx := context.WithValue(context.Background(), tidKey{}, "123")
 	l4 := WithContext(ctx, l3)
-	l4.Log(LevelInfo, "msg", "m")
+	_ = l4.Log(LevelInfo, "msg", "m")
 
 	want := "INFO traceId=123 msg=m\n"
 	if got := buf.String(); got != want {


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

Let `log.GetLogger` returns its stored value directly.

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

fixes #3417

#### Other special notes for the reviewers:
<!--
* Somethings that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->

Have breaking changes. `GetLogger` not always return the same Logger.
I know there is a function called `Context`. But sometimes we need to use `log.WithContext` to convert a Logger.
