### PR TITLE
feat(protoc-gen-go-http): add bind query to disable BindQuery

### DIFF
--- a/cmd/protoc-gen-go-http/httpTemplate.tpl
+++ b/cmd/protoc-gen-go-http/httpTemplate.tpl
@@ -30,9 +30,11 @@ func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) fu
 			return err
 		}
 		{{- end}}
+		{{- if .BindQuery}}
 		if err := ctx.BindQuery(&in); err != nil {
 			return err
 		}
+		{{- end}}
 		{{- if .HasVars}}
 		if err := ctx.BindVars(&in); err != nil {
 			return err

--- a/cmd/protoc-gen-go-http/main.go
+++ b/cmd/protoc-gen-go-http/main.go
@@ -12,6 +12,7 @@ var (
 	showVersion     = flag.Bool("version", false, "print the version and exit")
 	omitempty       = flag.Bool("omitempty", true, "omit if google.api is empty")
 	omitemptyPrefix = flag.String("omitempty_prefix", "", "omit if google.api is empty")
+	bindQuery       = flag.Bool("bind_query", true, "bind query")
 )
 
 func main() {
@@ -28,7 +29,7 @@ func main() {
 			if !f.Generate {
 				continue
 			}
-			generateFile(gen, f, *omitempty, *omitemptyPrefix)
+			generateFile(gen, f, *omitempty, *omitemptyPrefix, *bindQuery)
 		}
 		return nil
 	})

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -33,6 +33,7 @@ type methodDesc struct {
 	HasBody      bool
 	Body         string
 	ResponseBody string
+	BindQuery    bool
 }
 
 func (s *serviceDesc) execute() string {


### PR DESCRIPTION
### Description:
This PR introduces a new bind_query flag to the `protoc-gen-go-http` plugin, allowing users to disable the automatic generation of BindQuery logic in HTTP handlers. This provides finer control over query parameter binding, especially in cases where it's unnecessary or undesired.

### Key Changes:
- Added `bind_query` CLI flag to `main.go` default `true` to keep backward compatibility
- Propagated `bindQuery` parameter through `generateFile`, `generateFileContent`, and `genService`
- Updated `httpTemplate.tpl` to conditionally include BindQuery logic
- Extended `methodDesc` struct to include BindQuery field