### PR TITLE
perf(transport/http/binding): optimize EncodeURL performance for paths without placeholders

### DIFF
--- a/transport/http/binding/encode.go
+++ b/transport/http/binding/encode.go
@@ -3,6 +3,7 @@ package binding
 import (
 	"reflect"
 	"regexp"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 
@@ -16,17 +17,24 @@ func EncodeURL(pathTemplate string, msg any, needQuery bool) string {
 	if msg == nil || (reflect.ValueOf(msg).Kind() == reflect.Ptr && reflect.ValueOf(msg).IsNil()) {
 		return pathTemplate
 	}
+
 	queryParams, _ := form.EncodeValues(msg)
 	pathParams := make(map[string]struct{})
-	path := reg.ReplaceAllStringFunc(pathTemplate, func(in string) string {
-		// it's unreachable because the reg means that must have more than one char in {}
-		// if len(in) < 4 { //nolint:mnd // **  explain the 4 number here :-) **
-		//	return in
-		// }
-		key := in[1 : len(in)-1]
-		pathParams[key] = struct{}{}
-		return queryParams.Get(key)
-	})
+	var path string
+	if strings.ContainsRune(pathTemplate, '{') {
+		path = reg.ReplaceAllStringFunc(pathTemplate, func(in string) string {
+			// it's unreachable because the reg means that must have more than one char in {}
+			// if len(in) < 4 { //nolint:mnd // **  explain the 4 number here :-) **
+			//	return in
+			// }
+			key := in[1 : len(in)-1]
+			pathParams[key] = struct{}{}
+			return queryParams.Get(key)
+		})
+	} else {
+		path = pathTemplate
+	}
+
 	if !needQuery {
 		if v, ok := msg.(proto.Message); ok {
 			if query := form.EncodeFieldMask(v.ProtoReflect()); query != "" {

--- a/transport/http/binding/encode_test.go
+++ b/transport/http/binding/encode_test.go
@@ -125,3 +125,64 @@ func TestEncodeURL(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkEncodeURL(b *testing.B) {
+	benchmarks := []struct {
+		name         string
+		pathTemplate string
+		msg          *binding.HelloRequest
+		needQuery    bool
+	}{
+		{
+			name:         "NoParams",
+			pathTemplate: "http://helloworld.Greeter/helloworld/sub",
+			msg: &binding.HelloRequest{
+				Name: "test",
+				Sub:  &binding.Sub{Name: "kratos"},
+			},
+			needQuery: false,
+		},
+		{
+			name:         "NoParamsWithQuery",
+			pathTemplate: "http://helloworld.Greeter/helloworld/sub",
+			msg: &binding.HelloRequest{
+				Name: "test",
+				Sub:  &binding.Sub{Name: "kratos"},
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "sub.naming"},
+				},
+			},
+			needQuery: true,
+		},
+		{
+			name:         "WithParams",
+			pathTemplate: "http://helloworld.Greeter/helloworld/{name}/sub/{sub.naming}",
+			msg: &binding.HelloRequest{
+				Name: "test",
+				Sub:  &binding.Sub{Name: "kratos"},
+			},
+			needQuery: false,
+		},
+		{
+			name:         "WithParamsAndQuery",
+			pathTemplate: "http://helloworld.Greeter/helloworld/{name}/sub/{sub.naming}",
+			msg: &binding.HelloRequest{
+				Name: "test",
+				Sub:  &binding.Sub{Name: "kratos"},
+				UpdateMask: &fieldmaskpb.FieldMask{
+					Paths: []string{"name", "sub.naming"},
+				},
+			},
+			needQuery: true,
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				EncodeURL(bm.pathTemplate, bm.msg, bm.needQuery)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a fast path check using strings.ContainsRune() to avoid unnecessary regex 
processing when the path template contains no placeholders (e.g. {name}, {sub.naming}). 
This optimization improves performance by ~7.7% and reduces memory allocations by 3 
for paths without placeholders, while maintaining similar performance for paths with 
placeholders.

Benchmark results:
NoParams case (path without placeholders):
- Before: 778.7 ns/op, 893 B/op, 20 allocs/op
- After:  718.9 ns/op, 768 B/op, 17 allocs/op

## test code
### original encode.go
```go
package binding

import (
	"reflect"
	"regexp"

	"google.golang.org/protobuf/proto"

	"github.com/go-kratos/kratos/v2/encoding/form"
)

var reg = regexp.MustCompile(`{[\\.\w]+}`)

// EncodeURL encode proto message to url path.
func EncodeURL(pathTemplate string, msg any, needQuery bool) string {
	if msg == nil || (reflect.ValueOf(msg).Kind() == reflect.Ptr && reflect.ValueOf(msg).IsNil()) {
		return pathTemplate
	}
	queryParams, _ := form.EncodeValues(msg)
	pathParams := make(map[string]struct{})
	path := reg.ReplaceAllStringFunc(pathTemplate, func(in string) string {
		// it's unreachable because the reg means that must have more than one char in {}
		// if len(in) < 4 { //nolint:mnd // **  explain the 4 number here :-) **
		//	return in
		// }
		key := in[1 : len(in)-1]
		pathParams[key] = struct{}{}
		return queryParams.Get(key)
	})
	if !needQuery {
		if v, ok := msg.(proto.Message); ok {
			if query := form.EncodeFieldMask(v.ProtoReflect()); query != "" {
				return path + "?" + query
			}
		}
		return path
	}
	if len(queryParams) > 0 {
		for key := range pathParams {
			delete(queryParams, key)
		}
		if query := queryParams.Encode(); query != "" {
			path += "?" + query
		}
	}
	return path
}
```

### optimized encode.go
```go
package binding

import (
	"reflect"
	"regexp"
	"strings"

	"google.golang.org/protobuf/proto"

	"github.com/go-kratos/kratos/v2/encoding/form"
)

var reg = regexp.MustCompile(`{[\\.\w]+}`)

// EncodeURL encode proto message to url path.
func EncodeURL(pathTemplate string, msg any, needQuery bool) string {
	if msg == nil || (reflect.ValueOf(msg).Kind() == reflect.Ptr && reflect.ValueOf(msg).IsNil()) {
		return pathTemplate
	}

	queryParams, _ := form.EncodeValues(msg)
	pathParams := make(map[string]struct{})
	var path string
	if strings.ContainsRune(pathTemplate, '{') {
		path = reg.ReplaceAllStringFunc(pathTemplate, func(in string) string {
			// it's unreachable because the reg means that must have more than one char in {}
			// if len(in) < 4 { //nolint:mnd // **  explain the 4 number here :-) **
			//	return in
			// }
			key := in[1 : len(in)-1]
			pathParams[key] = struct{}{}
			return queryParams.Get(key)
		})
	} else {
		path = pathTemplate
	}
	if !needQuery {
		if v, ok := msg.(proto.Message); ok {
			if query := form.EncodeFieldMask(v.ProtoReflect()); query != "" {
				return path + "?" + query
			}
		}
		return path
	}
	if len(queryParams) > 0 {
		for key := range pathParams {
			delete(queryParams, key)
		}
		if query := queryParams.Encode(); query != "" {
			path += "?" + query
		}
	}
	return path
}
```

### benchmark code
```go
func BenchmarkEncodeURL(b *testing.B) {
	benchmarks := []struct {
		name         string
		pathTemplate string
		msg          *binding.HelloRequest
		needQuery    bool
	}{
		{
			name:         "NoParams",
			pathTemplate: "http://helloworld.Greeter/helloworld/sub",
			msg: &binding.HelloRequest{
				Name: "test",
				Sub:  &binding.Sub{Name: "kratos"},
			},
			needQuery: false,
		},
		{
			name:         "NoParamsWithQuery",
			pathTemplate: "http://helloworld.Greeter/helloworld/sub",
			msg: &binding.HelloRequest{
				Name: "test",
				Sub:  &binding.Sub{Name: "kratos"},
				UpdateMask: &fieldmaskpb.FieldMask{
					Paths: []string{"name", "sub.naming"},
				},
			},
			needQuery: true,
		},
		{
			name:         "WithParams",
			pathTemplate: "http://helloworld.Greeter/helloworld/{name}/sub/{sub.naming}",
			msg: &binding.HelloRequest{
				Name: "test",
				Sub:  &binding.Sub{Name: "kratos"},
			},
			needQuery: false,
		},
		{
			name:         "WithParamsAndQuery",
			pathTemplate: "http://helloworld.Greeter/helloworld/{name}/sub/{sub.naming}",
			msg: &binding.HelloRequest{
				Name: "test",
				Sub:  &binding.Sub{Name: "kratos"},
				UpdateMask: &fieldmaskpb.FieldMask{
					Paths: []string{"name", "sub.naming"},
				},
			},
			needQuery: true,
		},
	}

	for _, bm := range benchmarks {
		b.Run(bm.name, func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				EncodeURL(bm.pathTemplate, bm.msg, bm.needQuery)
			}
		})
	}
}
```

## benchmark results

### original result
```text
goos: darwin
goarch: arm64
pkg: github.com/go-kratos/kratos/v2/transport/http/binding
cpu: Apple M3 Pro
BenchmarkEncodeURL
BenchmarkEncodeURL/NoParams
BenchmarkEncodeURL/NoParams-11         	 1527271	       778.7 ns/op	     893 B/op	      20 allocs/op
BenchmarkEncodeURL/NoParamsWithQuery
BenchmarkEncodeURL/NoParamsWithQuery-11         	  977407	      1183 ns/op	    1339 B/op	      33 allocs/op
BenchmarkEncodeURL/WithParams
BenchmarkEncodeURL/WithParams-11                	 1000000	      1059 ns/op	    1005 B/op	      21 allocs/op
BenchmarkEncodeURL/WithParamsAndQuery
BenchmarkEncodeURL/WithParamsAndQuery-11        	  870063	      1347 ns/op	    1265 B/op	      30 allocs/op
PASS

Process finished with the exit code 0
```

### optimized result
```text
goos: darwin
goarch: arm64
pkg: github.com/go-kratos/kratos/v2/transport/http/binding
cpu: Apple M3 Pro
BenchmarkEncodeURL
BenchmarkEncodeURL/NoParams
BenchmarkEncodeURL/NoParams-11         	 1551934	       718.9 ns/op	     768 B/op	      17 allocs/op
BenchmarkEncodeURL/NoParamsWithQuery
BenchmarkEncodeURL/NoParamsWithQuery-11         	 1000000	      1088 ns/op	    1208 B/op	      30 allocs/op
BenchmarkEncodeURL/WithParams
BenchmarkEncodeURL/WithParams-11                	 1000000	      1058 ns/op	    1004 B/op	      21 allocs/op
BenchmarkEncodeURL/WithParamsAndQuery
BenchmarkEncodeURL/WithParamsAndQuery-11        	  889833	      1349 ns/op	    1264 B/op	      30 allocs/op
PASS

Process finished with the exit code 0
```
