### PR TITLE
perf(encoding/form): replace fmt.Sprintf with string concatenation 

### DIFF
--- a/encoding/form/proto_encode.go
+++ b/encoding/form/proto_encode.go
@@ -65,7 +65,7 @@ func encodeByField(u url.Values, path string, m protoreflect.Message) (finalErr 
 					finalErr = err
 				}
 				for k, value := range m {
-					u.Set(fmt.Sprintf("%s[%s]", newPath, k), value)
+					u.Set(newPath+"["+k+"]", value)
 				}
 			}
 		case (fd.Kind() == protoreflect.MessageKind) || (fd.Kind() == protoreflect.GroupKind):


### PR DESCRIPTION
replace fmt.Sprintf with string concatenation for map key encoding

Use + operator instead of fmt.Sprintf for building map key strings like "path[key]".
Go compiler optimizes this to runtime.concatstring, achieving zero heap allocation
for short strings.

Benchmark
<img width="1600" height="692" alt="image" src="https://github.com/user-attachments/assets/ad56a2d9-7df1-40ed-ba1c-4d6381064185" />


```go

// encodeMapKeyOld is the old implementation using fmt.Sprintf for benchmark comparison.
func encodeMapKeyOld(path, key string) string {
	return fmt.Sprintf("%s[%s]", path, key)
}

// encodeMapKeyBuilder uses strings.Builder with pre-allocation.
func encodeMapKeyBuilder(path, key string) string {
	var sb strings.Builder
	sb.Grow(len(path) + len(key) + 2)
	sb.WriteString(path)
	sb.WriteByte('[')
	sb.WriteString(key)
	sb.WriteByte(']')
	return sb.String()
}

// encodeMapKeyConcat uses simple string concatenation with + operator.
func encodeMapKeyConcat(path, key string) string {
	return path + "[" + key + "]"
}

func BenchmarkEncodeMapKey(b *testing.B) {
	testCases := []struct {
		name string
		path string
		key  string
	}{
		{"tiny", "m", "k"},
		{"short", "map", "key"},
		{"medium", "user.profile.settings", "theme"},
		{"long", "very.long.nested.path.to.some.field", "some_very_long_key_name"},
		{"very_long", "app.config.database.connection.pool.settings.timeout", "connection_timeout_milliseconds_value"},
		{"extreme", "a]very.deeply.nested.structure.with.many.levels.of.hierarchy.in.the.path", "an_extremely_long_key_name_that_might_appear_in_some_edge_cases"},
	}

	for _, tc := range testCases {
		b.Run(tc.name+"_sprintf", func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				_ = encodeMapKeyOld(tc.path, tc.key)
			}
		})

		b.Run(tc.name+"_builder", func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				_ = encodeMapKeyBuilder(tc.path, tc.key)
			}
		})

		b.Run(tc.name+"_concat", func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				_ = encodeMapKeyConcat(tc.path, tc.key)
			}
		})
	}
}

```


