### PR TITLE
fix(registry/eureka):fix Multiple endpoint registration leads to meta…

### DIFF
--- a/contrib/registry/eureka/register.go
+++ b/contrib/registry/eureka/register.go
@@ -3,6 +3,7 @@ package eureka
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 	"time"
@@ -110,10 +111,12 @@ func (r *Registry) Endpoints(service *registry.ServiceInstance) []Endpoint {
 		statusPageURL := fmt.Sprintf("%s/info", ep)
 		healthCheckURL := fmt.Sprintf("%s/health", ep)
 		instanceID := strings.Join([]string{ip, appID, sport}, ":")
-		metadata := make(map[string]string)
-		if len(service.Metadata) > 0 {
-			metadata = service.Metadata
+
+		metadata := maps.Clone(service.Metadata)
+		if metadata == nil {
+			metadata = make(map[string]string)
 		}
+
 		if s, ok := service.Metadata["securePort"]; ok {
 			securePort, _ = strconv.Atoi(s)
 		}

--- a/contrib/registry/eureka/register_test.go
+++ b/contrib/registry/eureka/register_test.go
@@ -92,6 +92,65 @@ func do(r *Registry, s *registry.ServiceInstance) {
 	}
 }
 
+func TestEndpoints_MetadataNotShared(t *testing.T) {
+	r, err := New([]string{"http://127.0.0.1:8761"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &registry.ServiceInstance{
+		ID:        "test-id",
+		Name:      "test-svc",
+		Version:   "v1.0.0",
+		Endpoints: []string{"grpc://192.168.1.100:9000", "http://192.168.1.100:8000"},
+		Metadata:  map[string]string{"weight": "10"},
+	}
+
+	eps := r.Endpoints(svc)
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(eps))
+	}
+
+	// Each endpoint must have the correct "Endpoints" value
+	wantEndpoints := []string{"grpc://192.168.1.100:9000", "http://192.168.1.100:8000"}
+	for i, ep := range eps {
+		if ep.MetaData["Endpoints"] != wantEndpoints[i] {
+			t.Logf("endpoint[%d] Endpoints = %q, want %q", i, ep.MetaData["Endpoints"], wantEndpoints[i])
+			t.Errorf("endpoint[%d] Endpoints = %q, want %q", i, ep.MetaData["Endpoints"], wantEndpoints[i])
+		}
+	}
+
+	// Mutating one metadata must not affect the other
+	eps[0].MetaData["weight"] = "999"
+	if eps[1].MetaData["weight"] != "10" {
+		t.Errorf("metadata map is shared between endpoints: endpoint[1].weight = %q, want %q", eps[1].MetaData["weight"], "10")
+	}
+}
+
+func TestEndpoints_EmptyMetadata(t *testing.T) {
+	r, err := New([]string{"http://127.0.0.1:8761"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &registry.ServiceInstance{
+		ID:        "test-id",
+		Name:      "test-svc",
+		Version:   "v1.0.0",
+		Endpoints: []string{"grpc://192.168.1.100:9000", "http://192.168.1.100:8000"},
+	}
+
+	eps := r.Endpoints(svc)
+	if len(eps) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(eps))
+	}
+	for i, ep := range eps {
+		if ep.MetaData["Endpoints"] == "" {
+			t.Errorf("endpoint[%d] Endpoints is empty", i)
+		}
+	}
+}
+
 func TestLock(_ *testing.T) {
 	type me struct {
 		lock sync.Mutex


### PR DESCRIPTION
Fixes #3818 

metadata overwritten when registering multiple endpoints in Eureka registry

Problem

  When a service registers multiple endpoints (e.g. grpc:// and http://) with non-empty Metadata, the Endpoints() function
  assigns a reference of service.Metadata (instead of a copy) to each Eureka Endpoint struct. Every loop iteration writes
  metadata["Endpoints"] = ep to the same underlying map, so the last endpoint overwrites all previous ones. As a result, gRPC
  consumers cannot discover the grpc:// address and fail with DeadlineExceeded.
  
  Root Cause

  In register.go:113-116, the branch handling non-empty service.Metadata does a shallow reference assignment:

  metadata = service.Metadata  // shared reference, not a copy
  
  Fix
  
  Use maps.Clone to deep-copy the metadata for each endpoint:
  
  metadata := maps.Clone(service.Metadata)
  if metadata == nil {
      metadata = make(map[string]string)
  }

  Tests Added

  - TestEndpoints_MetadataNotShared — verifies each endpoint holds an independent metadata map with the correct "Endpoints"
  value; mutating one does not affect the other.
  - TestEndpoints_EmptyMetadata — verifies the empty-metadata path still works correctly.
