### PR TITLE
fix:(contrib/registry/consul)consul Watch.Next 在没有服务实例时不生效的问题

### DIFF
--- a/contrib/registry/consul/registry.go
+++ b/contrib/registry/consul/registry.go
@@ -262,7 +262,7 @@ func (r *Registry) resolve(ctx context.Context, ss *serviceSet) error {
 					}
 					continue
 				}
-				if len(tmpService) != 0 && tmpIdx != idx {
+				if tmpIdx != idx {
 					services = tmpService
 					ss.broadcast(services)
 				}

--- a/contrib/registry/consul/registry_test.go
+++ b/contrib/registry/consul/registry_test.go
@@ -391,7 +391,7 @@ func TestRegistry_Watch(t *testing.T) {
 				opts: []Option{
 					WithHeartbeat(true),
 					WithHealthCheck(true),
-					WithHealthCheckInterval(5),
+					WithHealthCheckInterval(1),
 				},
 			},
 			want:    []*registry.ServiceInstance{instance3},


### PR DESCRIPTION
原情况：在最后一个服务实例下线时没有触发 Watch.Next
修改后：最后一个实例下线时正常触发Watch.Next