### PR TITLE
perf(contrib/config/etcd): optimize Next method of etcd watcher

### DIFF
--- a/contrib/config/etcd/watcher.go
+++ b/contrib/config/etcd/watcher.go
@@ -36,8 +36,8 @@ func newWatcher(s *source) *watcher {
 func (w *watcher) Next() ([]*config.KeyValue, error) {
 	select {
 	case resp := <-w.ch:
-		if resp.Err() != nil {
-			return nil, resp.Err()
+		if err := resp.Err(); err != nil {
+			return nil, err
 		}
 		return w.source.Load()
 	case <-w.ctx.Done():


### PR DESCRIPTION
resp.Err is not a straightforward logical execution; it should be avoided from being executed multiple times.