### PR TITLE
fix: replace http.DefaultServeMux fallback with safe defaults

### DIFF
--- a/transport/http/server.go
+++ b/transport/http/server.go
@@ -189,8 +189,10 @@ func NewServer(opts ...ServerOption) *Server {
 		strictSlash: true,
 		router:      mux.NewRouter(),
 	}
-	srv.router.NotFoundHandler = http.DefaultServeMux
-	srv.router.MethodNotAllowedHandler = http.DefaultServeMux
+	srv.router.NotFoundHandler = http.NotFoundHandler()
+	srv.router.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	})
 	for _, o := range opts {
 		o(srv)
 	}


### PR DESCRIPTION
Fixes #3810

## Security Issue

The HTTP server sets `http.DefaultServeMux` as the fallback handler for unmatched routes and disallowed methods. Since `DefaultServeMux` is a global shared instance, packages that register handlers in `init()` (most notably `net/http/pprof`) are inadvertently exposed to the network.

Any request to an unregistered route (e.g. `/debug/pprof/`) falls through to `DefaultServeMux`, potentially exposing profiling data, goroutine dumps, and heap profiles.

## Fix

Replace with safe defaults:
- `http.NotFoundHandler()` for `NotFoundHandler` (returns 404)
- A simple 405 handler for `MethodNotAllowedHandler`

Users who need the previous behavior can explicitly opt-in using the existing `NotFoundHandler()` and `MethodNotAllowedHandler()` server options added in #3131.

## Breaking Change

This is technically a breaking change for anyone relying on the `DefaultServeMux` fallback behavior, but the previous default was a security risk. The `NotFoundHandler()` and `MethodNotAllowedHandler()` options provide a migration path.