### PR TITLE
fix(transport/grpc): apply WithTimeout to streaming RPCs, matching unary behaviour (fixes #3833)

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -155,7 +155,7 @@ func NewClient(ctx context.Context, opts ...ClientOption) (*grpc.ClientConn, err
 		unaryClientInterceptor(options.middleware, options.timeout, options.filters),
 	}
 	sints := []grpc.StreamClientInterceptor{
-		streamClientInterceptor(options.streamMiddleware, options.filters),
+		streamClientInterceptor(options.streamMiddleware, options.timeout, options.filters),
 	}
 
 	if len(options.ints) > 0 {
@@ -237,6 +237,11 @@ type wrappedClientStream struct {
 	grpc.ClientStream
 	ctx        context.Context
 	middleware matcher.Matcher
+	// cancel releases the per-stream timeout context created when WithTimeout is
+	// configured. It is nil when no timeout is set. Called on the first terminal
+	// RecvMsg error (including io.EOF) so the context is not held open past the
+	// stream's lifetime.
+	cancel context.CancelFunc
 }
 
 func (w *wrappedClientStream) Context() context.Context {
@@ -276,10 +281,17 @@ func (w *wrappedClientStream) RecvMsg(m any) error {
 	}
 
 	_, err := h(w.ctx, m)
+	// Release the per-stream timeout context on any terminal error (including
+	// io.EOF which signals normal stream completion). This ensures that a
+	// context created by streamClientInterceptor with WithTimeout is not held
+	// open beyond the stream's actual lifetime.
+	if err != nil && w.cancel != nil {
+		w.cancel()
+	}
 	return err
 }
 
-func streamClientInterceptor(ms []middleware.Middleware, filters []selector.NodeFilter) grpc.StreamClientInterceptor {
+func streamClientInterceptor(ms []middleware.Middleware, timeout time.Duration, filters []selector.NodeFilter) grpc.StreamClientInterceptor {
 	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) { // nolint
 		ctx = transport.NewClientContext(ctx, &Transport{
 			endpoint:    cc.Target(),
@@ -287,11 +299,23 @@ func streamClientInterceptor(ms []middleware.Middleware, filters []selector.Node
 			reqHeader:   headerCarrier{},
 			nodeFilters: filters,
 		})
+		// Apply the configured per-stream timeout. Unlike unary RPCs where the
+		// context is cancelled via defer when the handler returns, streaming RPCs
+		// are long-lived: the cancel function is stored in wrappedClientStream and
+		// called when RecvMsg receives its first terminal error (including io.EOF),
+		// so the context is released exactly when the stream ends.
+		var cancel context.CancelFunc
+		if timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+		}
 		var p selector.Peer
 		ctx = selector.NewPeerContext(ctx, &p)
 
 		clientStream, err := streamer(ctx, desc, cc, method, opts...)
 		if err != nil {
+			if cancel != nil {
+				cancel()
+			}
 			return nil, err
 		}
 
@@ -309,6 +333,7 @@ func streamClientInterceptor(ms []middleware.Middleware, filters []selector.Node
 			ClientStream: clientStream,
 			ctx:          ctx,
 			middleware:   m,
+			cancel:       cancel,
 		}
 
 		return wrappedStream, nil

--- a/transport/grpc/client_test.go
+++ b/transport/grpc/client_test.go
@@ -103,6 +103,47 @@ func TestUnaryClientInterceptor(t *testing.T) {
 	}
 }
 
+// TestStreamClientInterceptorTimeout verifies that streamClientInterceptor
+// applies the configured timeout to the stream context, mirroring the
+// behaviour of unaryClientInterceptor. A nil cancel means no timeout was
+// configured; a non-nil cancel means the timeout deadline was set.
+func TestStreamClientInterceptorTimeout(t *testing.T) {
+	// With a positive timeout the interceptor should apply a deadline.
+	interceptorWithTimeout := streamClientInterceptor(nil, 50*time.Millisecond, nil)
+	deadlineSet := false
+	_, _ = interceptorWithTimeout(
+		context.Background(),
+		&grpc.StreamDesc{},
+		&grpc.ClientConn{},
+		"/test.Service/StreamMethod",
+		func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			_, deadlineSet = ctx.Deadline()
+			// Return an error so the test does not need a real connection.
+			return nil, context.DeadlineExceeded
+		},
+	)
+	if !deadlineSet {
+		t.Error("expected a deadline on the stream context when WithTimeout is set, got none")
+	}
+
+	// Without a timeout the context should be passed through unchanged.
+	interceptorNoTimeout := streamClientInterceptor(nil, 0, nil)
+	deadlineSet = false
+	_, _ = interceptorNoTimeout(
+		context.Background(),
+		&grpc.StreamDesc{},
+		&grpc.ClientConn{},
+		"/test.Service/StreamMethod",
+		func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			_, deadlineSet = ctx.Deadline()
+			return nil, context.DeadlineExceeded
+		},
+	)
+	if deadlineSet {
+		t.Error("expected no deadline on the stream context when timeout is zero, but deadline was set")
+	}
+}
+
 func TestWithUnaryInterceptor(t *testing.T) {
 	o := &clientOptions{}
 	v := []grpc.UnaryClientInterceptor{


### PR DESCRIPTION
## Problem

Fixes #3833.

`streamClientInterceptor` ignored the `timeout` configured via `WithTimeout`, silently dropping it for all streaming RPCs. `unaryClientInterceptor` has applied `context.WithTimeout` since the interceptor was introduced; the stream counterpart was never updated to match.

```go
// Before — timeout passed to unary but NOT to streaming
ints  := []grpc.UnaryClientInterceptor{
    unaryClientInterceptor(options.middleware, options.timeout, options.filters),  // ✅
}
sints := []grpc.StreamClientInterceptor{
    streamClientInterceptor(options.streamMiddleware, options.filters),            // ❌ timeout dropped
}
```

## Impact

Streaming RPCs (server-streaming, client-streaming, bidirectional) had no bounded client-side deadline from go-kratos regardless of `WithTimeout`. When a gRPC proxy has a connection pool issue and holds the stream open, the call stalls indefinitely — whereas the same RPC as unary would be cancelled after `WithTimeout` milliseconds.

## Changes

- `streamClientInterceptor` now accepts `timeout time.Duration` and applies `context.WithTimeout` when `timeout > 0`
- The `cancel` func is stored in `wrappedClientStream` and called from `RecvMsg` on the first terminal error (including `io.EOF`), releasing the context when the stream ends rather than when the interceptor returns
- `NewClient` passes `options.timeout` to `streamClientInterceptor`

## Tests

`TestStreamClientInterceptorTimeout` verifies:
- With `timeout > 0`: the stream context carries a deadline
- With `timeout == 0`: the context is passed through unchanged

All existing `transport/grpc` tests pass. (`TestServer` failure is pre-existing on `main`.)