### PR TITLE
fix(cmd): assign filepath.Join result to base in findCMD loop

### DIFF
--- a/cmd/kratos/internal/run/run.go
+++ b/cmd/kratos/internal/run/run.go
@@ -132,7 +132,7 @@ func findCMD(base string) (map[string]string, error) {
 		if root {
 			break
 		}
-		_ = filepath.Join(base, "..")
+		base = filepath.Join(base, "..")
 	}
 	return map[string]string{"": base}, nil
 }


### PR DESCRIPTION
The result of filepath.Join(base, "..") was discarded by assigning to _, causing the loop to scan the same directory repeatedly instead of traversing up to parent directories when searching for the cmd/ folder.
