### PR TITLE
feat(transport): add Response method to Transport HTTP

### DIFF
--- a/middleware/tracing/tracing_test.go
+++ b/middleware/tracing/tracing_test.go
@@ -3,6 +3,7 @@ package tracing
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"testing"
@@ -71,6 +72,9 @@ func (tr *mockTransport) Request() *http.Request {
 	return tr.request
 }
 func (tr *mockTransport) PathTemplate() string { return "" }
+func (tr *mockTransport) Response() http.ResponseWriter {
+	return httptest.NewRecorder()
+}
 
 func TestTracer(t *testing.T) {
 	carrier := headerCarrier{}

--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -14,6 +14,7 @@ type Transporter interface {
 	transport.Transporter
 	Request() *http.Request
 	PathTemplate() string
+	Response() http.ResponseWriter
 }
 
 // Transport is an HTTP transport.
@@ -50,6 +51,11 @@ func (tr *Transport) Request() *http.Request {
 // RequestHeader returns the request header.
 func (tr *Transport) RequestHeader() transport.Header {
 	return tr.reqHeader
+}
+
+// Response returns the HTTP response.
+func (tr *Transport) Response() http.ResponseWriter {
+	return tr.response
 }
 
 // ReplyHeader returns the reply header.

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -50,6 +50,14 @@ func TestTransport_RequestHeader(t *testing.T) {
 	}
 }
 
+func TestTransport_Response(t *testing.T) {
+	v := http.ResponseWriter(nil)
+	o := &Transport{response: v}
+	if !reflect.DeepEqual(v, o.Response()) {
+		t.Errorf("expect %v, got %v", v, o.Request())
+	}
+}
+
 func TestTransport_ReplyHeader(t *testing.T) {
 	v := headerCarrier{}
 	v.Set("a", "1")


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

- Add Response method to Transport interface in transport/http/transport.go
- Implement Response method in Transport struct
- Add test for Response method in transport/http/transport_test.go
- Implement Response method in mockTransport for testing purposes


Example:

HTTP and gRPC server code generated by Protobuf, where HTTP supports file downloads and gRPC retrieves file data.

```proto
syntax = "proto3";

package demo.v1;

import "google/api/annotations.proto";

option go_package = "demo/api/demo/v1;v1";

service Demo {
  rpc Download(DownloadReq) returns (DownloadResp) {
    option (google.api.http) = {
      get : "api/v1/download"
    };
  }
}

message DownloadReq {
}

message DownloadResp {
  bytes data = 1;
}

```

```go
func (s *Service) Download(ctx context.Context, in *v1.DownloadReq) (*v1.DownloadResp, error) {
	f := excelize.NewFile()
	index, err := f.NewSheet("Sheet2")
	if err != nil {
		return nil, err
	}

	f.SetCellValue("Sheet2", "A2", "Hello world.")
	f.SetCellValue("Sheet1", "B2", 100)
	f.SetActiveSheet(index)

	if tr, ok := transport.FromServerContext(ctx); ok {
		if tr.Kind() == transport.KindHTTP {
			h := tr.(*http.Transport)
			disposition := fmt.Sprintf("attachment; filename=%s", "demo.xlsx")
			h.ReplyHeader().Set("Content-Type", "application/octet-stream")
			h.ReplyHeader().Set("Content-Disposition", disposition)
			h.ReplyHeader().Set("Access-Control-Expose-Headers", "Content-Disposition")

                         // get response obj
			if err := f.Write(h.Response()); err != nil {
				return nil, err
			}

			return nil, nil
		}
		if tr.Kind() == transport.KindGRPC {
			buffer, err := f.WriteToBuffer()
			if err != nil {
				s.log.ErrorContext(ctx, err.Error())
				return nil, err
			}
			return &v1.DownloadResp{Data: buffer.Bytes()}, nil
		}
	}

	return nil, errors.New("transport kind error")
}

```

#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Some things that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
