### PR TITLE
fix(transport/http): resolve breaking change with ResponseTransporter interface

### DIFF
--- a/transport/http/transport.go
+++ b/transport/http/transport.go
@@ -9,11 +9,20 @@ import (
 
 var _ Transporter = (*Transport)(nil)
 
+var _ ResponseTransporter = (*Transport)(nil)
+
 // Transporter is http Transporter
 type Transporter interface {
 	transport.Transporter
 	Request() *http.Request
 	PathTemplate() string
+}
+
+// ResponseTransporter extends Transporter with HTTP response access
+// This interface provides access to the http.ResponseWriter for use cases
+// like file downloads, streaming responses, or direct response manipulation.
+type ResponseTransporter interface {
+	Transporter
 	Response() http.ResponseWriter
 }
 
@@ -127,4 +136,16 @@ func (hc headerCarrier) Keys() []string {
 // Values returns a slice of values associated with the passed key.
 func (hc headerCarrier) Values(key string) []string {
 	return http.Header(hc).Values(key)
+}
+
+// ResponseWriterFromServerContext returns the http.ResponseWriter from context if available.
+// This function provides backward compatibility and safe access to the ResponseWriter.
+// Returns nil if the transport doesn't implement ResponseTransporter.
+func ResponseWriterFromServerContext(ctx context.Context) (http.ResponseWriter, bool) {
+	if tr, ok := transport.FromServerContext(ctx); ok {
+		if httpTr, ok := tr.(ResponseTransporter); ok {
+			return httpTr.Response(), true
+		}
+	}
+	return nil, false
 }

--- a/transport/http/transport_test.go
+++ b/transport/http/transport_test.go
@@ -54,7 +54,7 @@ func TestTransport_Response(t *testing.T) {
 	v := http.ResponseWriter(nil)
 	o := &Transport{response: v}
 	if !reflect.DeepEqual(v, o.Response()) {
-		t.Errorf("expect %v, got %v", v, o.Request())
+		t.Errorf("expect %v, got %v", v, o.Response())
 	}
 }
 
@@ -100,3 +100,152 @@ func TestSetOperation(t *testing.T) {
 		t.Errorf("expect %v, got %v", "kratos", tr.operation)
 	}
 }
+
+// TestResponseTransporter_Interface tests that Transport implements ResponseTransporter
+func TestResponseTransporter_Interface(t *testing.T) {
+	var transport Transporter = &Transport{}
+	if _, ok := transport.(ResponseTransporter); !ok {
+		t.Error("Transport should implement ResponseTransporter interface")
+	}
+}
+
+// TestResponseWriterFromServerContext tests the ResponseWriterFromServerContext helper function
+func TestResponseWriterFromServerContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupContext func() context.Context
+		expectWriter bool
+		expectOk     bool
+	}{
+		{
+			name: "valid HTTP transport with ResponseWriter",
+			setupContext: func() context.Context {
+				mockWriter := &mockResponseWriter{header: make(http.Header)}
+				tr := &Transport{response: mockWriter}
+				return transport.NewServerContext(context.Background(), tr)
+			},
+			expectWriter: true,
+			expectOk:     true,
+		},
+		{
+			name: "context without transport",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			expectWriter: false,
+			expectOk:     false,
+		},
+		{
+			name: "context with non-HTTP transport",
+			setupContext: func() context.Context {
+				tr := &mockNonHTTPTransport{}
+				return transport.NewServerContext(context.Background(), tr)
+			},
+			expectWriter: false,
+			expectOk:     false,
+		},
+		{
+			name: "context with HTTP transport without ResponseTransporter interface",
+			setupContext: func() context.Context {
+				tr := &mockBasicHTTPTransport{}
+				return transport.NewServerContext(context.Background(), tr)
+			},
+			expectWriter: false,
+			expectOk:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupContext()
+			writer, ok := ResponseWriterFromServerContext(ctx)
+
+			if ok != tt.expectOk {
+				t.Errorf("ResponseWriterFromServerContext() ok = %v, want %v", ok, tt.expectOk)
+			}
+
+			if tt.expectWriter && writer == nil {
+				t.Error("ResponseWriterFromServerContext() should return non-nil writer")
+			}
+
+			if !tt.expectWriter && writer != nil {
+				t.Error("ResponseWriterFromServerContext() should return nil writer")
+			}
+		})
+	}
+}
+
+// TestTransport_InterfaceCompatibility tests interface compatibility
+func TestTransport_InterfaceCompatibility(t *testing.T) {
+	tr := &Transport{
+		endpoint:     "http://localhost:8080",
+		operation:    "/test",
+		pathTemplate: "/test/{id}",
+		request:      &http.Request{},
+		response:     &mockResponseWriter{header: make(http.Header)},
+	}
+
+	// Test basic Transporter interface
+	var basicTransporter Transporter = tr
+	if basicTransporter.Request() == nil {
+		t.Error("Transporter.Request() should not be nil")
+	}
+	if basicTransporter.PathTemplate() == "" {
+		t.Error("Transporter.PathTemplate() should not be empty")
+	}
+
+	// Test ResponseTransporter interface
+	var responseTransporter ResponseTransporter = tr
+	if responseTransporter.Response() == nil {
+		t.Error("ResponseTransporter.Response() should not be nil")
+	}
+
+	// Test that ResponseTransporter extends Transporter
+	if responseTransporter.Request() == nil {
+		t.Error("ResponseTransporter should have Request() method from Transporter")
+	}
+}
+
+// TestTransport_TypeAssertion tests safe type assertion patterns
+func TestTransport_TypeAssertion(t *testing.T) {
+	tr := &Transport{
+		response: &mockResponseWriter{header: make(http.Header)},
+	}
+	ctx := transport.NewServerContext(context.Background(), tr)
+
+	// Test type assertion to ResponseTransporter
+	if serverTr, ok := transport.FromServerContext(ctx); ok {
+		if httpTr, ok := serverTr.(ResponseTransporter); ok {
+			if httpTr.Response() == nil {
+				t.Error("ResponseTransporter.Response() should not be nil")
+			}
+		} else {
+			t.Error("Transport should be assertable to ResponseTransporter")
+		}
+	} else {
+		t.Error("Should be able to get transport from server context")
+	}
+}
+
+// Mock implementations for testing
+// Note: mockResponseWriter is already defined in codec_test.go and will be reused
+
+// mockNonHTTPTransport simulates a non-HTTP transport (like gRPC)
+type mockNonHTTPTransport struct{}
+
+func (m *mockNonHTTPTransport) Kind() transport.Kind            { return transport.KindGRPC }
+func (m *mockNonHTTPTransport) Endpoint() string                { return "grpc://localhost:9000" }
+func (m *mockNonHTTPTransport) Operation() string               { return "/grpc.Service/Method" }
+func (m *mockNonHTTPTransport) RequestHeader() transport.Header { return nil }
+func (m *mockNonHTTPTransport) ReplyHeader() transport.Header   { return nil }
+
+// mockBasicHTTPTransport simulates an HTTP transport that only implements basic Transporter
+type mockBasicHTTPTransport struct{}
+
+func (m *mockBasicHTTPTransport) Kind() transport.Kind            { return transport.KindHTTP }
+func (m *mockBasicHTTPTransport) Endpoint() string                { return "http://localhost:8080" }
+func (m *mockBasicHTTPTransport) Operation() string               { return "/test" }
+func (m *mockBasicHTTPTransport) RequestHeader() transport.Header { return nil }
+func (m *mockBasicHTTPTransport) ReplyHeader() transport.Header   { return nil }
+func (m *mockBasicHTTPTransport) Request() *http.Request          { return nil }
+func (m *mockBasicHTTPTransport) PathTemplate() string            { return "/test" }


