### PR TITLE
refactor: use math/rand/v2 instead of math/rand

### DIFF
--- a/contrib/registry/consul/client.go
+++ b/contrib/registry/consul/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"net/url"
 	"strconv"
@@ -262,7 +262,7 @@ func (c *Client) Register(ctx context.Context, svc *registry.ServiceInstance, en
 					if err != nil {
 						log.Errorf("[Consul] update ttl heartbeat to consul failed! err=%v", err)
 						// when the previous report fails, try to re register the service
-						if err := sleepCtx(cc.ctx, time.Duration(rand.Intn(5))*time.Second); err != nil {
+						if err := sleepCtx(cc.ctx, time.Duration(rand.IntN(5))*time.Second); err != nil {
 							_ = c.cli.Agent().ServiceDeregister(svc.ID)
 							return
 						}

--- a/contrib/registry/discovery/discovery.go
+++ b/contrib/registry/discovery/discovery.go
@@ -3,7 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"strconv"
 	"sync"
@@ -215,7 +215,7 @@ func (d *Discovery) serverProc() {
 func (d *Discovery) pickNode() string {
 	nodes, ok := d.node.Load().([]string)
 	if !ok || len(nodes) == 0 {
-		return d.config.Nodes[rand.Intn(len(d.config.Nodes))]
+		return d.config.Nodes[rand.IntN(len(d.config.Nodes))]
 	}
 	return nodes[d.nodeIdx.Load()%uint64(len(nodes))]
 }

--- a/contrib/registry/etcd/registry.go
+++ b/contrib/registry/etcd/registry.go
@@ -3,7 +3,7 @@ package etcd
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
@@ -178,7 +178,7 @@ func (r *Registry) heartBeat(ctx context.Context, leaseID clientv3.LeaseID, key 
 	if err != nil {
 		curLeaseID = 0
 	}
-	randSource := rand.New(rand.NewSource(time.Now().Unix()))
+	randSource := rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))
 
 	for {
 		if curLeaseID == 0 {
@@ -216,7 +216,7 @@ func (r *Registry) heartBeat(ctx context.Context, leaseID clientv3.LeaseID, key 
 					break
 				}
 				retreat = append(retreat, 1<<retryCnt)
-				time.Sleep(time.Duration(retreat[randSource.Intn(len(retreat))]) * time.Second)
+				time.Sleep(time.Duration(retreat[randSource.IntN(len(retreat))]) * time.Second)
 			}
 			if _, ok := <-kac; !ok {
 				// retry failed

--- a/contrib/registry/eureka/client.go
+++ b/contrib/registry/eureka/client.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"strings"
 	"sync"
@@ -292,7 +292,7 @@ func (e *Client) pickServer(currentTimes int) string {
 }
 
 func (e *Client) shuffle() {
-	rand.New(rand.NewSource(time.Now().UnixNano())).
+	rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0)).
 		Shuffle(len(e.urls), func(i, j int) {
 			e.urls[i], e.urls[j] = e.urls[j], e.urls[i]
 		})

--- a/middleware/auth/jwt/jwt_test.go
+++ b/middleware/auth/jwt/jwt_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"reflect"
 	"strconv"

--- a/middleware/metrics/metrics_test.go
+++ b/middleware/metrics/metrics_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"sync"
 	"testing"
@@ -143,7 +143,7 @@ func TestServer(t *testing.T) {
 		return nil, e
 	}
 	nextValid := func(context.Context, any) (any, error) {
-		time.Sleep(time.Millisecond * time.Duration(rand.Int31n(100)))
+		time.Sleep(time.Millisecond * time.Duration(rand.Int32N(100)))
 		return "Hello valid", nil
 	}
 

--- a/selector/p2c/p2c.go
+++ b/selector/p2c/p2c.go
@@ -2,7 +2,7 @@ package p2c
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,8 +40,8 @@ type Balancer struct {
 // choose two distinct nodes.
 func (s *Balancer) prePick(nodes []selector.WeightedNode) (nodeA selector.WeightedNode, nodeB selector.WeightedNode) {
 	s.mu.Lock()
-	a := s.r.Intn(len(nodes))
-	b := s.r.Intn(len(nodes) - 1)
+	a := s.r.IntN(len(nodes))
+	b := s.r.IntN(len(nodes) - 1)
 	s.mu.Unlock()
 	if b >= a {
 		b = b + 1
@@ -96,5 +96,5 @@ type Builder struct{}
 
 // Build creates Balancer
 func (b *Builder) Build() selector.Balancer {
-	return &Balancer{r: rand.New(rand.NewSource(time.Now().UnixNano()))}
+	return &Balancer{r: rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))}
 }

--- a/selector/p2c/p2c_test.go
+++ b/selector/p2c/p2c_test.go
@@ -3,7 +3,7 @@ package p2c
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"sync"
 	"sync/atomic"
@@ -38,7 +38,7 @@ func TestWrr3(t *testing.T) {
 		go func() {
 			defer group.Done()
 			lk.Lock()
-			d := time.Duration(rand.Intn(500)) * time.Millisecond
+			d := time.Duration(rand.IntN(500)) * time.Millisecond
 			lk.Unlock()
 			time.Sleep(d)
 			n, done, err := p2c.Select(context.Background(), selector.WithNodeFilter(filter.Version("v2.0.0")))

--- a/selector/random/random.go
+++ b/selector/random/random.go
@@ -2,7 +2,7 @@ package random
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 
 	"github.com/go-kratos/kratos/v2/selector"
 	"github.com/go-kratos/kratos/v2/selector/node/direct"
@@ -34,7 +34,7 @@ func (p *Balancer) Pick(_ context.Context, nodes []selector.WeightedNode) (selec
 	if len(nodes) == 0 {
 		return nil, nil, selector.ErrNoAvailable
 	}
-	cur := rand.Intn(len(nodes))
+	cur := rand.IntN(len(nodes))
 	selected := nodes[cur]
 	d := selected.Pick()
 	return selected, d, nil

--- a/selector/selector_test.go
+++ b/selector/selector_test.go
@@ -3,7 +3,7 @@ package selector
 import (
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -76,7 +76,7 @@ func (b *mockBalancer) Pick(_ context.Context, nodes []WeightedNode) (selected W
 		err = ErrNoAvailable
 		return
 	}
-	cur := rand.Intn(len(nodes))
+	cur := rand.IntN(len(nodes))
 	selected = nodes[cur]
 	done = selected.Pick()
 	return


### PR DESCRIPTION
`math/rand/v2` is introduced in Go 1.22. It provides improved randomness quality, safer auto-seeded defaults, clearer APIs, and better concurrency behavior. The old `math/rand` package is legacy and preserved only for compatibility, so switching to v2 aligns the project with Go's recommended modern random facilities.