### PR TITLE
perf(selector/wrr): detect stale entries in O(1) instead of a per-pick map scan

### DIFF
--- a/selector/wrr/wrr.go
+++ b/selector/wrr/wrr.go
@@ -25,29 +25,6 @@ type options struct{}
 type Balancer struct {
 	mu            sync.Mutex
 	currentWeight map[string]float64
-	lastNodes     []selector.WeightedNode
-}
-
-// equalNodes checks if two slices of WeightedNode contain the same nodes
-func equalNodes(a, b []selector.WeightedNode) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	// Create a map of addresses from slice a
-	aMap := make(map[string]bool, len(a))
-	for _, node := range a {
-		aMap[node.Address()] = true
-	}
-
-	// Check if all nodes in slice b exist in slice a
-	for _, node := range b {
-		if !aMap[node.Address()] {
-			return false
-		}
-	}
-
-	return true
 }
 
 // New random a selector.
@@ -63,26 +40,6 @@ func (p *Balancer) Pick(_ context.Context, nodes []selector.WeightedNode) (selec
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-
-	// Check if the node list has changed
-	if !equalNodes(p.lastNodes, nodes) {
-		// Update lastNodes
-		p.lastNodes = make([]selector.WeightedNode, len(nodes))
-		copy(p.lastNodes, nodes)
-
-		// Create a set of current node addresses for cleanup
-		currentNodes := make(map[string]bool, len(nodes))
-		for _, node := range nodes {
-			currentNodes[node.Address()] = true
-		}
-
-		// Clean up stale entries from currentWeight map
-		for address := range p.currentWeight {
-			if !currentNodes[address] {
-				delete(p.currentWeight, address)
-			}
-		}
-	}
 
 	var totalWeight float64
 	var selected selector.WeightedNode
@@ -102,8 +59,31 @@ func (p *Balancer) Pick(_ context.Context, nodes []selector.WeightedNode) (selec
 	}
 	p.currentWeight[selected.Address()] = selectWeight - totalWeight
 
+	// After the loop, currentWeight has an entry for every current node, plus any
+	// leftover entries for nodes that have disappeared from service discovery. So
+	// len(currentWeight) > len(nodes) exactly when stale entries exist: drop them
+	// to keep the map from growing without bound as nodes churn. When the node set
+	// is unchanged (the common case) the sizes match and cleanup is skipped, so the
+	// per-pick cost is just the algorithm itself with no extra bookkeeping.
+	if len(p.currentWeight) > len(nodes) {
+		p.cleanupStaleEntries(nodes)
+	}
+
 	d := selected.Pick()
 	return selected, d, nil
+}
+
+// cleanupStaleEntries removes currentWeight entries whose node is no longer present.
+func (p *Balancer) cleanupStaleEntries(nodes []selector.WeightedNode) {
+	current := make(map[string]struct{}, len(nodes))
+	for _, node := range nodes {
+		current[node.Address()] = struct{}{}
+	}
+	for address := range p.currentWeight {
+		if _, ok := current[address]; !ok {
+			delete(p.currentWeight, address)
+		}
+	}
 }
 
 // NewBuilder returns a selector builder with wrr balancer

