### PR TITLE
perf(selector/p2c): remove per-pick mutex by using lock-free rand/v2

### DIFF
--- a/selector/p2c/bench_test.go
+++ b/selector/p2c/bench_test.go
@@ -1,0 +1,59 @@
+package p2c
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-kratos/kratos/v3/registry"
+	"github.com/go-kratos/kratos/v3/selector"
+)
+
+func benchSelector(nodeCount int) selector.Selector {
+	s := New()
+	nodes := make([]selector.Node, 0, nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		addr := fmt.Sprintf("127.0.0.%d:8080", i)
+		nodes = append(nodes, selector.NewNode("http", addr, &registry.ServiceInstance{
+			ID:       addr,
+			Version:  "v1.0.0",
+			Metadata: map[string]string{"weight": "10"},
+		}))
+	}
+	s.Apply(nodes)
+	return s
+}
+
+// BenchmarkSelectParallel hammers a single shared balancer from GOMAXPROCS
+// goroutines, which is how a balancer is used under real client load. The
+// per-pick mutex around the *rand.Rand serializes every pick here.
+func BenchmarkSelectParallel(b *testing.B) {
+	s := benchSelector(10)
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, done, err := s.Select(ctx)
+			if err != nil {
+				b.Fatal(err)
+			}
+			done(ctx, selector.DoneInfo{})
+		}
+	})
+}
+
+// BenchmarkSelectSerial measures the single-goroutine cost (uncontended lock).
+func BenchmarkSelectSerial(b *testing.B) {
+	s := benchSelector(10)
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, done, err := s.Select(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		done(ctx, selector.DoneInfo{})
+	}
+}

--- a/selector/p2c/p2c.go
+++ b/selector/p2c/p2c.go
@@ -3,7 +3,6 @@ package p2c
 import (
 	"context"
 	"math/rand/v2"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,17 +31,15 @@ func New(opts ...Option) selector.Selector {
 
 // Balancer is p2c selector.
 type Balancer struct {
-	mu     sync.Mutex
-	r      *rand.Rand
 	picked atomic.Bool
 }
 
 // choose two distinct nodes.
 func (s *Balancer) prePick(nodes []selector.WeightedNode) (nodeA selector.WeightedNode, nodeB selector.WeightedNode) {
-	s.mu.Lock()
-	a := s.r.IntN(len(nodes))
-	b := s.r.IntN(len(nodes) - 1)
-	s.mu.Unlock()
+	// rand/v2 top-level functions are safe for concurrent use and lock-free, so
+	// no per-balancer mutex/Rand is needed - picks no longer serialize on a lock.
+	a := rand.IntN(len(nodes))
+	b := rand.IntN(len(nodes) - 1)
 	if b >= a {
 		b = b + 1
 	}
@@ -96,5 +93,5 @@ type Builder struct{}
 
 // Build creates Balancer
 func (b *Builder) Build() selector.Balancer {
-	return &Balancer{r: rand.New(rand.NewPCG(uint64(time.Now().UnixNano()), 0))}
+	return &Balancer{}
 }


### PR DESCRIPTION
## Summary

p2c locked a `*rand.Rand` on every `prePick`, so all picks on a shared balancer
serialized on that lock. `math/rand/v2` top-level functions are concurrency-safe
and lock-free, making the mutex and the `*rand.Rand` field redundant.

## Change

- Remove `mu sync.Mutex` / `r *rand.Rand` from `Balancer`; `prePick` calls the
  package-level `rand.IntN`.
- `Builder.Build` returns `&Balancer{}`; drop the `sync` import.
- Index-selection math is untouched and `rand/v2` was already imported.

## Test

Added `BenchmarkSelectParallel`/`BenchmarkSelectSerial`. benchstat (n=6,
GOMAXPROCS=8, M1 Pro):

| Benchmark | before | after | delta |
|---|---|---|---|
| `SelectParallel` | 329.5 ns/op | 128.1 ns/op | **−61.1%** (p=0.002) |
| `SelectSerial` | 274.3 ns/op | 273.4 ns/op | ~ (p=0.084) |

Under the lock, 8-core parallel (329n) ≈ serial (274n) — picks didn't scale;
lock-free they do, and the gain grows with core count.

Selection distribution is unchanged. p2c is load-aware and intentionally
non-uniform, so a raw pick count looks skewed both before and after — that skew
comes from the EWMA weighting, not the RNG. The only thing this PR touches,
`prePick`, stays uniform (uniform RNG → uniform RNG; <0.67% deviation over 800k
picks, never returns identical nodes), and replaying the same workload against
the old impl yields the same distribution. Race-checked: full suite ×10 plus a
`cpu=16` parallel stress (~4M iterations) under `-race`, clean.

---

## 概述

p2c 在每次 `prePick` 时对一个 `*rand.Rand` 加锁，因此共用同一 balancer 的所有挑选都会在
这把锁上串行。`math/rand/v2` 的顶层函数本身并发安全且无锁，这把互斥锁和 `*rand.Rand` 字段
都是多余的。

## 改动

- 从 `Balancer` 移除 `mu sync.Mutex` / `r *rand.Rand`；`prePick` 改用包级 `rand.IntN`。
- `Builder.Build` 返回 `&Balancer{}`；移除 `sync` 导入。
- 索引选择的算法未动，且 `rand/v2` 原本就已导入。

## 测试

新增 `BenchmarkSelectParallel`/`BenchmarkSelectSerial`。benchstat（n=6，
GOMAXPROCS=8，M1 Pro）：

| 基准测试 | 优化前 | 优化后 | 变化 |
|---|---|---|---|
| `SelectParallel` | 329.5 ns/op | 128.1 ns/op | **−61.1%**（p=0.002） |
| `SelectSerial` | 274.3 ns/op | 273.4 ns/op | ~（p=0.084） |

加锁时 8 核并发（329n）≈ 单 goroutine（274n）——挑选无法随核数扩展；去锁后可以扩展，核数
越多收益越大。

选择分布不变。p2c 是负载感知的、本就刻意非均匀，因此裸挑选计数在改动前后都呈现倾斜——这个
倾斜来自 EWMA 权重，与 RNG 无关。本 PR 唯一改动的 `prePick` 仍然均匀（均匀 RNG → 均匀
RNG；80 万次挑选偏差 <0.67%，且从不返回相同节点），用相同负载在旧实现上回放得到一致的分
布。竞态检查：全套测试 ×10，外加 `cpu=16` 并发压测（约 400 万次迭代）在 `-race` 下均干净。
