### PR TITLE
refactor(consul)!: optimize ServiceInstance tags handling with registrarTags option

### DIFF
--- a/app.go
+++ b/app.go
@@ -195,6 +195,7 @@ func (a *App) buildInstance() (*registry.ServiceInstance, error) {
 		Version:   a.opts.version,
 		Metadata:  a.opts.metadata,
 		Endpoints: endpoints,
+		Tags: 	   a.opts.registrarTags,
 	}, nil
 }
 

--- a/contrib/registry/consul/client.go
+++ b/contrib/registry/consul/client.go
@@ -170,7 +170,7 @@ func (c *Client) Register(ctx context.Context, svc *registry.ServiceInstance, en
 		ID:              svc.ID,
 		Name:            svc.Name,
 		Meta:            svc.Metadata,
-		Tags:            []string{fmt.Sprintf("version=%s", svc.Version)},
+		Tags:            svc.Tags,
 		TaggedAddresses: addresses,
 	}
 	if len(checkAddresses) > 0 {

--- a/options.go
+++ b/options.go
@@ -28,6 +28,7 @@ type options struct {
 	logger           log.Logger
 	registrar        registry.Registrar
 	registrarTimeout time.Duration
+	registrarTags             []string
 	stopTimeout      time.Duration
 	servers          []transport.Server
 
@@ -91,6 +92,11 @@ func Registrar(r registry.Registrar) Option {
 // RegistrarTimeout with registrar timeout.
 func RegistrarTimeout(t time.Duration) Option {
 	return func(o *options) { o.registrarTimeout = t }
+}
+
+// RegistrarTags with registrar tags.
+func RegistrarTags(tags ...string) Option {
+	return func(o *options) { o.registrarTags = tags }
 }
 
 // StopTimeout with app stop timeout.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -48,6 +48,8 @@ type ServiceInstance struct {
 	//   http://127.0.0.1:8000?isSecure=false
 	//   grpc://127.0.0.1:9000?isSecure=false
 	Endpoints []string `json:"endpoints"`
+	// Tags are the labels associated with the service instance.
+	Tags      []string `json:"tags"`
 }
 
 func (i *ServiceInstance) String() string {


### PR DESCRIPTION
## What this PR does / why we need it
Optimizes tag handling for the Consul registry:

- Introduces a new `registrarTags` option, allowing users to explicitly define the tags sent during service registration.  
- Adds the `Tags` field to `ServiceInstance`, enabling consistent retrieval on the discovery side.  
- Maintains backward compatibility.