### PR TITLE
feat(cmd): add --repo flag to kratos new command

### DIFF
--- a/cmd/kratos/internal/project/project.go
+++ b/cmd/kratos/internal/project/project.go
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	CmdNew.Flags().StringVarP(&repo, "repo", "c", repo, "custom repo url")
+	CmdNew.Flags().StringVarP(&repo, "repo", "r", repo, "custom repo url")
 	CmdNew.Flags().StringVarP(&branch, "branch", "b", branch, "repo branch")
 	CmdNew.Flags().StringVarP(&timeout, "timeout", "t", timeout, "time out")
 	CmdNew.Flags().BoolVarP(&nomod, "nomod", "", nomod, "retain go mod")


### PR DESCRIPTION
#### Description (what this PR does / why we need it):
Add a `--repo` / `-c` flag to the `kratos new` command to allow using a custom repository URL.
If the flag is not provided, the interactive repo selection is maintained.
This works together with the `--branch` and `--nomod` flags, ensuring the repo URL is correctly passed
to the project creation process.

#### Which issue(s) this PR fixes (resolves / be part of):
None

#### Other special notes for the reviewers:
* Please review the integration with `--branch` and `--nomod`
* Ensure that interactive selection is not broken when `--repo` is provided
