### PR TITLE
perf(config/env): use strings.LastIndexByte instead of strings.LastIndex

### DIFF
--- a/config/file/format.go
+++ b/config/file/format.go
@@ -3,7 +3,7 @@ package file
 import "strings"
 
 func format(name string) string {
-	if idx := strings.LastIndex(name, "."); idx >= 0 {
+	if idx := strings.LastIndexByte(name, '.'); idx >= 0 {
 		return name[idx+1:]
 	}
 	return ""

--- a/config/file/format_test.go
+++ b/config/file/format_test.go
@@ -49,3 +49,9 @@ func TestFormat(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkFormat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		format("abc.txt")
+	}
+}

--- a/config/file/format_test.go
+++ b/config/file/format_test.go
@@ -22,6 +22,10 @@ func TestFormat(t *testing.T) {
 			expect: "",
 		},
 		{
+			input:  "a",
+			expect: "",
+		},
+		{
 			input:  "a.",
 			expect: "",
 		},
@@ -32,6 +36,10 @@ func TestFormat(t *testing.T) {
 		{
 			input:  "a.b",
 			expect: "b",
+		},
+		{
+			input:  "a.b.c",
+			expect: "c",
 		},
 	}
 	for _, v := range tests {


### PR DESCRIPTION
`strings.LastIndexByte` offers better performance than `strings.LastIndex`.