### PR DESCRIPTION
- Add ResponseTransporter interface extending Transporter with Response() method
- Add ResponseWriterFromServerContext helper function for safe access
- Maintain backward compatibility with existing Transporter implementations
- Follow Go standard library patterns (io.Reader + io.ReaderFrom)

Fixes dependency chain breaking changes from PR #3624

<!--
🎉 Thanks for sending a pull request to Kratos! Here are some tips for you:

1. If this is your first time contributing to Kratos, please read our contribution guide: https://go-kratos.dev/en/docs/community/contribution/
2. Ensure you have added or ran the appropriate tests and lint for your PR, please use `make lint` and `make test` before filing your PR, use `make clean` to tidy your go mod.
3. If the PR is unfinished, you may need to mark it as a WIP(Work In Progress) PR or Draft PR
4. Please use a semantic commits format title, such as `<type>[optional scope]: <description>`, see: https://go-kratos.dev/docs/community/contribution#type
5. at the same time, please note that similar work should be submitted in one PR as far as possible to reduce the workload of reviewers. Do not split a work into multiple PR unless it should.
-->

<!--
🎉 感谢您向 Kratos 发送 PR！以下是一些提示：
如果这是你第一次为 Kratos 贡献，请阅读我们的贡献指南：https://go-kratos.dev/en/docs/community/contribution/
2、确保您已经为您的 PR 添加或运行了适当的测试和lint，请在提交PR之前使用“make lint”和“make test”，使用“make clean”整理您的 go.mod。
3、如果 PR 未完成，您可能需要将其标记为 WIP（Work In Progress）PR 或 Draft PR
4、请使用语义提交格式标题，如“<类型>[可选范围]：<说明>`，请参阅：https://go-kratos.dev/docs/community/contribution#type
5. 同时请注意，同类的工作请尽量在一个PR中提交，以减轻 review 者的工作负担，不要把一项工作拆分成很多个PR，除非它应该这样做。
-->


#### Description (what this PR does / why we need it):
<!--
* The description should include the motivation for this PR or contrast this with previous behavior
-->
We encountered a breaking change issue with PR #3624 in production:

1. **Proto Repository** updated to latest Kratos (with breaking change)
2. **Business Projects** imported proto stubs, automatically pulling new Kratos version  
3. **Unit Tests Failed** due to custom HTTP transport implementations no longer compiling
4. **Root Cause** traced to the breaking change in `Transporter` interface

This shows why breaking changes in public APIs are problematic - they break downstream consumers through dependency chains.

Following the same pattern used in Go's standard library (`io.Reader` + `io.ReaderFrom`, `http.ResponseWriter` + `http.Hijacker`):

```go
// Original interface unchanged (backward compatible)
type Transporter interface {
    transport.Transporter
    Request() *http.Request
    PathTemplate() string
}

