### PR TITLE
fix(cmd): use errors.Is for path existence check in pathExists

### DIFF
--- a/cmd/kratos/internal/proto/client/client.go
+++ b/cmd/kratos/internal/proto/client/client.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -124,7 +126,7 @@ func generate(proto string, args []string) error {
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
 	if err != nil {
-		return os.IsExist(err)
+		return !errors.Is(err, fs.ErrNotExist)
 	}
 	return true
 }


### PR DESCRIPTION
os.IsExist checks if an error indicates a file already exists (e.g., during creation), not if a file is present on disk. When os.Stat fails with "file not found", os.IsExist returns false, which happens to be correct but is semantically wrong. Replace with the idiomatic !errors.Is(err, fs.ErrNotExist) for clarity and correctness.
