### PR TITLE
perf(metadata):  avoid redundant strings.ToLower call in Metadata.Add

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -26,11 +26,12 @@ func New(mds ...map[string][]string) Metadata {
 
 // Add adds the key, value pair to the header.
 func (m Metadata) Add(key, value string) {
-	if len(key) == 0 {
+	if key == "" {
 		return
 	}
 
-	m[strings.ToLower(key)] = append(m[strings.ToLower(key)], value)
+	lowerKey := strings.ToLower(key)
+	m[lowerKey] = append(m[lowerKey], value)
 }
 
 // Get returns the value associated with the passed key.


### PR DESCRIPTION
This PR introduces a performance optimization to the `Metadata.Add` method.  
The original implementation calls `strings.ToLower(key)` twice, which is redundant.  
The optimized version calls it once and reuses the result, improving both clarity and performance.

### Before

```go
func (m Metadata) Add(key, value string) {
	if len(key) == 0 {
		return
	}
	
	m[strings.ToLower(key)] = append(m[strings.ToLower(key)], value)
}
```

### After
```go
func (m Metadata) AddOptimized(key, value string) {
	if key == "" {
		return
	}
	
	lowerKey := strings.ToLower(key)
	m[lowerKey] = append(m[lowerKey], value)
}
```

### Benchmark
```go
func BenchmarkAdd(b *testing.B) {
	kvs := map[string]string{
		"key0": "value0",
		"key1": "value1",
		"key2": "value2",
		"key3": "value3",
	}

	b.Run("original", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			m := Metadata{"hello": {"kratos"}, "env": {"dev"}}
			for k, v := range kvs {
				m.Add(k, v)
			}
		}
	})

	b.Run("optimized", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			m := Metadata{"hello": {"kratos"}, "env": {"dev"}}
			for k, v := range kvs {
				m.AddOptimized(k, v)
			}
		}
	})
}
```

### Benchmark results
```text
goos: darwin
goarch: amd64
pkg: testgolang/kratos/metadata
cpu: Intel(R) Core(TM) i7-8569U CPU @ 2.80GHz
BenchmarkAdd
BenchmarkAdd/original
BenchmarkAdd/original-8         	 2616540	       436.4 ns/op
BenchmarkAdd/optimized
BenchmarkAdd/optimized-8        	 3153590	       347.8 ns/op
PASS

Process finished with the exit code 0
```