### PR TITLE
feat(encoding): split json and protojson codecs

### DIFF
--- a/config/value.go
+++ b/config/value.go
@@ -8,9 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-
-	kratosjson "github.com/go-kratos/kratos/v3/encoding/json"
 )
 
 var (
@@ -172,7 +171,7 @@ func (v *atomicValue) Scan(obj any) error {
 		return err
 	}
 	if pb, ok := obj.(proto.Message); ok {
-		return kratosjson.UnmarshalOptions.Unmarshal(data, pb)
+		return protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, pb)
 	}
 	return json.Unmarshal(data, obj)
 }

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -2,27 +2,12 @@ package json
 
 import (
 	"encoding/json"
-	"reflect"
-
-	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/go-kratos/kratos/v3/encoding"
 )
 
 // Name is the name registered for the json codec.
 const Name = "json"
-
-var (
-	// MarshalOptions is a configurable JSON format marshaller.
-	MarshalOptions = protojson.MarshalOptions{
-		EmitUnpopulated: true,
-	}
-	// UnmarshalOptions is a configurable JSON format parser.
-	UnmarshalOptions = protojson.UnmarshalOptions{
-		DiscardUnknown: true,
-	}
-)
 
 func init() {
 	encoding.RegisterCodec(codec{})
@@ -35,8 +20,6 @@ func (codec) Marshal(v any) ([]byte, error) {
 	switch m := v.(type) {
 	case json.Marshaler:
 		return m.MarshalJSON()
-	case proto.Message:
-		return MarshalOptions.Marshal(m)
 	default:
 		return json.Marshal(m)
 	}
@@ -49,19 +32,7 @@ func (codec) Unmarshal(data []byte, v any) error {
 	switch m := v.(type) {
 	case json.Unmarshaler:
 		return m.UnmarshalJSON(data)
-	case proto.Message:
-		return UnmarshalOptions.Unmarshal(data, m)
 	default:
-		rv := reflect.ValueOf(v)
-		for rv := rv; rv.Kind() == reflect.Pointer; {
-			if rv.IsNil() {
-				rv.Set(reflect.New(rv.Type().Elem()))
-			}
-			rv = rv.Elem()
-		}
-		if m, ok := reflect.Indirect(rv).Interface().(proto.Message); ok {
-			return UnmarshalOptions.Unmarshal(data, m)
-		}
 		return json.Unmarshal(data, m)
 	}
 }

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -78,7 +78,7 @@ func TestJSON_Marshal(t *testing.T) {
 		},
 		{
 			input:  &testData.TestModel{Id: 1, Name: "go-kratos", Hobby: []string{"1", "2"}},
-			expect: `{"id":"1","name":"go-kratos","hobby":["1","2"],"attrs":{}}`,
+			expect: `{"id":1,"name":"go-kratos","hobby":["1","2"]}`,
 		},
 		{
 			input:  &mock{value: Gopher},
@@ -102,8 +102,7 @@ func TestJSON_Marshal(t *testing.T) {
 
 func TestJSON_Unmarshal(t *testing.T) {
 	p := testMessage{}
-	p2 := testData.TestModel{}
-	p3 := &testData.TestModel{}
+	p2 := &testData.TestModel{}
 	p4 := &mock{}
 	tests := []struct {
 		input  string
@@ -118,12 +117,8 @@ func TestJSON_Unmarshal(t *testing.T) {
 			expect: &p,
 		},
 		{
-			input:  `{"id":"1","name":"go-kratos","hobby":["1","2"],"attrs":{}}`,
-			expect: &p2,
-		},
-		{
 			input:  `{"id":1,"name":"go-kratos","hobby":["1","2"]}`,
-			expect: &p3,
+			expect: &p2,
 		},
 		{
 			input:  `"zebra"`,

--- a/encoding/protojson/protojson.go
+++ b/encoding/protojson/protojson.go
@@ -1,0 +1,54 @@
+package protojson
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/go-kratos/kratos/v3/encoding"
+)
+
+// Name is the name registered for the protojson codec.
+const Name = "protojson"
+
+var (
+	// MarshalOptions is a configurable JSON format marshaller.
+	MarshalOptions = protojson.MarshalOptions{
+		EmitUnpopulated: true,
+	}
+	// UnmarshalOptions is a configurable JSON format parser.
+	UnmarshalOptions = protojson.UnmarshalOptions{
+		DiscardUnknown: true,
+	}
+)
+
+func init() {
+	encoding.RegisterCodec(codec{})
+}
+
+// codec is a Codec implementation with protojson.
+type codec struct{}
+
+func (codec) Marshal(v any) ([]byte, error) {
+	m, ok := v.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
+	}
+	return MarshalOptions.Marshal(m)
+}
+
+func (codec) Unmarshal(data []byte, v any) error {
+	if len(data) == 0 {
+		return nil
+	}
+	m, ok := v.(proto.Message)
+	if !ok {
+		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
+	}
+	return UnmarshalOptions.Unmarshal(data, m)
+}
+
+func (codec) Name() string {
+	return Name
+}

--- a/encoding/protojson/protojson_test.go
+++ b/encoding/protojson/protojson_test.go
@@ -1,0 +1,58 @@
+package protojson
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	testData "github.com/go-kratos/kratos/v3/internal/testdata/encoding"
+)
+
+func TestName(t *testing.T) {
+	c := new(codec)
+	if !reflect.DeepEqual(c.Name(), "protojson") {
+		t.Errorf("expected %v, got %v", "protojson", c.Name())
+	}
+}
+
+func TestCodec(t *testing.T) {
+	c := new(codec)
+	model := testData.TestModel{
+		Id:    1,
+		Name:  "go-kratos",
+		Hobby: []string{"1", "2"},
+	}
+
+	data, err := c.Marshal(&model)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if got, want := strings.ReplaceAll(string(data), " ", ""), `{"id":"1","name":"go-kratos","hobby":["1","2"],"attrs":{}}`; got != want {
+		t.Errorf("Marshal() = %s, want %s", got, want)
+	}
+
+	var out testData.TestModel
+	if err := c.Unmarshal([]byte(`{"id":"1","name":"go-kratos","hobby":["1","2"],"unknown":"discarded"}`), &out); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !reflect.DeepEqual(out.Id, model.Id) {
+		t.Errorf("Id = %d, want %d", out.Id, model.Id)
+	}
+	if !reflect.DeepEqual(out.Name, model.Name) {
+		t.Errorf("Name = %s, want %s", out.Name, model.Name)
+	}
+	if !reflect.DeepEqual(out.Hobby, model.Hobby) {
+		t.Errorf("Hobby = %v, want %v", out.Hobby, model.Hobby)
+	}
+}
+
+func TestCodecRejectsNonProtoMessage(t *testing.T) {
+	c := new(codec)
+
+	if _, err := c.Marshal(struct{}{}); err == nil {
+		t.Fatal("Marshal() error = nil, want error")
+	}
+	if err := c.Unmarshal([]byte("{}"), &struct{}{}); err == nil {
+		t.Fatal("Unmarshal() error = nil, want error")
+	}
+}

--- a/transport/grpc/codec.go
+++ b/transport/grpc/codec.go
@@ -7,8 +7,10 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	enc "github.com/go-kratos/kratos/v3/encoding"
-	"github.com/go-kratos/kratos/v3/encoding/json"
+	"github.com/go-kratos/kratos/v3/encoding/protojson"
 )
+
+const jsonName = "json"
 
 func init() {
 	encoding.RegisterCodec(codec{})
@@ -22,7 +24,7 @@ func (codec) Marshal(v any) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to marshal, message is %T, want proto.Message", v)
 	}
-	return enc.GetCodec(json.Name).Marshal(vv)
+	return enc.GetCodec(protojson.Name).Marshal(vv)
 }
 
 func (codec) Unmarshal(data []byte, v any) error {
@@ -30,9 +32,9 @@ func (codec) Unmarshal(data []byte, v any) error {
 	if !ok {
 		return fmt.Errorf("failed to unmarshal, message is %T, want proto.Message", v)
 	}
-	return enc.GetCodec(json.Name).Unmarshal(data, vv)
+	return enc.GetCodec(protojson.Name).Unmarshal(data, vv)
 }
 
 func (codec) Name() string {
-	return json.Name
+	return jsonName
 }

--- a/transport/grpc/codec_test.go
+++ b/transport/grpc/codec_test.go
@@ -13,9 +13,15 @@ func TestCodec(t *testing.T) {
 		t.Errorf("grpc codec create input data error:%v", err)
 	}
 	c := codec{}
+	if c.Name() != "json" {
+		t.Errorf("grpc codec name want %v, got %v", "json", c.Name())
+	}
 	data, err := c.Marshal(in)
 	if err != nil {
 		t.Errorf("grpc codec marshal error:%v", err)
+	}
+	if string(data) != `{"Golang":"Kratos"}` {
+		t.Errorf("grpc codec marshal want %v, got %v", `{"Golang":"Kratos"}`, string(data))
 	}
 	out := &structpb.Struct{}
 	err = c.Unmarshal(data, out)

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/go-kratos/kratos/v3/encoding/form"
 	_ "github.com/go-kratos/kratos/v3/encoding/json"
 	_ "github.com/go-kratos/kratos/v3/encoding/proto"
+	_ "github.com/go-kratos/kratos/v3/encoding/protojson"
 	_ "github.com/go-kratos/kratos/v3/encoding/xml"
 	_ "github.com/go-kratos/kratos/v3/encoding/yaml"
 )


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

This PR splits the JSON codec behavior into two explicit codecs:

- `encoding/json` now uses only the Go standard library `encoding/json` package and keeps the registered codec name `json`.
- `encoding/protojson` is added as a separate codec with registered name `protojson`.
- `transport/grpc` keeps its gRPC codec name as `json`, but continues to use protojson semantics internally.

This removes the implicit protobuf JSON behavior from `encoding/json` and lets users opt into protojson explicitly.

#### Which issue(s) this PR fixes (resolves / be part of):

Part of #3820

#### Other special notes for the reviewers:

BREAKING CHANGE: `encoding/json` no longer handles protobuf JSON. Users that need protobuf JSON should import `_ "github.com/go-kratos/kratos/v3/encoding/protojson"` and use the `protojson` codec explicitly.

Validation:

- `go test ./encoding/json ./encoding/protojson ./encoding/proto ./encoding ./transport/http ./transport/grpc ./config`
- `go list -deps ./encoding/json | rg 'google.golang.org/protobuf' || true`
- `make lint`

Local `make test` was started, but this environment does not provide the external Nacos and Consul services used by `contrib/config/nacos` and `contrib/config/consul` tests (`127.0.0.1:8848` and `127.0.0.1:8500`). The main module and the earlier modules in the test sequence passed before the external-service block.
