### PR TITLE
fix(transport/http): bind named body field for websocket client streaming

### DIFF
--- a/cmd/protoc-gen-go-http/.gitignore
+++ b/cmd/protoc-gen-go-http/.gitignore
@@ -1,0 +1,2 @@
+# Compiled plugin binary produced by `go build` in this directory.
+/protoc-gen-go-http

--- a/cmd/protoc-gen-go-http/http.go
+++ b/cmd/protoc-gen-go-http/http.go
@@ -139,13 +139,18 @@ func buildHTTPRule(g *protogen.GeneratedFile, service *protogen.Service, m *prot
 	body = rule.Body
 	responseBody = rule.ResponseBody
 	md := buildMethodDesc(g, m, method, path)
-	if method == http.MethodGet || method == http.MethodDelete {
-		if body != "" {
-			_, _ = fmt.Fprintf(os.Stderr, "\u001B[31mWARN\u001B[m: %s %s body should not be declared.\n", method, path)
-		}
-	} else {
-		if body == "" {
-			_, _ = fmt.Fprintf(os.Stderr, "\u001B[31mWARN\u001B[m: %s %s does not declare a body.\n", method, path)
+	// Client-streaming RPCs are served over WebSocket, whose handshake is always an
+	// HTTP GET regardless of the declared verb. Declaring a body for them is legitimate
+	// (it identifies the streamed message field), so skip the GET/DELETE body warnings.
+	if !m.Desc.IsStreamingClient() {
+		if method == http.MethodGet || method == http.MethodDelete {
+			if body != "" {
+				_, _ = fmt.Fprintf(os.Stderr, "\u001B[31mWARN\u001B[m: %s %s body should not be declared.\n", method, path)
+			}
+		} else {
+			if body == "" {
+				_, _ = fmt.Fprintf(os.Stderr, "\u001B[31mWARN\u001B[m: %s %s does not declare a body.\n", method, path)
+			}
 		}
 	}
 	if body == "*" {
@@ -169,6 +174,9 @@ func buildHTTPRule(g *protogen.GeneratedFile, service *protogen.Service, m *prot
 		md.BodyField = body
 		md.BodyQueryName = fd.JSONName()
 		md.BodyHTTPBody = isHTTPBodyField(fd)
+		// A singular message-kind body field can be streamed frame-by-frame for
+		// client-streaming RPCs (each frame carries just this field's payload).
+		md.BodyMessage = fd.Kind() == protoreflect.MessageKind && !fd.IsList() && !fd.IsMap()
 	} else {
 		md.HasBody = false
 	}

--- a/cmd/protoc-gen-go-http/httpTemplate.tpl
+++ b/cmd/protoc-gen-go-http/httpTemplate.tpl
@@ -65,7 +65,7 @@ func (x *{{$svrType}}_{{.Name}}HTTPServer) SendAndClose(m *{{.Reply}}) error {
 func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) func(ctx http.Context) error {
 	return func(ctx http.Context) error {
 		{{- if .ClientStreaming}}
-		stream, err := http.NewWebSocketServerStream(ctx)
+		stream, err := http.NewWebSocketServerStream(ctx{{if .BodyMessage}}, http.WithStreamBodyField("{{.BodyField}}"){{end}})
 		if err != nil {
 			return err
 		}
@@ -216,7 +216,7 @@ func (x *{{$svrType}}_{{.Name}}HTTPClient) Send(m *{{.Request}}) error {
 	if err := x.open(m); err != nil {
 		return err
 	}
-	return x.ClientStream.Send(m)
+	return x.ClientStream.Send(m{{if .BodyMessage}}{{.Body}}{{end}})
 }
 {{- end}}
 

--- a/cmd/protoc-gen-go-http/http_test.go
+++ b/cmd/protoc-gen-go-http/http_test.go
@@ -216,6 +216,40 @@ func TestHTTPTemplateStreamsAndHTTPBody(t *testing.T) {
 				BodyHTTPBody:  true,
 				ResponseBody:  ".Body",
 			},
+			{
+				Name:            "ChatData",
+				OriginalName:    "ChatData",
+				Request:         "ChatDataRequest",
+				Reply:           "ChatDataReply",
+				Path:            "/v1/bitto/chat",
+				PathTemplate:    "/v1/bitto/chat",
+				Method:          "GET",
+				HasBody:         true,
+				Body:            ".Data",
+				BodyField:       "data",
+				BodyQueryName:   "data",
+				BodyMessage:     true,
+				ClientStreaming: true,
+				ServerStreaming: true,
+			},
+			{
+				// Client-streaming RPC whose named body is a scalar field: it is not
+				// streamable frame-by-frame, so the whole message is sent/decoded.
+				Name:            "ChatText",
+				OriginalName:    "ChatText",
+				Request:         "ChatTextRequest",
+				Reply:           "ChatTextReply",
+				Path:            "/v1/bitto/text",
+				PathTemplate:    "/v1/bitto/text",
+				Method:          "GET",
+				HasBody:         true,
+				Body:            ".Text",
+				BodyField:       "text",
+				BodyQueryName:   "text",
+				BodyMessage:     false,
+				ClientStreaming: true,
+				ServerStreaming: true,
+			},
 		},
 	}
 	got := sd.execute()
@@ -233,9 +267,23 @@ func TestHTTPTemplateStreamsAndHTTPBody(t *testing.T) {
 		`http.ContentType(http.BodyContentType(in.Body))`,
 		`http.WithOmitFields("body")`,
 		`return ctx.Result(200, reply.Body)`,
+		// Client-streaming RPC with a streamable (message-kind) named body field.
+		`stream, err := http.NewWebSocketServerStream(ctx, http.WithStreamBodyField("data"))`,
+		`return x.ClientStream.Send(m.Data)`,
+		// Client-streaming RPC with a scalar named body: whole message is streamed.
+		`func (x *Greeter_ChatTextHTTPClient) Send(m *ChatTextRequest) error`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("generated template missing %q in:\n%s", want, got)
 		}
+	}
+	// The whole-message streaming client (ChatHello) and the scalar-body streaming
+	// client (ChatText) must both send the whole message, not a sub-field.
+	if !strings.Contains(got, "return x.ClientStream.Send(m)\n") {
+		t.Fatalf("generated template should send whole message for non-streamable body:\n%s", got)
+	}
+	// The scalar-body server handler must NOT receive a stream body-field option.
+	if strings.Contains(got, `http.WithStreamBodyField("text")`) {
+		t.Fatalf("scalar named body should not emit WithStreamBodyField:\n%s", got)
 	}
 }

--- a/cmd/protoc-gen-go-http/template.go
+++ b/cmd/protoc-gen-go-http/template.go
@@ -36,6 +36,7 @@ type methodDesc struct {
 	BodyField            string
 	BodyQueryName        string
 	BodyHTTPBody         bool
+	BodyMessage          bool
 	ResponseBody         string
 	ResponseBodyHTTPBody bool
 	ReplyHTTPBody        bool

--- a/transport/http/stream.go
+++ b/transport/http/stream.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gorilla/websocket"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	"github.com/go-kratos/kratos/v3/encoding"
 	kerrors "github.com/go-kratos/kratos/v3/errors"
@@ -58,18 +60,32 @@ type ClientStream interface {
 }
 
 type serverStream struct {
-	ctx      context.Context
-	req      *stdhttp.Request
-	res      stdhttp.ResponseWriter
-	mode     streamMode
-	conn     *websocket.Conn
-	header   metadata.MD
-	trailer  metadata.MD
-	encoder  encoding.Codec
-	decoder  encoding.Codec
-	started  bool
-	writeMu  sync.Mutex
-	upgrader websocket.Upgrader
+	ctx       context.Context
+	req       *stdhttp.Request
+	res       stdhttp.ResponseWriter
+	mode      streamMode
+	conn      *websocket.Conn
+	header    metadata.MD
+	trailer   metadata.MD
+	encoder   encoding.Codec
+	decoder   encoding.Codec
+	started   bool
+	writeMu   sync.Mutex
+	upgrader  websocket.Upgrader
+	bodyField string
+}
+
+// ServerStreamOption customizes a server stream created by the HTTP transport.
+type ServerStreamOption func(*serverStream)
+
+// WithStreamBodyField declares the request message field that carries each streamed
+// frame's payload. It is used for client-streaming RPCs whose HTTP rule maps a named
+// body field (e.g. body: "data"): every received frame is decoded into that field while
+// the remaining fields are bound from the request query and path vars.
+func WithStreamBodyField(name string) ServerStreamOption {
+	return func(s *serverStream) {
+		s.bodyField = name
+	}
 }
 
 // NewServerSentEventServerStream returns a stream that writes server messages as SSE events.
@@ -86,12 +102,15 @@ func NewServerSentEventServerStream(ctx Context) ServerStream {
 }
 
 // NewWebSocketServerStream upgrades the current request and returns a WebSocket stream.
-func NewWebSocketServerStream(ctx Context) (ServerStream, error) {
+func NewWebSocketServerStream(ctx Context, opts ...ServerStreamOption) (ServerStream, error) {
 	s := &serverStream{
 		ctx:  ctx,
 		req:  ctx.Request(),
 		res:  ctx.Response(),
 		mode: streamModeWebSocket,
+	}
+	for _, opt := range opts {
+		opt(s)
 	}
 	s.encoder = streamCodecFromHeaders(s.req.Header, "Accept", "Content-Type")
 	s.decoder = streamCodecFromHeaders(s.req.Header, "Content-Type", "Accept")
@@ -141,7 +160,7 @@ func (s *serverStream) Send(m any) error {
 }
 
 func (s *serverStream) Recv(m any) error {
-	if err := s.RecvMsg(m); err != nil {
+	if err := s.recvMessage(m); err != nil {
 		return err
 	}
 	if s.req != nil {
@@ -152,6 +171,31 @@ func (s *serverStream) Recv(m any) error {
 			return err
 		}
 	}
+	return nil
+}
+
+// recvMessage decodes the next frame. When a named body field is declared the frame
+// carries only that field's payload, so it is decoded into a freshly allocated sub-message
+// and assigned back onto m; otherwise the frame is decoded into m directly. The generator
+// only declares a body field for a singular message-kind field, so a mismatch here is a
+// programming error and is reported rather than silently ignored.
+func (s *serverStream) recvMessage(m any) error {
+	if s.bodyField == "" {
+		return s.RecvMsg(m)
+	}
+	pm, ok := m.(proto.Message)
+	if !ok {
+		return fmt.Errorf("http: stream body field %q requires a proto.Message, got %T", s.bodyField, m)
+	}
+	fd := pm.ProtoReflect().Descriptor().Fields().ByName(protoreflect.Name(s.bodyField))
+	if fd == nil || fd.Kind() != protoreflect.MessageKind || fd.IsList() || fd.IsMap() {
+		return fmt.Errorf("http: stream body field %q is not a singular message field", s.bodyField)
+	}
+	sub := pm.ProtoReflect().NewField(fd)
+	if err := s.RecvMsg(sub.Message().Interface()); err != nil {
+		return err
+	}
+	pm.ProtoReflect().Set(fd, sub)
 	return nil
 }
 

--- a/transport/http/stream_test.go
+++ b/transport/http/stream_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -226,6 +227,87 @@ func TestWebSocketStreamBindsPathQueryAndExchangesMessages(t *testing.T) {
 	}
 	if err := stream.Recv(&out); !errors.Is(err, io.EOF) {
 		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestWebSocketStreamBindsNamedBodyField(t *testing.T) {
+	srv := NewServer()
+	srv.Route("/").GET("/ws/{name}", func(ctx Context) error {
+		stream, err := NewWebSocketServerStream(ctx, WithStreamBodyField("sub"))
+		if err != nil {
+			return err
+		}
+
+		in := new(binding.HelloRequest)
+		if err := stream.Recv(in); err != nil {
+			return stream.Close(err)
+		}
+		// name comes from the path var, the sub message from the streamed frame payload.
+		if in.GetName() != "kratos" {
+			return stream.Close(fmt.Errorf("expected path name kratos, got %s", in.GetName()))
+		}
+		if in.GetSub().GetName() != "go" {
+			return stream.Close(fmt.Errorf("expected body sub go, got %s", in.GetSub().GetName()))
+		}
+		if err := stream.Send(&binding.HelloRequest{Name: in.GetName(), Sub: in.GetSub()}); err != nil {
+			return stream.Close(err)
+		}
+		return stream.Close(nil)
+	})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	client, err := NewClient(context.Background(), WithEndpoint(ts.URL), WithTimeout(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stream, err := client.WebSocket(context.Background(), "/ws/kratos", Accept("application/protojson"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The client streams only the body field (Sub), mirroring generated code that
+	// sends m.Sub instead of the whole request message.
+	if err := stream.Send(&binding.Sub{Name: "go"}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out binding.HelloRequest
+	if err := stream.Recv(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.GetName() != "kratos" {
+		t.Fatalf("expected %v, got %v", "kratos", out.GetName())
+	}
+	if out.GetSub().GetName() != "go" {
+		t.Fatalf("expected %v, got %v", "go", out.GetSub().GetName())
+	}
+	if err := stream.Recv(&out); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestServerStreamRecvMessageRejectsInvalidBodyField(t *testing.T) {
+	tests := []struct {
+		name      string
+		bodyField string
+	}{
+		{name: "unknown field", bodyField: "does_not_exist"},
+		{name: "scalar field", bodyField: "name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &serverStream{mode: streamModeWebSocket, bodyField: tt.bodyField}
+			// The field validation happens before any frame is read, so no live
+			// connection is required to exercise the error path.
+			err := s.recvMessage(new(binding.HelloRequest))
+			if err == nil {
+				t.Fatalf("expected error for body field %q, got nil", tt.bodyField)
+			}
+			if !strings.Contains(err.Error(), tt.bodyField) {
+				t.Fatalf("expected error to mention %q, got %v", tt.bodyField, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

A client-streaming RPC is served over WebSocket, whose handshake is **always** an HTTP `GET`. When such a method declares a named body field, e.g.

```proto
rpc Chat(stream ChatRequest) returns (stream ChatReply) {
  option (google.api.http) = { get: "/v1/bitto/chat", body: "data" };
}
```

`protoc-gen-go-http` had two problems:

1. **Spurious warning.** `buildHTTPRule` printed `WARN: GET /v1/bitto/chat body should not be declared.` for any GET with a body — but for a WebSocket stream the GET is just the handshake verb, so a body field is legitimate.
2. **The named field never bound at runtime.** The generated client sent the whole request message while the server decoded each frame into the top-level message, leaving the `data` field empty.

This PR makes client and server agree on framing, deciding it **once at generation time** so the two sides cannot diverge:

- **`cmd/protoc-gen-go-http/http.go`** — skip the GET/DELETE "body should not be declared" / "does not declare a body" warnings for client-streaming methods (`m.Desc.IsStreamingClient()`); unary and SSE GET-with-body still warn, since that is a genuine HTTP anti-pattern. Record a new `BodyMessage` flag when the named body is a singular message-kind field.
- **`cmd/protoc-gen-go-http/template.go`** — add `methodDesc.BodyMessage`.
- **`cmd/protoc-gen-go-http/httpTemplate.tpl`** — gate both sides on `BodyMessage`: for a streamable message body the client streams the body sub-field (`Send(m.Data)`) and the server receives `http.WithStreamBodyField("data")`; otherwise (whole-message `*`, scalar field, or no body) the whole message is sent/decoded.
- **`transport/http/stream.go`** — add the `WithStreamBodyField` server-stream option; `serverStream.Recv` decodes each frame into the named message field, then overlays query params + path vars as before. An invalid body-field declaration now returns an explicit error instead of silently falling back.

Non-streaming, SSE/server-streaming, and whole-message (`body: "*"`) behavior are unchanged.

#### Which issue(s) this PR fixes (resolves / be part of):

<!-- no linked issue -->

#### Other special notes for the reviewers:

- Verified end-to-end with `protoc`: a streaming `get:` + message `body:` emits **no** warning and generates `WithStreamBodyField` + `Send(m.Data)`; a streaming `get:` + **scalar** `body:` generates the plain stream + `Send(m)` (symmetric); a **unary** `get:` + `body:` still warns.
- Tests added: `cmd/protoc-gen-go-http/http_test.go` (message vs scalar named-body template generation), `transport/http/stream_test.go` (`TestWebSocketStreamBindsNamedBodyField` round-trip and `TestServerStreamRecvMessageRejectsInvalidBodyField` negative cases).
- Also adds `cmd/protoc-gen-go-http/.gitignore` so the compiled plugin binary produced by `go build` in that directory is not accidentally committed.
- Ran `make lint`-equivalent checks: `gofmt`, `go vet`, and `go test` pass for both the root module and the `cmd/protoc-gen-go-http` module.