### PR TITLE
fix(registry): add timeout validation

### DIFF
--- a/transport/grpc/resolver/discovery/builder.go
+++ b/transport/grpc/resolver/discovery/builder.go
@@ -19,10 +19,12 @@ var ErrWatcherCreateTimeout = errors.New("discovery create watcher overtime")
 // Option is builder option.
 type Option func(o *builder)
 
-// WithTimeout with timeout option.
+// WithTimeout with timeout option. timeout must be greater than 0.
 func WithTimeout(timeout time.Duration) Option {
 	return func(b *builder) {
-		b.timeout = timeout
+		if timeout > 0 {
+			b.timeout = timeout
+		}
 	}
 }
 

--- a/transport/grpc/resolver/discovery/builder_test.go
+++ b/transport/grpc/resolver/discovery/builder_test.go
@@ -107,7 +107,7 @@ func TestBuilder_Build(t *testing.T) {
 		&mockConn{},
 		resolver.BuildOptions{},
 	)
-	if err == nil {
-		t.Errorf("expected error, got %v", err)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
 	}
 }


### PR DESCRIPTION
使用 Consul 做服务发现时，如果 gRPC Client 的 timeout 设置为 0，程序会报错 `discovery create watcher overtime`。

原因是：

1. gRPC Client 会将 `timeout` 传给 discovery；

https://github.com/go-kratos/kratos/blob/861493a20524217061cf329eff0b4e39fb9cbfeb/transport/grpc/client.go#L190-L196

2. discovery 的 `Build` 会因为 `timeout` 为 0，立马超时，得到 `ErrWatcherCreateTimeout` 的错误。

https://github.com/go-kratos/kratos/blob/861493a20524217061cf329eff0b4e39fb9cbfeb/transport/grpc/resolver/discovery/builder.go#L97-L102
