### PR TITLE
fix(contrib/registry/consul): validate port in consul Register

### DIFF
--- a/contrib/registry/consul/client.go
+++ b/contrib/registry/consul/client.go
@@ -38,7 +38,7 @@ type Client struct {
 	heartbeat bool
 	// deregisterCriticalServiceAfter time interval in seconds
 	deregisterCriticalServiceAfter int
-	// serviceChecks  user custom checks
+	// serviceChecks user custom checks
 	serviceChecks api.AgentServiceChecks
 
 	// used to control heartbeat
@@ -161,7 +161,10 @@ func (c *Client) Register(ctx context.Context, svc *registry.ServiceInstance, en
 			return err
 		}
 		addr := raw.Hostname()
-		port, _ := strconv.ParseUint(raw.Port(), 10, 16)
+		port, err := strconv.ParseUint(raw.Port(), 10, 16)
+		if err != nil || port == 0 {
+			return fmt.Errorf("invalid port in endpoint: %q", endpoint)
+		}
 
 		checkAddresses = append(checkAddresses, net.JoinHostPort(addr, strconv.FormatUint(port, 10)))
 		addresses[raw.Scheme] = api.ServiceAddress{Address: endpoint, Port: int(port)}
@@ -175,7 +178,7 @@ func (c *Client) Register(ctx context.Context, svc *registry.ServiceInstance, en
 	}
 	if len(checkAddresses) > 0 {
 		host, portRaw, _ := net.SplitHostPort(checkAddresses[0])
-		port, _ := strconv.ParseInt(portRaw, 10, 32)
+		port, _ := strconv.ParseUint(portRaw, 10, 16)
 		asr.Address = host
 		asr.Port = int(port)
 	}


### PR DESCRIPTION
This PR addresses an issue where the port parsed from the endpoint using `raw, err := url.Parse(endpoint)` and `raw.Port()` was not being validated properly. Although `raw.Port()` extracts the port from the URL, it does not guarantee that the port is valid or within the legal range (0-65535). This fix ensures that the port is parsed and checked to fall within the valid range and is not zero, preventing invalid service registration.