### PR TITLE
fix(transport/grpc): ClientOption cannot initialize StreamMiddleware(#3697)

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -62,6 +62,13 @@ func WithMiddleware(m ...middleware.Middleware) ClientOption {
 	}
 }
 
+// WithStreamMiddleware with client stream middleware.
+func WithStreamMiddleware(m ...middleware.Middleware) ClientOption {
+	return func(o *clientOptions) {
+		o.streamMiddleware = m
+	}
+}
+
 // WithDiscovery with client discovery.
 func WithDiscovery(d registry.Discovery) ClientOption {
 	return func(o *clientOptions) {

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -42,6 +42,17 @@ func TestWithMiddleware(t *testing.T) {
 	}
 }
 
+func TestWithStreamMiddleware(t *testing.T) {
+	o := &clientOptions{}
+	v := []middleware.Middleware{
+		func(middleware.Handler) middleware.Handler { return nil },
+	}
+	WithStreamMiddleware(v...)(o)
+	if !reflect.DeepEqual(v, o.streamMiddleware) {
+		t.Errorf("expect %v but got %v", v, o.streamInts)
+	}
+}
+
 type mockRegistry struct{}
 
 func (m *mockRegistry) GetService(_ context.Context, _ string) ([]*registry.ServiceInstance, error) {
@@ -148,6 +159,7 @@ func TestDialConn(t *testing.T) {
 		WithTimeout(10*time.Second),
 		WithEndpoint("abc"),
 		WithMiddleware(EmptyMiddleware()),
+		WithStreamMiddleware(EmptyMiddleware()),
 	)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
Description (what this PR does / why we need it):
streamMiddleware of ClientOption in Transport/grpc is implemented but cannot be initialized.

Which issue(s) this PR fixes (resolves / be part of):
None.

Other special notes for the reviewers:
None.