### PR TITLE
fix(config/apollo): prevent panic on nil NewValue

### DIFF
--- a/contrib/config/apollo/watcher.go
+++ b/contrib/config/apollo/watcher.go
@@ -28,13 +28,15 @@ func (c *customChangeListener) onChange(namespace string, changes map[string]*st
 	if strings.Contains(namespace, ".") && !strings.HasSuffix(namespace, "."+properties) &&
 		(format(namespace) == yaml || format(namespace) == yml || format(namespace) == json) {
 		if value, ok := changes["content"]; ok {
-			kv = append(kv, &config.KeyValue{
-				Key:    namespace,
-				Value:  []byte(value.NewValue.(string)),
-				Format: format(namespace),
-			})
+			if s, ok := value.NewValue.(string); ok {
+				kv = append(kv, &config.KeyValue{
+					Key:    namespace,
+					Value:  []byte(s),
+					Format: format(namespace),
+				})
 
-			return kv
+				return kv
+			}
 		}
 	}
 

--- a/contrib/config/apollo/watcher_test.go
+++ b/contrib/config/apollo/watcher_test.go
@@ -77,3 +77,70 @@ func Test_onChange(t *testing.T) {
 		})
 	}
 }
+
+func Test_onChange_deletedContent(t *testing.T) {
+	c := customChangeListener{}
+
+	t.Run("json content deleted should not panic", func(t *testing.T) {
+		changes := map[string]*storage.ConfigChange{
+			"content": {
+				OldValue:   `{"name":"old"}`,
+				NewValue:   nil,
+				ChangeType: storage.DELETED,
+			},
+		}
+		kvs := c.onChange("app.json", changes)
+		// NewValue is nil, so the original config path is skipped;
+		// falls through to resolve path which also skips nil NewValue.
+		if len(kvs) != 1 {
+			t.Fatalf("expected 1 kv, got %d", len(kvs))
+		}
+	})
+
+	t.Run("yaml content deleted should not panic", func(t *testing.T) {
+		changes := map[string]*storage.ConfigChange{
+			"content": {
+				OldValue:   "name: old",
+				NewValue:   nil,
+				ChangeType: storage.DELETED,
+			},
+		}
+		kvs := c.onChange("app.yaml", changes)
+		if len(kvs) != 1 {
+			t.Fatalf("expected 1 kv, got %d", len(kvs))
+		}
+	})
+
+	t.Run("properties key deleted should not panic", func(t *testing.T) {
+		changes := map[string]*storage.ConfigChange{
+			"name": {
+				OldValue:   "old",
+				NewValue:   nil,
+				ChangeType: storage.DELETED,
+			},
+		}
+		kvs := c.onChange("app", changes)
+		if len(kvs) != 1 {
+			t.Fatalf("expected 1 kv, got %d", len(kvs))
+		}
+	})
+}
+
+func Test_onChange_nonStringNewValue(t *testing.T) {
+	c := customChangeListener{}
+
+	t.Run("json content with non-string NewValue should not panic", func(t *testing.T) {
+		changes := map[string]*storage.ConfigChange{
+			"content": {
+				OldValue:   `{"name":"old"}`,
+				NewValue:   12345,
+				ChangeType: storage.MODIFIED,
+			},
+		}
+		// Should not panic; falls through to resolve path
+		kvs := c.onChange("app.json", changes)
+		if kvs == nil {
+			t.Fatal("expected non-nil kvs")
+		}
+	})
+}


### PR DESCRIPTION
When parser.Parse(content) fails (e.g. malformed YAML), the error is only logged at Debug level and swallowed. Since m is empty, apolloConfig.Configurations retains the raw {"content": "<bad yaml>"} map from the JSON unmarshal step, which gets stored in cache.

Later, when a valid YAML is pushed, the parser succeeds and Configurations becomes a flat KV map (e.g. {"server.name": "foo", ...}). During cache diff, the old "content" key no longer exists in the new config, so agollo creates a DELETED change event with NewValue = nil.

The watcher in kratos/contrib/config/apollo unconditionally checks changes["content"] for .yaml namespaces and does value.NewValue.(string) without a nil guard — causing a nil interface conversion panic.

#### Description (what this PR does / why we need it):
```go
// apolloconfig/agollo/v4 v4.3.1 component/remote/sync.go
func processJSONFiles(b []byte, callback http.CallBack) (o interface{}, err error) {
	...

	configurations := make(map[string]interface{}, 0)
	apolloConfig.Configurations = configurations

	...

	content, ok := configurations[defaultContentKey] // content with bad yaml
	if !ok {
		content = string(b)
	}
	m, err := parser.Parse(content) // parse error here
	if err != nil {
		log.Debugf("GetContent fail! error: %v", err)
	}

	if len(m) > 0 {
		apolloConfig.Configurations = m // not execute
	}
	return apolloConfig, nil
}
```
