### PR TITLE
fix(all): replace strconv.Itoa with strconv.FormatInt for int64 handling

### DIFF
--- a/contrib/registry/discovery/discovery_helper.go
+++ b/contrib/registry/discovery/discovery_helper.go
@@ -115,7 +115,7 @@ func toServiceInstance(ins *discoveryInstance) *registry.ServiceInstance {
 	md := map[string]string{
 		"region":   ins.Region,
 		"zone":     ins.Zone,
-		"lastTs":   strconv.Itoa(int(ins.LastTs)),
+		"lastTs":   strconv.FormatInt(ins.LastTs, 10),
 		"env":      ins.Env,
 		"hostname": ins.Hostname,
 	}

--- a/contrib/registry/nacos/registry.go
+++ b/contrib/registry/nacos/registry.go
@@ -203,7 +203,7 @@ func (r *Registry) GetService(_ context.Context, serviceName string) ([]*registr
 			Metadata:  in.Metadata,
 			Endpoints: []string{fmt.Sprintf("%s://%s:%d", kind, in.Ip, in.Port)},
 		}
-		r.Metadata["weight"] = strconv.Itoa(int(math.Ceil(weight)))
+		r.Metadata["weight"] = strconv.FormatInt(int64(math.Ceil(weight)), 10)
 		items = append(items, r)
 	}
 	return items, nil


### PR DESCRIPTION
Replaced instances of strconv.Itoa(int(a)) with strconv.FormatInt(a, 10) to safely handle int64 values. 
Using strconv.Itoa with int64 risks overflow on 32-bit systems when the value exceeds the maximum range of int32.  
Although 32-bit operating systems are rare in modern devices.