### PR TITLE
fix: Improve server stop handling with graceful shutdowns

### DIFF
--- a/app.go
+++ b/app.go
@@ -41,7 +41,6 @@ func New(opts ...Option) *App {
 		ctx:              context.Background(),
 		sigs:             []os.Signal{syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT},
 		registrarTimeout: 10 * time.Second,
-		stopTimeout:      10 * time.Second,
 	}
 	if id, err := uuid.NewUUID(); err == nil {
 		o.id = id.String()
@@ -98,18 +97,23 @@ func (a *App) Run() error {
 			return err
 		}
 	}
+	octx := NewContext(a.opts.ctx, a)
 	for _, srv := range a.opts.servers {
 		server := srv
 		eg.Go(func() error {
 			<-ctx.Done() // wait for stop signal
-			stopCtx, cancel := context.WithTimeout(NewContext(a.opts.ctx, a), a.opts.stopTimeout)
-			defer cancel()
+			stopCtx := octx
+			if a.opts.stopTimeout > 0 {
+				var cancel context.CancelFunc
+				stopCtx, cancel = context.WithTimeout(stopCtx, a.opts.stopTimeout)
+				defer cancel()
+			}
 			return server.Stop(stopCtx)
 		})
 		wg.Add(1)
 		eg.Go(func() error {
 			wg.Done() // here is to ensure server start has begun running before register, so defer is not needed
-			return server.Start(NewContext(a.opts.ctx, a))
+			return server.Start(octx)
 		})
 	}
 	wg.Wait()

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -1,13 +1,16 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -17,6 +20,7 @@ import (
 	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/internal/matcher"
 	pb "github.com/go-kratos/kratos/v2/internal/testdata/helloworld"
+	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware"
 	"github.com/go-kratos/kratos/v2/transport"
 )
@@ -370,4 +374,131 @@ func TestListener(t *testing.T) {
 	if e, err := s.Endpoint(); err != nil || e == nil {
 		t.Errorf("expect not empty")
 	}
+}
+
+func TestStop(t *testing.T) {
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	tests := []struct {
+		name          string
+		ctx           context.Context
+		cancel        context.CancelFunc
+		wantForceStop bool
+	}{
+		{
+			name:          "normal",
+			ctx:           context.Background(),
+			cancel:        func() {},
+			wantForceStop: false,
+		},
+		{
+			name:          "timeout",
+			ctx:           timeoutCtx,
+			cancel:        cancel,
+			wantForceStop: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, err := net.Listen("tcp", ":0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer l.Close()
+
+			old := log.GetLogger()
+			defer log.SetLogger(old)
+
+			// Create a logger to capture logs
+			var logs safeBytesBuffer
+			log.SetLogger(log.NewStdLogger(&logs))
+
+			s := NewServer(Listener(l))
+			pb.RegisterGreeterServer(s, &server{})
+
+			go func() {
+				err := s.Start(context.Background()) //nolint
+				if err != nil {
+					log.Fatal(err)
+				}
+			}()
+
+			time.Sleep(100 * time.Millisecond)
+
+			conn, err := DialInsecure(
+				context.Background(),
+				WithEndpoint(l.Addr().String()),
+				WithOptions(grpc.WithBlock()),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+
+			go func() {
+				client := pb.NewGreeterClient(conn)
+				if tt.wantForceStop {
+					// Simulate a long-running request
+					s, err := client.SayHelloStream(context.Background()) //nolint
+					if err != nil {
+						log.Fatal(err)
+					}
+					// Keep the stream open
+					for {
+						// Intentionally do not send messages, only receive messages
+						_, err := s.Recv()
+						if err != nil {
+							if errors.Is(err, io.EOF) {
+								log.Error(err)
+								break
+							}
+						}
+					}
+				} else {
+					_, err := client.SayHello(context.Background(), &pb.HelloRequest{Name: "test"}) //nolint
+					if err != nil {
+						log.Error(err)
+					}
+				}
+			}()
+
+			time.Sleep(100 * time.Millisecond)
+
+			err = s.Stop(tt.ctx)
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+				return
+			}
+
+			// Check if the stop was forced or graceful
+			if tt.wantForceStop {
+				if !strings.Contains(logs.String(), "force stop") {
+					t.Errorf("Expected force stop\n%s", logs.String())
+				}
+			} else {
+				if strings.Contains(logs.String(), "force stop") {
+					t.Errorf("Expected graceful stop\n%s", logs.String())
+				}
+			}
+		})
+	}
+}
+
+type safeBytesBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBytesBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBytesBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/transport/grpc/server_test.go
+++ b/transport/grpc/server_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
 	"reflect"
@@ -450,10 +449,7 @@ func TestStop(t *testing.T) {
 						// Intentionally do not send messages, only receive messages
 						_, err := s.Recv()
 						if err != nil {
-							if errors.Is(err, io.EOF) {
-								log.Error(err)
-								break
-							}
+							break
 						}
 					}
 				} else {

--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -343,7 +343,14 @@ func (s *Server) Start(ctx context.Context) error {
 // Stop stop the HTTP server.
 func (s *Server) Stop(ctx context.Context) error {
 	log.Info("[HTTP] server stopping")
-	return s.Shutdown(ctx)
+	err := s.Shutdown(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			log.Warn("[HTTP] server couldn't stop gracefully in time, doing force stop")
+			err = s.Server.Close()
+		}
+	}
+	return err
 }
 
 func (s *Server) listenAndEndpoint() error {


### PR DESCRIPTION
参考 gRPC 官方示例，当 Server 未能及时优雅退出时，执行强制退出。

https://github.com/grpc/grpc-go/blob/2fd426d0919db7e9e7920e365dd30674c4c9fe90/examples/features/gracefulstop/server/main.go#L89-L100
