### PR TITLE
refactor(config): remove mergo dependency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"dario.cat/mergo"
-
 	// init encoding
 	_ "github.com/go-kratos/kratos/v3/encoding/json"
 	_ "github.com/go-kratos/kratos/v3/encoding/proto"
@@ -46,9 +44,7 @@ func New(opts ...Option) Config {
 	o := options{
 		decoder:  defaultDecoder,
 		resolver: defaultResolver,
-		merge: func(dst, src any) error {
-			return mergo.Map(dst, src, mergo.WithOverride)
-		},
+		merge:    defaultMerge,
 	}
 	for _, opt := range opts {
 		opt(&o)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -3,8 +3,6 @@ package config
 import (
 	"errors"
 	"testing"
-
-	"dario.cat/mergo"
 )
 
 const (
@@ -133,9 +131,7 @@ func TestConfig(t *testing.T) {
 		sources:  []Source{jSource},
 		decoder:  defaultDecoder,
 		resolver: defaultResolver,
-		merge: func(dst, src any) error {
-			return mergo.Map(dst, src, mergo.WithOverride)
-		},
+		merge:    defaultMerge,
 	}
 	cf := &config{}
 	cf.opts = opts

--- a/config/file/watcher.go
+++ b/config/file/watcher.go
@@ -38,7 +38,7 @@ func (w *watcher) Next() ([]*config.KeyValue, error) {
 	case <-w.ctx.Done():
 		return nil, w.ctx.Err()
 	case event := <-w.fw.Events:
-		if event.Op == fsnotify.Rename {
+		if event.Has(fsnotify.Rename) {
 			if _, err := os.Stat(event.Name); err == nil || os.IsExist(err) {
 				if err := w.fw.Add(event.Name); err != nil {
 					return nil, err

--- a/config/merge.go
+++ b/config/merge.go
@@ -1,0 +1,48 @@
+package config
+
+import "fmt"
+
+func defaultMerge(dst, src any) error {
+	dstMap, ok := dst.(*map[string]any)
+	if !ok {
+		return fmt.Errorf("config: merge dst must be *map[string]interface{}, got %T", dst)
+	}
+	srcMap, ok := convertMap(src).(map[string]any)
+	if !ok {
+		return fmt.Errorf("config: merge src must be map[string]interface{}, got %T", src)
+	}
+	if *dstMap == nil {
+		*dstMap = make(map[string]any, len(srcMap))
+	}
+	mergeMap(*dstMap, srcMap)
+	return nil
+}
+
+func mergeMap(dst, src map[string]any) {
+	for key, srcValue := range src {
+		if srcMap, ok := srcValue.(map[string]any); ok {
+			if dstMap, ok := dst[key].(map[string]any); ok {
+				mergeMap(dstMap, srcMap)
+				continue
+			}
+		}
+		dst[key] = cloneMergeValue(srcValue)
+	}
+}
+
+func cloneMergeValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(val))
+		mergeMap(cloned, val)
+		return cloned
+	case []any:
+		cloned := make([]any, len(val))
+		for i, item := range val {
+			cloned[i] = cloneMergeValue(item)
+		}
+		return cloned
+	default:
+		return val
+	}
+}

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDefaultMerge(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  map[string]any
+		src  any
+		want map[string]any
+	}{
+		{
+			name: "merge nested maps and override leaves",
+			dst: map[string]any{
+				"server": map[string]any{
+					"http": map[string]any{
+						"addr": "0.0.0.0",
+						"port": 80,
+					},
+					"grpc": true,
+				},
+				"endpoints": []any{"a.example.com"},
+			},
+			src: map[string]any{
+				"server": map[string]any{
+					"http": map[string]any{
+						"port": 8080,
+						"tls":  true,
+					},
+				},
+				"endpoints": []any{"b.example.com", "c.example.com"},
+			},
+			want: map[string]any{
+				"server": map[string]any{
+					"http": map[string]any{
+						"addr": "0.0.0.0",
+						"port": 8080,
+						"tls":  true,
+					},
+					"grpc": true,
+				},
+				"endpoints": []any{"b.example.com", "c.example.com"},
+			},
+		},
+		{
+			name: "override type conflicts and nil values",
+			dst: map[string]any{
+				"map_to_scalar": map[string]any{"value": "old"},
+				"scalar_to_map": "old",
+				"nil_value":     "old",
+			},
+			src: map[string]any{
+				"map_to_scalar": "new",
+				"scalar_to_map": map[string]any{"value": "new"},
+				"nil_value":     nil,
+			},
+			want: map[string]any{
+				"map_to_scalar": "new",
+				"scalar_to_map": map[string]any{"value": "new"},
+				"nil_value":     nil,
+			},
+		},
+		{
+			name: "convert map keys",
+			dst:  map[string]any{},
+			src: map[any]any{
+				"service": map[any]any{
+					"name": "kratos",
+				},
+			},
+			want: map[string]any{
+				"service": map[string]any{
+					"name": "kratos",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := defaultMerge(&tt.dst, tt.src); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(tt.dst, tt.want) {
+				t.Fatalf("defaultMerge() = %#v, want %#v", tt.dst, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultMergeClonesSourceValues(t *testing.T) {
+	srcMap := map[string]any{"name": "kratos"}
+	srcSlice := []any{map[string]any{"port": 8000}}
+	dst := map[string]any{}
+
+	if err := defaultMerge(&dst, map[string]any{
+		"server":    srcMap,
+		"listeners": srcSlice,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srcMap["name"] = "changed"
+	srcSlice[0].(map[string]any)["port"] = 9000
+
+	want := map[string]any{
+		"server":    map[string]any{"name": "kratos"},
+		"listeners": []any{map[string]any{"port": 8000}},
+	}
+	if !reflect.DeepEqual(dst, want) {
+		t.Fatalf("defaultMerge() retained source aliases: got %#v, want %#v", dst, want)
+	}
+}
+
+func TestDefaultMergeInvalidInput(t *testing.T) {
+	dst := map[string]any{}
+	if err := defaultMerge(dst, map[string]any{}); err == nil {
+		t.Fatal("defaultMerge() error is nil for non-pointer dst")
+	}
+	if err := defaultMerge(&dst, []any{}); err == nil {
+		t.Fatal("defaultMerge() error is nil for non-map src")
+	}
+}

--- a/config/reader_test.go
+++ b/config/reader_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-kratos/kratos/v3/encoding"
-
-	"dario.cat/mergo"
 )
 
 func TestReader_Merge(t *testing.T) {
@@ -23,9 +21,7 @@ func TestReader_Merge(t *testing.T) {
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
 		resolver: defaultResolver,
-		merge: func(dst, src any) error {
-			return mergo.Map(dst, src, mergo.WithOverride)
-		},
+		merge:    defaultMerge,
 	}
 	r := newReader(opts)
 	err = r.Merge(&KeyValue{
@@ -87,9 +83,7 @@ func TestReader_Value(t *testing.T) {
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
 		resolver: defaultResolver,
-		merge: func(dst, src any) error {
-			return mergo.Map(dst, src, mergo.WithOverride)
-		},
+		merge:    defaultMerge,
 	}
 
 	ymlval := `
@@ -192,9 +186,7 @@ func TestReader_Source(t *testing.T) {
 			return fmt.Errorf("unsupported key: %s format: %s", kv.Key, kv.Format)
 		},
 		resolver: defaultResolver,
-		merge: func(dst, src any) error {
-			return mergo.Map(dst, src, mergo.WithOverride)
-		},
+		merge:    defaultMerge,
 	}
 	r := newReader(opts)
 	err = r.Merge(&KeyValue{

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/go-kratos/kratos/v3
 go 1.22
 
 require (
-	dario.cat/mergo v1.0.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-playground/form/v4 v4.2.0
 	github.com/google/uuid v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
-dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 github.com/census-instrumentation/opencensus-proto v0.4.1 h1:iKLQ0xPNFxR/2hzXZMrBo8f1j86j5WHzznCCQxV/b8g=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
 github.com/cncf/xds/go v0.0.0-20231109132714-523115ebc101 h1:7To3pQ+pZo0i3dsWEbinPNFs5gPSBOsJtx3wTT94VBY=

--- a/internal/testdata/helloworld/helloworld_http.pb.go
+++ b/internal/testdata/helloworld/helloworld_http.pb.go
@@ -13,7 +13,7 @@ import (
 // is compatible with the kratos package it is being compiled against.
 var _ = new(context.Context)
 
-const _ = http.SupportPackageIsVersion1
+const _ = http.SupportPackageIsVersion3
 
 const OperationGreeterSayHello = "/helloworld.Greeter/SayHello"
 


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

This PR removes the core `config` package dependency on `dario.cat/mergo` by replacing the default merge function with an internal map merge implementation.

It keeps `github.com/fsnotify/fsnotify` because `config/file` still requires filesystem watching, and updates the watcher rename check to use `event.Has(fsnotify.Rename)` for combined fsnotify operations.

It also refreshes the stale helloworld HTTP generated testdata assertion so it references the only retained HTTP support constant, `http.SupportPackageIsVersion3`.

Local validation:

- `go build ./...`
- `go test -v ./...`
- `go test -race ./config/... ./transport/http ./internal/testdata/helloworld`
- `make lint`
- `git diff --check`

Note: `make test` was started and passed the root module plus early contrib modules, then was stopped while waiting in `contrib/config/nacos` because this local environment does not run the CI service dependencies.

#### Which issue(s) this PR fixes (resolves / be part of):

Part of #3820

#### Other special notes for the reviewers:

`github.com/fsnotify/fsnotify` is intentionally retained; removing it would require a larger design change to make file watching optional or split the file source into another module.