### PR TITLE
perf(log): optimize key-value pair processing in Filter.Log

### DIFF
--- a/log/filter.go
+++ b/log/filter.go
@@ -80,7 +80,7 @@ func (f *Filter) Log(level Level, keyvals ...any) error {
 		for i := 0; i < len(keyvals); i += 2 {
 			v := i + 1
 			if v >= len(keyvals) {
-				continue
+				break
 			}
 			if _, ok := f.key[keyvals[i]]; ok {
 				keyvals[v] = fuzzyStr


### PR DESCRIPTION
When keyvals length is odd, break saves one unnecessary loop condition check compared to continue.