### PR TITLE
ci: add Go 1.25 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: [1.22.x, 1.23.x, 1.24.x]
+        go: [1.22.x, 1.23.x, 1.24.x, 1.25.x]
     name: build & test
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
Update CI configurations to maintain project compatibility and security,
include Go `1.25.x` in build & test matrix to ensure compatibility with latest Go version.