### PR TITLE
fix: honor shutdown timeout when provided context already canceled

### DIFF
--- a/app.go
+++ b/app.go
@@ -102,7 +102,7 @@ func (a *App) Run() error {
 		server := srv
 		eg.Go(func() error {
 			<-ctx.Done() // wait for stop signal
-			stopCtx := octx
+			stopCtx := context.WithoutCancel(octx)
 			if a.opts.stopTimeout > 0 {
 				var cancel context.CancelFunc
 				stopCtx, cancel = context.WithTimeout(stopCtx, a.opts.stopTimeout)

--- a/app_test.go
+++ b/app_test.go
@@ -283,3 +283,18 @@ func TestApp_Context(t *testing.T) {
 		})
 	}
 }
+
+func TestApp_ContextCanceled(t *testing.T) {
+	ctx, stop := context.WithCancel(context.Background())
+	stopFn := func(ctx context.Context) error {
+		select {
+		case <-ctx.Done():
+			t.Fatal("context should not be done yet")
+		default:
+		}
+		return nil
+	}
+	app := New(Context(ctx), Server(&mockServer{stopFn: stopFn}), StopTimeout(time.Hour))
+	time.AfterFunc(time.Millisecond*10, stop)
+	_ = app.Run()
+}

--- a/options_test.go
+++ b/options_test.go
@@ -86,10 +86,17 @@ func TestLogger(t *testing.T) {
 	}
 }
 
-type mockServer struct{}
+type mockServer struct {
+	stopFn func(context.Context) error
+}
 
 func (m *mockServer) Start(_ context.Context) error { return nil }
-func (m *mockServer) Stop(_ context.Context) error  { return nil }
+func (m *mockServer) Stop(ctx context.Context) error {
+	if m.stopFn != nil {
+		return m.stopFn(ctx)
+	}
+	return nil
+}
 
 func TestServer(t *testing.T) {
 	o := &options{}


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->

Servers are immediately force stopped if the provided context is canceled externally, completely ignoring the configured stop timeout.

```golang
ctx, stop := context.WithCancel(t.Context())
app := kratos.New(kratos.Context(ctx), kratos.Server(grpc.NewServer()), kratos.StopTimeout(10*time.Second))
time.AfterFunc(time.Millisecond*10, stop)
_ = app.Run()
```

The above example stops immediately with the following log output:

```
INFO msg=[gRPC] server listening on: [::]:42609
WARN msg=[gRPC] server couldn't stop gracefully in time, doing force stop
INFO msg=[gRPC] server stopping
```

This regression was introduced by #3525 and is easily fixed with the handy `context.WithoutCancel` function.