### PR TITLE
feat(config): add generic config Get support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -156,3 +156,34 @@ func (c *config) Close() error {
 	}
 	return nil
 }
+
+// Get retrieves a config value by key and scans it into the target type.
+func Get[T any](c Config, key string) (T, error) {
+	var t T
+	v := c.Value(key)
+
+	if v.Load() == nil {
+		return t, ErrNotFound
+	}
+
+	switch any(t).(type) {
+	case bool:
+		b, err := v.Bool()
+		return any(b).(T), err
+	case int64:
+		i, err := v.Int()
+		return any(i).(T), err
+	case int:
+		i, err := v.Int()
+		return any(int(i)).(T), err
+	case float64:
+		f, err := v.Float()
+		return any(f).(T), err
+	case string:
+		s, err := v.String()
+		return any(s).(T), err
+	}
+
+	err := v.Scan(&t)
+	return t, err
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -154,6 +154,27 @@ func TestConfig(t *testing.T) {
 		t.Fatal("databaseDriver is not equal to val")
 	}
 
+	driverGet, err := Get[string](cf, "data.database.driver")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if databaseDriver != driverGet {
+		t.Errorf("Get[string] want: %s, got: %s", databaseDriver, driverGet)
+	}
+
+	type HTTPConfig struct {
+		Addr string `json:"addr"`
+		Port int    `json:"port"`
+	}
+	v, err := Get[HTTPConfig](cf, "server.http")
+	if err != nil {
+		t.Fatal(err)
+	} else if v.Addr != httpAddr {
+		t.Errorf("Get[HttpConfig] Addr want: %s, got: %s", httpAddr, v.Addr)
+	} else if v.Port != 80 {
+		t.Errorf("Get[HttpConfig] Port want: 80, got: %d", v.Port)
+	}
+
 	err = cf.Watch("endpoints", func(string, Value) {})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR implements a new feature for the `config` package to support generic value retrieval》

**Generic `Get` Method (New Feature)**
Currently, retrieving configuration values requires manual type conversion (e.g., `c.Value("key").Int()`). This PR adds a `Get[T]` helper function that leverages Go generics to directly return the desired typed value.

```
// Before
port, err := c.Value("server.port").Int()

// After
port, err := config.Get[int](c, "server.port")
```