### PR TITLE
refactor: replace repeated error reasons with constants

### DIFF
--- a/contrib/middleware/validate/validate.go
+++ b/contrib/middleware/validate/validate.go
@@ -20,14 +20,14 @@ func ProtoValidate() middleware.Middleware {
 		return func(ctx context.Context, req any) (reply any, err error) {
 			if msg, ok := req.(proto.Message); ok {
 				if err := protovalidate.Validate(msg); err != nil {
-					return nil, errors.BadRequest("VALIDATOR", err.Error()).WithCause(err)
+					return nil, errors.BadRequest(errors.ValidatorReason, err.Error()).WithCause(err)
 				}
 			}
 
 			// to compatible with the [old validator](https://github.com/envoyproxy/protoc-gen-validate)
 			if v, ok := req.(validator); ok {
 				if err := v.Validate(); err != nil {
-					return nil, errors.BadRequest("VALIDATOR", err.Error()).WithCause(err)
+					return nil, errors.BadRequest(errors.ValidatorReason, err.Error()).WithCause(err)
 				}
 			}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,11 @@ const (
 	UnknownCode = 500
 	// UnknownReason is unknown reason for error info.
 	UnknownReason = ""
+	// ValidatorReason indicates an error related to request validation.
+	ValidatorReason = "VALIDATOR"
+	// CodecReason indicates an error related to encoding/decoding.
+	CodecReason = "CODEC"
+
 	// SupportPackageIsVersion1 this constant should not be referenced by any other code.
 	SupportPackageIsVersion1 = true
 )

--- a/middleware/validate/validate.go
+++ b/middleware/validate/validate.go
@@ -19,7 +19,7 @@ func Validator() middleware.Middleware {
 		return func(ctx context.Context, req any) (reply any, err error) {
 			if v, ok := req.(validator); ok {
 				if err := v.Validate(); err != nil {
-					return nil, errors.BadRequest("VALIDATOR", err.Error()).WithCause(err)
+					return nil, errors.BadRequest(errors.ValidatorReason, err.Error()).WithCause(err)
 				}
 			}
 			return handler(ctx, req)

--- a/transport/http/binding/bind.go
+++ b/transport/http/binding/bind.go
@@ -12,7 +12,7 @@ import (
 // BindQuery bind vars parameters to target.
 func BindQuery(vars url.Values, target any) error {
 	if err := encoding.GetCodec(form.Name).Unmarshal([]byte(vars.Encode()), target); err != nil {
-		return errors.BadRequest("CODEC", err.Error())
+		return errors.BadRequest(errors.CodecReason, err.Error())
 	}
 	return nil
 }
@@ -23,7 +23,7 @@ func BindForm(req *http.Request, target any) error {
 		return err
 	}
 	if err := encoding.GetCodec(form.Name).Unmarshal([]byte(req.Form.Encode()), target); err != nil {
-		return errors.BadRequest("CODEC", err.Error())
+		return errors.BadRequest(errors.CodecReason, err.Error())
 	}
 	return nil
 }

--- a/transport/http/binding/bind_test.go
+++ b/transport/http/binding/bind_test.go
@@ -49,7 +49,7 @@ func TestBindQuery(t *testing.T) {
 				vars:   map[string][]string{"age": {"kratos"}, "url": {"https://go-kratos.dev/"}},
 				target: &TestBind2{},
 			},
-			err: kratoserror.BadRequest("CODEC", "Field Namespace:age ERROR:Invalid Integer Value 'kratos' Type 'int' Namespace 'age'"),
+			err: kratoserror.BadRequest(kratoserror.CodecReason, "Field Namespace:age ERROR:Invalid Integer Value 'kratos' Type 'int' Namespace 'age'"),
 		},
 		{
 			name: "test2",
@@ -118,7 +118,7 @@ func TestBindForm(t *testing.T) {
 				},
 				target: &TestBind2{},
 			},
-			err:  kratoserror.BadRequest("CODEC", "Field Namespace:age ERROR:Invalid Integer Value 'a' Type 'int' Namespace 'age'"),
+			err:  kratoserror.BadRequest(kratoserror.CodecReason, "Field Namespace:age ERROR:Invalid Integer Value 'a' Type 'int' Namespace 'age'"),
 			want: nil,
 		},
 	}

--- a/transport/http/codec.go
+++ b/transport/http/codec.go
@@ -61,7 +61,7 @@ func DefaultRequestQuery(r *http.Request, v any) error {
 func DefaultRequestDecoder(r *http.Request, v any) error {
 	codec, ok := CodecForRequest(r, "Content-Type")
 	if !ok {
-		return errors.BadRequest("CODEC", fmt.Sprintf("unregister Content-Type: %s", r.Header.Get("Content-Type")))
+		return errors.BadRequest(errors.CodecReason, fmt.Sprintf("unregister Content-Type: %s", r.Header.Get("Content-Type")))
 	}
 	data, err := io.ReadAll(r.Body)
 
@@ -69,13 +69,13 @@ func DefaultRequestDecoder(r *http.Request, v any) error {
 	r.Body = io.NopCloser(bytes.NewBuffer(data))
 
 	if err != nil {
-		return errors.BadRequest("CODEC", err.Error())
+		return errors.BadRequest(errors.CodecReason, err.Error())
 	}
 	if len(data) == 0 {
 		return nil
 	}
 	if err = codec.Unmarshal(data, v); err != nil {
-		return errors.BadRequest("CODEC", fmt.Sprintf("body unmarshal %s", err.Error()))
+		return errors.BadRequest(errors.CodecReason, fmt.Sprintf("body unmarshal %s", err.Error()))
 	}
 	return nil
 }


### PR DESCRIPTION
This refactor replaces multiple occurrences of the "VALIDATOR" and "CODEC" error reason literals with defined constants. This improves code maintainability by reducing duplication, making it easier to update and preventing potential inconsistencies in the future.