--- a/selector/wrr/wrr_invariant_test.go
+++ b/selector/wrr/wrr_invariant_test.go
@@ -1,0 +1,63 @@
+package wrr
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/go-kratos/kratos/v3/selector"
+)
+
+// TestNoStaleEntriesUnderRandomChurn is a differential/property check: after any
+// sequence of random node-set changes, currentWeight must track exactly the live
+// node addresses and nothing else. This validates that the O(1) length-based
+// staleness detection is equivalent to a full per-pick set comparison.
+func TestNoStaleEntriesUnderRandomChurn(t *testing.T) {
+	balancer := &Balancer{currentWeight: make(map[string]float64)}
+	ctx := context.Background()
+	rng := rand.New(rand.NewPCG(1, 2))
+
+	makeNode := func(i int) selector.WeightedNode {
+		return &mockWeightedNode{address: fmt.Sprintf("node-%d", i), weight: float64(1 + i%10)}
+	}
+
+	for iter := 0; iter < 20000; iter++ {
+		// Build a random live set of 1..12 distinct nodes drawn from a pool of 20.
+		size := 1 + rng.IntN(12)
+		perm := rng.Perm(20)
+		live := make(map[string]struct{}, size)
+		nodes := make([]selector.WeightedNode, 0, size)
+		for _, idx := range perm[:size] {
+			n := makeNode(idx)
+			nodes = append(nodes, n)
+			live[n.Address()] = struct{}{}
+		}
+
+		// A few picks against this set (steady state between changes).
+		for p := 0; p < 1+rng.IntN(3); p++ {
+			if _, _, err := balancer.Pick(ctx, nodes); err != nil {
+				t.Fatalf("iter %d: unexpected error: %v", iter, err)
+			}
+		}
+
+		// currentWeight must equal the live set exactly: no stale, no missing.
+		if len(balancer.currentWeight) != len(live) {
+			t.Fatalf("iter %d: currentWeight has %d entries, want %d (%v)",
+				iter, len(balancer.currentWeight), len(live), keysOf(balancer.currentWeight))
+		}
+		for addr := range balancer.currentWeight {
+			if _, ok := live[addr]; !ok {
+				t.Fatalf("iter %d: stale entry %q lingered in currentWeight", iter, addr)
+			}
+		}
+	}
+}
+
+func keysOf(m map[string]float64) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}

--- a/selector/wrr/wrr_test.go
+++ b/selector/wrr/wrr_test.go
@@ -114,125 +114,78 @@ func TestCurrentWeightCleanup(t *testing.T) {
 	}
 }
 
