### PR TITLE
feat: update yaml package import from gopkg.in to go.yaml.in

### DIFF
--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -1,7 +1,7 @@
 package yaml
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/go-kratos/kratos/v2/encoding"
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240102182953-50ed04b92917
 	google.golang.org/grpc v1.61.1
 	google.golang.org/protobuf v1.33.0
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v3 v3.0.1
 )
 
 require (
@@ -46,3 +46,5 @@ require (
 )
 
 retract v2.9.0
+
+replace go.yaml.in/yaml/v3 => gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
## Summary

Update the YAML package import path from the legacy `gopkg.in/yaml.v3` to the canonical `go.yaml.in/yaml/v3` path.

### Changes

- `encoding/yaml/yaml.go`: Changed import from `gopkg.in/yaml.v3` to `go.yaml.in/yaml/v3`
- `go.mod`: Updated dependency to use `go.yaml.in/yaml/v3` with a replace directive

### Rationale

The `go.yaml.in` domain is the official canonical path for the YAML package, maintained by the official YAML organization. This migration aligns with Go best practices for module path canonicalization.