### PR TITLE
refactor(all): replace atomic functions with atomic types

### DIFF
--- a/contrib/registry/discovery/discovery.go
+++ b/contrib/registry/discovery/discovery.go
@@ -24,7 +24,7 @@ type Discovery struct {
 	httpClient *resty.Client
 
 	node    atomic.Value
-	nodeIdx uint64
+	nodeIdx atomic.Uint64
 
 	mutex       sync.RWMutex
 	apps        map[string]*appInfo
@@ -217,11 +217,11 @@ func (d *Discovery) pickNode() string {
 	if !ok || len(nodes) == 0 {
 		return d.config.Nodes[rand.Intn(len(d.config.Nodes))]
 	}
-	return nodes[atomic.LoadUint64(&d.nodeIdx)%uint64(len(nodes))]
+	return nodes[d.nodeIdx.Load()%uint64(len(nodes))]
 }
 
 func (d *Discovery) switchNode() {
-	atomic.AddUint64(&d.nodeIdx, 1)
+	d.nodeIdx.Add(1)
 }
 
 // renew an instance with Discovery

--- a/contrib/registry/zookeeper/watcher.go
+++ b/contrib/registry/zookeeper/watcher.go
@@ -21,7 +21,7 @@ type watcher struct {
 	conn   *zk.Conn
 	cancel context.CancelFunc
 
-	first uint32
+	first atomic.Bool
 	// prefix for ZooKeeper paths or keys (used for filtering or identifying watched nodes)
 	prefix string
 	// the name of the service being watched in ZooKeeper
@@ -61,7 +61,7 @@ func (w *watcher) watch(ctx context.Context) {
 
 func (w *watcher) Next() ([]*registry.ServiceInstance, error) {
 	// TODO: multiple calls to Next may lead to inconsistent service instance information
-	if atomic.CompareAndSwapUint32(&w.first, 0, 1) {
+	if w.first.CompareAndSwap(false, true) {
 		return w.getServices()
 	}
 	select {

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -109,8 +109,8 @@ func TestFinish(t *testing.T) {
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("expect %v, got %v", context.DeadlineExceeded, err)
 	}
-	if !reflect.DeepEqual(mc.doneMark, uint32(1)) {
-		t.Errorf("expect %v, got %v", 1, mc.doneMark)
+	if done := mc.doneMark.Load(); done != true {
+		t.Errorf("expect %v, got %v", true, done)
 	}
 	if <-mc.done != struct{}{} {
 		t.Errorf("expect %v, got %v", struct{}{}, <-mc.done)

--- a/selector/node/direct/direct.go
+++ b/selector/node/direct/direct.go
@@ -22,7 +22,7 @@ type Node struct {
 	selector.Node
 
 	// last lastPick timestamp
-	lastPick int64
+	lastPick atomic.Int64
 }
 
 // Builder is direct node builder
@@ -30,12 +30,12 @@ type Builder struct{}
 
 // Build create node
 func (*Builder) Build(n selector.Node) selector.WeightedNode {
-	return &Node{Node: n, lastPick: 0}
+	return &Node{Node: n, lastPick: atomic.Int64{}}
 }
 
 func (n *Node) Pick() selector.DoneFunc {
 	now := time.Now().UnixNano()
-	atomic.StoreInt64(&n.lastPick, now)
+	n.lastPick.Store(now)
 	return func(context.Context, selector.DoneInfo) {}
 }
 
@@ -48,7 +48,7 @@ func (n *Node) Weight() float64 {
 }
 
 func (n *Node) PickElapsed() time.Duration {
-	return time.Duration(time.Now().UnixNano() - atomic.LoadInt64(&n.lastPick))
+	return time.Duration(time.Now().UnixNano() - n.lastPick.Load())
 }
 
 func (n *Node) Raw() selector.Node {


### PR DESCRIPTION
- Replaced usage of atomic.Add/atomic.Load functions with atomic.Int64 and atomic.Uint64 types for improved type safety and readability. 
- Use atomic types to explicitly enforce atomic access and prevent non-atomic modifications.