-// TestCleanupOnlyWhenNodesChange verifies that cleanup logic only runs when nodes actually change
+// addrSet returns the set of addresses currently tracked in currentWeight.
+func addrSet(b *Balancer) map[string]struct{} {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	s := make(map[string]struct{}, len(b.currentWeight))
+	for addr := range b.currentWeight {
+		s[addr] = struct{}{}
+	}
+	return s
+}
+
+// assertTracked checks that currentWeight tracks exactly the given addresses,
+// i.e. no stale entries linger and the map never grows beyond the live node set.
+func assertTracked(t *testing.T, b *Balancer, want ...string) {
+	t.Helper()
+	got := addrSet(b)
+	if len(got) != len(want) {
+		t.Fatalf("currentWeight tracks %d entries, want %d (%v)", len(got), len(want), got)
+	}
+	for _, addr := range want {
+		if _, ok := got[addr]; !ok {
+			t.Fatalf("expected %q to be tracked, currentWeight=%v", addr, got)
+		}
+	}
+}
+
+// TestCleanupOnlyWhenNodesChange verifies that repeated picks with the same node
+// set never accumulate stale entries, and that changing the node set (including a
+// same-length swap and a partial overlap) drops entries for nodes that disappeared.
 func TestCleanupOnlyWhenNodesChange(t *testing.T) {
-	// Create a custom balancer that tracks cleanup calls
-	type trackingBalancer struct {
-		*Balancer
-		cleanupCount int
-	}
-
-	// Override the Pick method to count cleanup operations
-	balancer := &trackingBalancer{
-		Balancer: &Balancer{currentWeight: make(map[string]float64)},
-	}
-
-	originalPick := func(_ context.Context, nodes []selector.WeightedNode) (selector.WeightedNode, selector.DoneFunc, error) {
-		if len(nodes) == 0 {
-			return nil, nil, selector.ErrNoAvailable
-		}
-
-		balancer.mu.Lock()
-		defer balancer.mu.Unlock()
-
-		// Check if the node list has changed
-		if len(balancer.lastNodes) != len(nodes) || !equalNodes(balancer.lastNodes, nodes) {
-			balancer.cleanupCount++ // Count cleanup operations
-
-			// Update lastNodes
-			balancer.lastNodes = make([]selector.WeightedNode, len(nodes))
-			copy(balancer.lastNodes, nodes)
-
-			// Create a set of current node addresses for cleanup
-			currentNodes := make(map[string]bool)
-			for _, node := range nodes {
-				currentNodes[node.Address()] = true
-			}
-
-			// Clean up stale entries from currentWeight map
-			for address := range balancer.currentWeight {
-				if !currentNodes[address] {
-					delete(balancer.currentWeight, address)
-				}
-			}
-		}
-
-		var totalWeight float64
-		var selected selector.WeightedNode
-		var selectWeight float64
-
-		// nginx wrr load balancing algorithm
-		for _, node := range nodes {
-			totalWeight += node.Weight()
-			cwt := balancer.currentWeight[node.Address()]
-			cwt += node.Weight()
-			balancer.currentWeight[node.Address()] = cwt
-			if selected == nil || selectWeight < cwt {
-				selectWeight = cwt
-				selected = node
-			}
-		}
-		balancer.currentWeight[selected.Address()] = selectWeight - totalWeight
-
-		d := selected.Pick()
-		return selected, d, nil
-	}
-
 	ctx := context.Background()
+	balancer := &Balancer{currentWeight: make(map[string]float64)}
+
 	nodes1 := []selector.WeightedNode{
 		&mockWeightedNode{address: "node1", weight: 10},
 		&mockWeightedNode{address: "node2", weight: 20},
 	}
-
+	// nodes2 is a full swap of nodes1 with the same length - the trickiest case
+	// for length-based staleness detection.
 	nodes2 := []selector.WeightedNode{
 		&mockWeightedNode{address: "node3", weight: 30},
 		&mockWeightedNode{address: "node4", weight: 40},
 	}
-
-	var err error
-
-	// First call with nodes1 - should trigger cleanup (initialization)
-	_, _, err = originalPick(ctx, nodes1)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// nodes3 keeps node3 but replaces node4 with node5 (same length, partial overlap).
+	nodes3 := []selector.WeightedNode{
+		&mockWeightedNode{address: "node3", weight: 30},
+		&mockWeightedNode{address: "node5", weight: 50},
 	}
 
-	if balancer.cleanupCount != 1 {
-		t.Errorf("expected 1 cleanup call after first pick, got %d", balancer.cleanupCount)
-	}
-
-	// Multiple calls with same nodes1 - should NOT trigger additional cleanup
-	for i := 0; i < 5; i++ {
-		_, _, err = originalPick(ctx, nodes1)
-		if err != nil {
+	pick := func(nodes []selector.WeightedNode) {
+		t.Helper()
+		if _, _, err := balancer.Pick(ctx, nodes); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	}
 
-	if balancer.cleanupCount != 1 {
-		t.Errorf("expected still 1 cleanup call after repeated picks with same nodes, got %d", balancer.cleanupCount)
+	// Repeated picks with the same nodes must not grow the map.
+	for i := 0; i < 6; i++ {
+		pick(nodes1)
+		assertTracked(t, balancer, "node1", "node2")
 	}
 
-	// Call with different nodes2 - should trigger cleanup
-	_, _, err = originalPick(ctx, nodes2)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// Full swap of an equal-length node set must drop the old entries.
+	for i := 0; i < 4; i++ {
+		pick(nodes2)
+		assertTracked(t, balancer, "node3", "node4")
 	}
 
-	if balancer.cleanupCount != 2 {
-		t.Errorf("expected 2 cleanup calls after node change, got %d", balancer.cleanupCount)
-	}
-
-	// Multiple calls with same nodes2 - should NOT trigger additional cleanup
-	for i := 0; i < 3; i++ {
-		_, _, err = originalPick(ctx, nodes2)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	}
-
-	if balancer.cleanupCount != 2 {
-		t.Errorf("expected still 2 cleanup calls after repeated picks with same nodes, got %d", balancer.cleanupCount)
+	// Partial overlap swap: node4 leaves, node5 joins, node3 stays.
+	for i := 0; i < 4; i++ {
+		pick(nodes3)
+		assertTracked(t, balancer, "node3", "node5")
 	}
 }
 


### PR DESCRIPTION
## Summary

`wrr` is the default client-side balancer for both the HTTP and gRPC clients, so
`Balancer.Pick` runs on **every outbound RPC**. Since #3690 every `Pick` built a
`map[string]bool` of all node addresses plus a `lastNodes` copy and compared them
(`equalNodes`) just to detect whether the node set changed — even though in
steady state it almost never does.

Since the `Pick` loop only touches `currentWeight` entries for *current* nodes,
after the loop `currentWeight = previousSet ∪ currentSet`, so
`len(currentWeight) > len(nodes)` holds **exactly when** a node disappeared (a
stale entry exists). This replaces `equalNodes`/`lastNodes` with that O(1) length
check; cleanup runs only when the node set actually changed. Selection output and
final `currentWeight` contents are unchanged — a pure perf refactor, net −40 LOC.

Benchstat (n=10, Apple M1 Pro, Go 1.26):

| Benchmark | before | after | delta |
|---|---|---|---|
| `PickWithSameNodes` (steady state, common case) | 225.4 ns/op | 120.8 ns/op | **−46.4%** (p=0.000) |
| `PickWithChangingNodes` (node churn) | 232.7 ns/op | 209.2 ns/op | −10.1% (p=0.000) |
| `PickWithChangingNodes` allocs | 32 B / 1 alloc | **0 B / 0 alloc** | −100% |

The win grows with cluster size, since the removed work was O(node count).

## Testing

- `TestWrr` and `TestCurrentWeightCleanup` pass unchanged.
- `TestCleanupOnlyWhenNodesChange` rewritten to assert the observable contract
  (no stale entries linger; map never grows past the live node set) through the
  real `Pick`, covering same-length full-swap and partial-overlap cases.
- Added `TestNoStaleEntriesUnderRandomChurn`: applies 20k random node-set changes
  and asserts `currentWeight` tracks exactly the live addresses. It passes
  identically against the old `equalNodes` impl, confirming equivalence.
- `go test ./selector/... ./transport/...` and `go vet ./selector/...` pass.

---

## 概述

`wrr` 是 HTTP 和 gRPC 客户端的默认负载均衡器，因此 `Balancer.Pick` 会在**每一次出站
RPC** 上执行。自 #3690 起，每次 `Pick` 都会构建一个包含所有节点地址的
`map[string]bool`，并额外保存一份 `lastNodes` 副本进行比较（`equalNodes`），仅仅是为了
判断节点集合是否发生变化——而在稳定状态下，节点集合几乎从不变化。

由于 `Pick` 循环只会访问**当前**节点对应的 `currentWeight` 条目，循环结束后
`currentWeight = 旧集合 ∪ 当前集合`，因此 `len(currentWeight) > len(nodes)` **当且仅当**
有节点消失（即存在残留条目）时成立。本 PR 用这个 O(1) 的长度判断替换了
`equalNodes`/`lastNodes`；清理仅在节点集合真正发生变化时执行。选择结果与最终的
`currentWeight` 内容保持不变——这是一次纯性能重构，净减少约 40 行代码。

Benchstat（n=10，Apple M1 Pro，Go 1.26）：

| 基准测试 | 优化前 | 优化后 | 变化 |
|---|---|---|---|
| `PickWithSameNodes`（稳定状态，常见场景） | 225.4 ns/op | 120.8 ns/op | **−46.4%**（p=0.000） |
| `PickWithChangingNodes`（节点变动） | 232.7 ns/op | 209.2 ns/op | −10.1%（p=0.000） |
| `PickWithChangingNodes` 内存分配 | 32 B / 1 alloc | **0 B / 0 alloc** | −100% |

由于被移除的工作量是 O(节点数)，集群规模越大，收益越明显。

## 测试

- `TestWrr` 与 `TestCurrentWeightCleanup` 保持不变并通过。
- `TestCleanupOnlyWhenNodesChange` 重写为通过真实的 `Pick` 验证可观测契约（不残留过期
  条目；map 不会增长超过存活节点集合），覆盖等长全量替换和部分重叠两种场景。
- 新增 `TestNoStaleEntriesUnderRandomChurn`：执行 2 万次随机节点集合变更，断言
  `currentWeight` 恰好跟踪存活地址。该测试在旧的 `equalNodes` 实现上同样通过，证明行为
  等价。
- `go test ./selector/... ./transport/...` 与 `go vet ./selector/...` 均通过。
