### PR TITLE
fix: return inner Logger from GetLogger for log.WithContext reuse

### DIFF
--- a/log/global.go
+++ b/log/global.go
@@ -13,7 +13,7 @@ var global = &loggerAppliance{}
 // loggerAppliance is the proxy of `Logger` to
 // make logger change will affect all sub-logger.
 type loggerAppliance struct {
-	lock sync.Mutex
+	lock sync.RWMutex
 	Logger
 }
 
@@ -35,7 +35,9 @@ func SetLogger(logger Logger) {
 
 // GetLogger returns global logger appliance as logger in current process.
 func GetLogger() Logger {
-	return global
+	global.lock.RLock()
+	defer global.lock.RUnlock()
+	return global.Logger
 }
 
 // Log Print log by level and keyvals.

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -121,15 +121,16 @@ func TestGlobalContext(t *testing.T) {
 func TestContextWithGlobalLog(t *testing.T) {
 	buffer := &bytes.Buffer{}
 
+	type traceKey struct{}
 	// set "trace-id" Valuer
 	newLogger := With(NewStdLogger(buffer), "trace-id", Valuer(func(ctx context.Context) interface{} {
-		return ctx.Value("trace-id")
+		return ctx.Value(traceKey{})
 	}))
 
 	SetLogger(newLogger)
 
 	// add value to ctx
-	ctx := context.WithValue(context.Background(), "trace-id", "test-trace-id")
+	ctx := context.WithValue(context.Background(), traceKey{}, "test-trace-id")
 
 	_ = WithContext(ctx, GetLogger()).Log(LevelInfo)
 	if buffer.String() != "INFO trace-id=test-trace-id\n" {

--- a/log/global_test.go
+++ b/log/global_test.go
@@ -117,3 +117,22 @@ func TestGlobalContext(t *testing.T) {
 		t.Errorf("Expected:%s, got:%s", "INFO msg=111", buffer.String())
 	}
 }
+
+func TestContextWithGlobalLog(t *testing.T) {
+	buffer := &bytes.Buffer{}
+
+	// set "trace-id" Valuer
+	newLogger := With(NewStdLogger(buffer), "trace-id", Valuer(func(ctx context.Context) interface{} {
+		return ctx.Value("trace-id")
+	}))
+
+	SetLogger(newLogger)
+
+	// add value to ctx
+	ctx := context.WithValue(context.Background(), "trace-id", "test-trace-id")
+
+	_ = WithContext(ctx, GetLogger()).Log(LevelInfo)
+	if buffer.String() != "INFO trace-id=test-trace-id\n" {
+		t.Errorf("Expected:%s, got:%s", "INFO trace-id=test-trace-id", buffer.String())
+	}
+}


### PR DESCRIPTION
fix: Ensure thread safety by eliminating lock copy in GetLogger

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Some things that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
