### PR TITLE
fix: premature return when toType=true and multiple replacements exist

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -181,14 +181,16 @@ func convertToType(input string) interface{} {
 func expand(s string, mapping func(string) string, toType bool) interface{} {
 	r := regexp.MustCompile(`\${(.*?)}`)
 	re := r.FindAllStringSubmatch(s, -1)
-	var ct interface{}
+
+	// Convert to type if the string is a single `${VAR}` placeholder.
+	if toType && len(re) == 1 && regexp.MustCompile(`^\${(.*?)}$`).MatchString(s) {
+		m := mapping(re[0][1])
+		return convertToType(m)
+	}
+
 	for _, i := range re {
 		if len(i) == 2 { //nolint:mnd
 			m := mapping(i[1])
-			if toType {
-				ct = convertToType(m)
-				return ct
-			}
 			s = strings.ReplaceAll(s, i[0], m)
 		}
 	}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -67,6 +67,7 @@ func TestDefaultResolver(t *testing.T) {
 				"value2": "$PORT",
 				"value3": "abc${PORT}foo${COUNT}bar",
 				"value4": "${foo${bar}}",
+				"url_with_port": "${URL:http://example.com}:8080",
 			},
 		},
 		"test": map[string]interface{}{
@@ -143,6 +144,11 @@ func TestDefaultResolver(t *testing.T) {
 			name:   "test ${foo${bar}}",
 			path:   "foo.bar.value4",
 			expect: "}",
+		},
+		{
+			name:   "test ${URL:http://example.com}:8080",
+			path:   "foo.bar.url_with_port",
+			expect: "http://example.com:8080",
 		},
 	}
 
@@ -224,6 +230,7 @@ func TestNewDefaultResolver(t *testing.T) {
 				"value2": "$PORT",
 				"value3": "abc${PORT}foo${COUNT}bar",
 				"value4": "${foo${bar}}",
+				"url_with_port": "${URL:http://example.com}:8080",
 			},
 		},
 		"test": map[string]interface{}{
@@ -300,6 +307,11 @@ func TestNewDefaultResolver(t *testing.T) {
 			name:   "test ${foo${bar}}",
 			path:   "foo.bar.value4",
 			expect: "",
+		},
+		{
+			name:   "test ${URL:http://example.com}:8080",
+			path:   "foo.bar.url_with_port",
+			expect: "http://example.com:8080",
 		},
 	}
 


### PR DESCRIPTION
####  Description (What this PR does / Why we need it)
This PR fixes an issue where the expand function would return prematurely when toType=true and multiple ${VAR} placeholders exist in the input string.