// New optional interface for response access
type ResponseTransporter interface {
    Transporter
    Response() http.ResponseWriter
}

// Safe helper function
func ResponseWriterFromServerContext(ctx context.Context) (http.ResponseWriter, bool) {
    if tr, ok := transport.FromServerContext(ctx); ok {
        if httpTr, ok := tr.(ResponseTransporter); ok {
            return httpTr.Response(), true
        }
    }
    return nil, false
}
```

## Example

Proto definition:
```proto
syntax = "proto3";

package demo.v1;

import "google/api/annotations.proto";

option go_package = "demo/api/demo/v1;v1";

service Demo {
  rpc Download(DownloadReq) returns (DownloadResp) {
    option (google.api.http) = {
      get : "api/v1/download"
    };
  }
}

message DownloadReq {
}

message DownloadResp {
  bytes data = 1;
}
```

Service implementation:
```go
func (s *Service) Download(ctx context.Context, in *v1.DownloadReq) (*v1.DownloadResp, error) {
	f := excelize.NewFile()
	index, err := f.NewSheet("Sheet2")
	if err != nil {
		return nil, err
	}

	f.SetCellValue("Sheet2", "A2", "Hello world.")
	f.SetCellValue("Sheet1", "B2", 100)
	f.SetActiveSheet(index)

	if tr, ok := transport.FromServerContext(ctx); ok {
		if tr.Kind() == transport.KindHTTP {
			// Set response headers
			if httpTr, ok := tr.(http.Transporter); ok {
				disposition := fmt.Sprintf("attachment; filename=%s", "demo.xlsx")
				httpTr.ReplyHeader().Set("Content-Type", "application/octet-stream")
				httpTr.ReplyHeader().Set("Content-Disposition", disposition)
				httpTr.ReplyHeader().Set("Access-Control-Expose-Headers", "Content-Disposition")
			}

			// Write directly to HTTP response if available
			if w, ok := http.ResponseWriterFromServerContext(ctx); ok {
				if err := f.Write(w); err != nil {
					return nil, err
				}
				return nil, nil
			}

			// Fallback to bytes for older implementations
			buffer, err := f.WriteToBuffer()
			if err != nil {
				return nil, err
			}
			return &v1.DownloadResp{Data: buffer.Bytes()}, nil
		}
		
		if tr.Kind() == transport.KindGRPC {
			buffer, err := f.WriteToBuffer()
			if err != nil {
				return nil, err
			}
			return &v1.DownloadResp{Data: buffer.Bytes()}, nil
		}
	}

	return nil, errors.New("transport kind error")
}
```

## Advantages

- **Backward Compatible**: Existing code continues to work unchanged
- **Go Standard Library Pattern**: Follows `io.Reader`+`io.ReaderFrom`, `http.ResponseWriter`+`http.Hijacker` patterns  
- **Safe Migration**: Users can adopt gradually with fallback options
- **Production Safe**: Prevents the dependency chain issues we experienced


#### Which issue(s) this PR fixes (resolves / be part of):
<!--
* Automatically closes linked issue when PR is merged.
* If your PR is not fully resolved the issue, please use `part of #<issue number>` instead.

Usage: `fixes/resolves #<issue number>`, or `fixes/resolves (paste link of issue)`.
-->

PR #3624 directly added `Response() http.ResponseWriter` to the existing `Transporter` interface, creating a breaking change:

- Custom implementations of `http.Transporter` fail to compile
- Since `transport/http` is public (not `internal/`), it must maintain backward compatibility  
- Violates Go's compatibility promise for public APIs


#### Other special notes for the reviewers:
<!--
* Some things that need extra attention for the reviewers
* Some additional notes, TODO list, etc.
-->
