### PR TITLE
Introducing Kratos Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <a href="https://github.com/go-kratos/kratos/blob/main/LICENSE"><img src="https://img.shields.io/github/license/go-kratos/kratos" alt="License"></a>
 <a href="https://github.com/avelino/awesome-go"><img src="https://awesome.re/mentioned-badge.svg" alt="Awesome Go"></a>
 <a href="https://discord.gg/BWzJsUJ"><img src="https://img.shields.io/discord/766619759214854164?label=chat&logo=discord" alt="Discord"></a>
+<a href="https://gurubase.io/g/kratos"><img src="https://img.shields.io/badge/Gurubase-Ask%20Kratos%20Guru-006BFF" alt="Gurubase"></a>
 </p>
 <p align="center">
 <a href="https://www.producthunt.com/posts/go-kratos?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-go-kratos" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=306565&theme=light" alt="Go Kratos - A Go framework for microservices. | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Kratos Guru](https://gurubase.io/g/kratos) has been manually added to Gurubase. Kratos Guru uses the data from this repo and data from the [docs](https://go-kratos.dev/en/docs/) to answer questions by leveraging the LLM.

This PR introduces the "Kratos Guru", showcasing that Kratos now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Kratos Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Kratos documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Kratos Guru in Gurubase, just let us know that's totally fine.
