### PR TITLE
feat(errors): add context support and i18n functionality

### DIFF
--- a/cmd/protoc-gen-go-errors/errors.go
+++ b/cmd/protoc-gen-go-errors/errors.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	errorsPackage = protogen.GoImportPath("github.com/go-kratos/kratos/v2/errors")
-	fmtPackage    = protogen.GoImportPath("fmt")
+	errorsPackage  = protogen.GoImportPath("github.com/go-kratos/kratos/v2/errors")
+	fmtPackage     = protogen.GoImportPath("fmt")
+	contextPackage = protogen.GoImportPath("context")
 )
 
 var enCases = cases.Title(language.AmericanEnglish, cases.NoLower)
@@ -32,6 +33,7 @@ func generateFile(gen *protogen.Plugin, file *protogen.File) *protogen.Generated
 	g.P()
 	g.P("package ", file.GoPackageName)
 	g.P()
+	g.QualifiedGoIdent(contextPackage.Ident(""))
 	g.QualifiedGoIdent(fmtPackage.Ident(""))
 	generateFileContent(gen, file, g)
 	return g

--- a/cmd/protoc-gen-go-errors/errorsTemplate.tpl
+++ b/cmd/protoc-gen-go-errors/errorsTemplate.tpl
@@ -14,4 +14,11 @@ func Error{{ .CamelValue }}(format string, args ...interface{}) *errors.Error {
 	 return errors.New({{ .HTTPCode }}, {{ .Name }}_{{ .Value }}.String(), fmt.Sprintf(format, args...))
 }
 
+func Error{{ .CamelValue }}WithContext(ctx context.Context, args ...interface{}) *errors.Error {
+     if len(args) == 0 {
+          return errors.NewWithContext(ctx, {{ .HTTPCode }}, {{ .Name }}_{{ .Value }}.String(), "")
+     }
+	 return errors.NewWithContext(ctx, {{ .HTTPCode }}, {{ .Name }}_{{ .Value }}.String(), args[0])
+}
+
 {{- end }}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -66,6 +67,22 @@ func (e *Error) GRPCStatus() *status.Status {
 
 // New returns an error object for the code, message.
 func New(code int, reason, message string) *Error {
+	return &Error{
+		Status: Status{
+			Code:    int32(code),
+			Message: message,
+			Reason:  reason,
+		},
+	}
+}
+
+// NewWithContext Use context to create error objects and support i18n localization
+func NewWithContext(ctx context.Context, code int, reason string, data any) *Error {
+	message := ""
+	// If the global i18n manager is registered, it is used to localize the error message
+	if globalI18n != nil {
+		message = globalI18n.Localize(ctx, reason, data)
+	}
 	return &Error{
 		Status: Status{
 			Code:    int32(code),

--- a/errors/i18n.go
+++ b/errors/i18n.go
@@ -1,0 +1,23 @@
+package errors
+
+import (
+	"context"
+	"sync"
+)
+
+// I18nMessage An interface to internationalize error messages is defined
+type I18nMessage interface {
+	// Localize Localization of error causes based on context and data
+	Localize(ctx context.Context, reason string, data any) string
+}
+
+// The global i18n manager
+var globalI18n I18nMessage
+var globalI18nOnce sync.Once
+
+// RegisterI18nManager Register the global i18n manager
+func RegisterI18nManager(i18n I18nMessage) {
+	globalI18nOnce.Do(func() {
+		globalI18n = i18n
+	})
+}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
error adds context support and i18n functionality

- Add context package import to errors.go
- Generate ErrorWithContext function in errorsTemplate.tpl
- Implement NewWithContext function in errors/errors.go
- Create i18n.go to handle internationalization
- Add RegisterI18nManager function for global i18n manager
- Add unit tests for NewWithContext function

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->
resolves #3619

