### PR TITLE
fix stale entries before the each pick operation

### DIFF
--- a/selector/wrr/wrr_test.go
+++ b/selector/wrr/wrr_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-kratos/kratos/v2/registry"
 	"github.com/go-kratos/kratos/v2/selector"
@@ -56,6 +57,81 @@ func TestWrr(t *testing.T) {
 		t.Errorf("expect 60, got %d", count2)
 	}
 }
+
+// TestCurrentWeightCleanup tests that stale entries in currentWeight map are cleaned up
+func TestCurrentWeightCleanup(t *testing.T) {
+	balancer := &Balancer{currentWeight: make(map[string]float64)}
+
+	// Create initial nodes
+	nodes1 := []selector.WeightedNode{
+		&mockWeightedNode{address: "node1", weight: 10},
+		&mockWeightedNode{address: "node2", weight: 20},
+		&mockWeightedNode{address: "node3", weight: 30},
+	}
+
+	// Pick from initial nodes to populate currentWeight
+	for i := 0; i < 10; i++ {
+		_, _, err := balancer.Pick(context.Background(), nodes1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	// Verify all 3 nodes are in currentWeight map
+	if len(balancer.currentWeight) != 3 {
+		t.Errorf("expected 3 entries in currentWeight, got %d", len(balancer.currentWeight))
+	}
+
+	// Change to different set of nodes (simulating service discovery update)
+	nodes2 := []selector.WeightedNode{
+		&mockWeightedNode{address: "node2", weight: 20}, // only node2 remains
+		&mockWeightedNode{address: "node4", weight: 40}, // node4 is new
+	}
+
+	// Pick from new nodes
+	_, _, err := balancer.Pick(context.Background(), nodes2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that stale entries (node1, node3) are cleaned up
+	if len(balancer.currentWeight) != 2 {
+		t.Errorf("expected 2 entries in currentWeight after cleanup, got %d", len(balancer.currentWeight))
+	}
+
+	// Verify that node2 and node4 are present, but node1 and node3 are not
+	if _, exists := balancer.currentWeight["node1"]; exists {
+		t.Error("stale entry node1 should have been cleaned up")
+	}
+	if _, exists := balancer.currentWeight["node3"]; exists {
+		t.Error("stale entry node3 should have been cleaned up")
+	}
+	if _, exists := balancer.currentWeight["node2"]; !exists {
+		t.Error("node2 should be present in currentWeight")
+	}
+	if _, exists := balancer.currentWeight["node4"]; !exists {
+		t.Error("node4 should be present in currentWeight")
+	}
+}
+
+// mockWeightedNode is a mock implementation for testing
+type mockWeightedNode struct {
+	address string
+	weight  float64
+}
+
+func (m *mockWeightedNode) Raw() selector.Node { return nil }
+func (m *mockWeightedNode) Weight() float64    { return m.weight }
+func (m *mockWeightedNode) Address() string    { return m.address }
+func (m *mockWeightedNode) Pick() selector.DoneFunc {
+	return func(context.Context, selector.DoneInfo) {}
+}
+func (m *mockWeightedNode) PickElapsed() time.Duration  { return 0 }
+func (m *mockWeightedNode) Scheme() string              { return "http" }
+func (m *mockWeightedNode) ServiceName() string         { return "test" }
+func (m *mockWeightedNode) InitialWeight() *int64       { return nil }
+func (m *mockWeightedNode) Version() string             { return "v1.0.0" }
+func (m *mockWeightedNode) Metadata() map[string]string { return nil }
 
 func TestEmpty(t *testing.T) {
 	b := &Balancer{}


### PR DESCRIPTION
<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

The original implementation had a critical flaw in the `currentWeight` map management:
* No Cleanup Logic: The `currentWeight` map accumulated entries for every node address that was ever encountered
* Stale Entries Persist: When service discovery updated the node list (nodes added/removed), old entries remained in the map
* Weight Pollution: Stale entries could have accumulated very high or very low weights, affecting future calculations

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->


#### Other special notes for the reviewers:
<!--
* Some things that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
