### PR TITLE
fix: various typos

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,6 +35,6 @@ Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue
 
 #### Other special notes for the reviewers:
 <!--
-* Somethings that need extra attention for the reviewers
+* Some things that need extra attention for the reviewers
 * Some additional notes, TODO list, etc.
 -->

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ linters:
   # - nestif
   # - prealloc
   # - testpackage
-  # - stylrcheck
+  # - stylecheck
   # - wsl
 
 linters-settings:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Kratos is accessible, powerful, and provides tools required for large, robust ap
 
 Kratos has the most extensive and thorough [documentation](https://go-kratos.dev/en/docs/getting-started/start) and [example](https://github.com/go-kratos/examples) library of all modern web application frameworks, making it a breeze to get started with the framework.
 
-We also provide a [modern template](https://github.com/go-kratos/kratos-layout). This template should help reduce the work required to setup up modern projects.
+We also provide a [modern template](https://github.com/go-kratos/kratos-layout). This template should help reduce the work required to set up modern projects.
 
 ### Goals
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ This document defines the roadmap for Kratos development.
         - [ ] javascript/typescript clients
     - [x] gRPC
         - [x] TLS
-        - [x] Uarry Handler
+        - [x] Unary Handler
         - [x] Streaming Handler
 - [ ] Cache
     - [ ] go-redis

--- a/cmd/kratos/internal/proto/server/server.go
+++ b/cmd/kratos/internal/proto/server/server.go
@@ -72,7 +72,7 @@ func run(_ *cobra.Command, args []string) {
 		}),
 	)
 	if _, err := os.Stat(targetDir); os.IsNotExist(err) {
-		fmt.Printf("Target directory: %s does not exsit\n", targetDir)
+		fmt.Printf("Target directory: %s does not exist\n", targetDir)
 		return
 	}
 	for _, s := range res {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -185,7 +185,7 @@ func TestDefaultResolver(t *testing.T) {
 				default:
 					actual = v.Load()
 					if !reflect.DeepEqual(test.expect, actual) {
-						t.Logf("expect: %#v, actural: %#v", test.expect, actual)
+						t.Logf("expect: %#v, actual: %#v", test.expect, actual)
 						t.Fail()
 					}
 				}
@@ -343,7 +343,7 @@ func TestNewDefaultResolver(t *testing.T) {
 				default:
 					actual = v.Load()
 					if !reflect.DeepEqual(test.expect, actual) {
-						t.Logf("expect: %#v, actural: %#v", test.expect, actual)
+						t.Logf("expect: %#v, actual: %#v", test.expect, actual)
 						t.Fail()
 					}
 				}

--- a/contrib/config/apollo/README.md
+++ b/contrib/config/apollo/README.md
@@ -1,4 +1,4 @@
-## Apollo config centry
+## Apollo config center
 
 This module implements the `config.Source` interface in kratos based apollo config management center.
 

--- a/contrib/config/kubernetes/README.md
+++ b/contrib/config/kubernetes/README.md
@@ -7,7 +7,7 @@ execute this command:
 ```
 kubectl create clusterrolebinding go-kratos:kube --clusterrole=view --serviceaccount=mesh:default
 ```
-or use `kubect apply -f bind-role.yaml`
+or use `kubectl apply -f bind-role.yaml`
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/contrib/log/aliyun/aliyun.go
+++ b/contrib/log/aliyun/aliyun.go
@@ -102,7 +102,7 @@ func (a *aliyunLog) Log(level log.Level, keyvals ...interface{}) error {
 	return a.producer.SendLog(a.opts.project, a.opts.logstore, "", "", logInst)
 }
 
-// NewAliyunLog new a aliyun logger with options.
+// NewAliyunLog new aliyun logger with options.
 func NewAliyunLog(options ...Option) Logger {
 	opts := defaultOptions()
 	for _, o := range options {

--- a/contrib/registry/kubernetes/registry_test.go
+++ b/contrib/registry/kubernetes/registry_test.go
@@ -150,7 +150,7 @@ func TestRegistry(t *testing.T) {
 
 	os.Setenv("HOSTNAME", pod.Items[0].Name)
 
-	// Alway remember delete test resource
+	// Always remember delete test resource
 	defer func() {
 		_ = clientSet.AppsV1().Deployments(namespace).Delete(context.Background(), deployName, metav1.DeleteOptions{})
 	}()

--- a/encoding/form/form_test.go
+++ b/encoding/form/form_test.go
@@ -237,7 +237,7 @@ func TestDecodeStructPb(t *testing.T) {
 		t.Errorf("except %v, got %v", "kratos", req.Data.GetFields()["name"].GetStringValue())
 	}
 	if len(req.DataList) != 2 {
-		t.Fatalf("execpt %v, got %v", 2, len(req.DataList))
+		t.Fatalf("except %v, got %v", 2, len(req.DataList))
 	}
 	if "kratos" != req.DataList[0].GetFields()["name1"].GetStringValue() {
 		t.Errorf("except %v, got %v", "kratos", req.Data.GetFields()["name1"].GetStringValue())

--- a/encoding/form/proto_decode.go
+++ b/encoding/form/proto_decode.go
@@ -20,7 +20,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-const fieldSeparater = "."
+const fieldSeparator = "."
 
 var errInvalidFormatMapKey = errors.New("invalid formatting for map key")
 
@@ -138,7 +138,7 @@ func populateRepeatedField(fd protoreflect.FieldDescriptor, list protoreflect.Li
 }
 
 func populateMapField(fd protoreflect.FieldDescriptor, mp protoreflect.Map, fieldPath []string, values []string) error {
-	_, keyName, err := parseURLQueryMapKey(strings.Join(fieldPath, fieldSeparater))
+	_, keyName, err := parseURLQueryMapKey(strings.Join(fieldPath, fieldSeparator))
 	if err != nil {
 		return err
 	}
@@ -359,7 +359,7 @@ func parseURLQueryMapKey(key string) (string, string, error) {
 	)
 	if startIndex < 0 {
 		//nolint:mnd
-		values := strings.Split(key, fieldSeparater)
+		values := strings.Split(key, fieldSeparator)
 		//nolint:mnd
 		if len(values) != 2 {
 			return "", "", errInvalidFormatMapKey

--- a/internal/matcher/middleware.go
+++ b/internal/matcher/middleware.go
@@ -17,14 +17,14 @@ type Matcher interface {
 // New new a middleware matcher.
 func New() Matcher {
 	return &matcher{
-		matchs: make(map[string][]middleware.Middleware),
+		matches: make(map[string][]middleware.Middleware),
 	}
 }
 
 type matcher struct {
 	prefix   []string
 	defaults []middleware.Middleware
-	matchs   map[string][]middleware.Middleware
+	matches  map[string][]middleware.Middleware
 }
 
 func (m *matcher) Use(ms ...middleware.Middleware) {
@@ -42,7 +42,7 @@ func (m *matcher) Add(selector string, ms ...middleware.Middleware) {
 			return m.prefix[i] > m.prefix[j]
 		})
 	}
-	m.matchs[selector] = ms
+	m.matches[selector] = ms
 }
 
 func (m *matcher) Match(operation string) []middleware.Middleware {
@@ -50,12 +50,12 @@ func (m *matcher) Match(operation string) []middleware.Middleware {
 	if len(m.defaults) > 0 {
 		ms = append(ms, m.defaults...)
 	}
-	if next, ok := m.matchs[operation]; ok {
+	if next, ok := m.matches[operation]; ok {
 		return append(ms, next...)
 	}
 	for _, prefix := range m.prefix {
 		if strings.HasPrefix(operation, prefix) {
-			return append(ms, m.matchs[prefix]...)
+			return append(ms, m.matches[prefix]...)
 		}
 	}
 	return ms

--- a/log/README.md
+++ b/log/README.md
@@ -8,7 +8,7 @@
 logger := log.NewStdLogger(os.Stdout)
 // fields & valuer
 logger = log.With(logger,
-    "service.name", "hellworld",
+    "service.name", "helloworld",
     "service.version", "v1.0.0",
     "ts", log.DefaultTimestamp,
     "caller", log.DefaultCaller,

--- a/log/filter_test.go
+++ b/log/filter_test.go
@@ -102,7 +102,7 @@ func TestFilterFuncWitchLoggerPrefix(t *testing.T) {
 		want   string
 	}{
 		{
-			logger: NewFilter(With(NewStdLogger(buf), "caller", "caller", "prefix", "whaterver"), FilterFunc(testFilterFuncWithLoggerPrefix)),
+			logger: NewFilter(With(NewStdLogger(buf), "caller", "caller", "prefix", "whatever"), FilterFunc(testFilterFuncWithLoggerPrefix)),
 			want:   "",
 		},
 		{
@@ -168,7 +168,7 @@ func TestFilterWithContext(t *testing.T) {
 	_ = WithContext(ctx, filter).Log(LevelInfo, "kind", "test")
 
 	if info.String() != "" {
-		t.Error("filter is not woring")
+		t.Error("filter is not working")
 		return
 	}
 

--- a/middleware/tracing/metadata.go
+++ b/middleware/tracing/metadata.go
@@ -40,7 +40,7 @@ func (b Metadata) Extract(parent context.Context, carrier propagation.TextMapCar
 	return parent
 }
 
-// Fields returns the keys who's values are set with Inject.
+// Fields returns the keys whose values are set with Inject.
 func (b Metadata) Fields() []string {
 	return []string{serviceHeader}
 }

--- a/third_party/validate/validate.proto
+++ b/third_party/validate/validate.proto
@@ -535,7 +535,7 @@ message StringRules {
     // at a maximum
     optional uint64 max_bytes = 5;
 
-    // Pattern specifes that this field must match against the specified
+    // Pattern specifies that this field must match against the specified
     // regular expression (RE2 syntax). The included expression should elide
     // any delimiters.
     optional string pattern  = 6;
@@ -647,7 +647,7 @@ message BytesRules {
     // at a maximum
     optional uint64 max_len = 3;
 
-    // Pattern specifes that this field must match against the specified
+    // Pattern specifies that this field must match against the specified
     // regular expression (RE2 syntax). The included expression should elide
     // any delimiters.
     optional string pattern  = 4;

--- a/transport/grpc/resolver/discovery/builder.go
+++ b/transport/grpc/resolver/discovery/builder.go
@@ -113,7 +113,7 @@ func (b *builder) Build(target resolver.Target, cc resolver.ClientConn, _ resolv
 		insecure:    b.insecure,
 		debugLog:    b.debugLog,
 		subsetSize:  b.subsetSize,
-		selecterKey: uuid.New().String(),
+		selectorKey: uuid.New().String(),
 	}
 	go r.watch()
 	return r, nil

--- a/transport/grpc/resolver/discovery/resolver.go
+++ b/transport/grpc/resolver/discovery/resolver.go
@@ -24,7 +24,7 @@ type discoveryResolver struct {
 
 	insecure    bool
 	debugLog    bool
-	selecterKey string
+	selectorKey string
 	subsetSize  int
 }
 
@@ -70,7 +70,7 @@ func (r *discoveryResolver) update(ins []*registry.ServiceInstance) {
 		filtered = append(filtered, in)
 	}
 	if r.subsetSize != 0 {
-		filtered = subset.Subset(r.selecterKey, filtered, r.subsetSize)
+		filtered = subset.Subset(r.selectorKey, filtered, r.subsetSize)
 	}
 
 	addrs := make([]resolver.Address, 0, len(filtered))

--- a/transport/http/resolver.go
+++ b/transport/http/resolver.go
@@ -47,7 +47,7 @@ type resolver struct {
 
 	target      *Target
 	watcher     registry.Watcher
-	selecterKey string
+	selectorKey string
 	subsetSize  int
 
 	insecure bool
@@ -66,7 +66,7 @@ func newResolver(ctx context.Context, discovery registry.Discovery, target *Targ
 		watcher:     watcher,
 		rebalancer:  rebalancer,
 		insecure:    insecure,
-		selecterKey: uuid.New().String(),
+		selectorKey: uuid.New().String(),
 		subsetSize:  subsetSize,
 	}
 	if block {
@@ -133,7 +133,7 @@ func (r *resolver) update(services []*registry.ServiceInstance) bool {
 		filtered = append(filtered, ins)
 	}
 	if r.subsetSize != 0 {
-		filtered = subset.Subset(r.selecterKey, filtered, r.subsetSize)
+		filtered = subset.Subset(r.selectorKey, filtered, r.subsetSize)
 	}
 	nodes := make([]selector.Node, 0, len(filtered))
 	for _, ins := range filtered {


### PR DESCRIPTION
Just thought I'd contribute some typo fixes that I stumbled on in the samples area. Nothing controversial (hopefully).

FYI, the typos are:
* selecter (6)
* matchs (5)
* separater (3)
* actural (2)
* specifes (2)
* alway (1)
* uarry (1)
* centry (1)
* execpt (1)
* exsit (1)
* hellworld (1)
* kubect (1)
* stylrcheck (1)
* whaterver (1)
* woring (1)