### PR TITLE
fix(metrics): remove redundant _bucket suffix from default histogram name

### DIFF
--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -23,9 +23,9 @@ const (
 )
 
 const (
-	DefaultServerSecondsHistogramName = "server_requests_seconds_bucket"
+	DefaultServerSecondsHistogramName = "server_requests_seconds"
 	DefaultServerRequestsCounterName  = "server_requests_code_total"
-	DefaultClientSecondsHistogramName = "client_requests_seconds_bucket"
+	DefaultClientSecondsHistogramName = "client_requests_seconds"
 	DefaultClientRequestsCounterName  = "client_requests_code_total"
 )
 


### PR DESCRIPTION
Currently, DefaultServerSecondsHistogramName is defined as server_requests_seconds_bucket. When using the OpenTelemetry Prometheus exporter, it automatically appends _bucket to histogram instruments, resulting in a redundant name like server_requests_seconds_bucket_bucket.

This PR changes the default name to server_requests_seconds, allowing the exporter to append the standard suffixes correctly.

Related Issue: Fixes #3793 

Checklist:
[x] I have read the contributing guidelines.
[x] My code follows the code style of this project.
[x] All new and existing tests passed.