### PR TITLE
feat(protoc-gen-go-http): support google.api.HttpBody response

### DIFF
--- a/cmd/protoc-gen-go-http/httpTemplate.tpl
+++ b/cmd/protoc-gen-go-http/httpTemplate.tpl
@@ -135,7 +135,11 @@ func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) fu
 			return err
 		}
 		reply := out.(*{{.Reply}})
+		{{- if or .ReplyHTTPBody .ResponseBodyHTTPBody}}
+		return ctx.Blob(200, http.BodyContentType(reply{{.ResponseBody}}), reply{{.ResponseBody}}.GetData())
+		{{- else}}
 		return ctx.Result(200, reply{{.ResponseBody}})
+		{{- end}}
 		{{- end}}
 	}
 }


### PR DESCRIPTION
## Summary

Generated HTTP handlers now return raw body content when a method's reply is a `google.api.HttpBody` (or when the `response_body` field maps to an `HttpBody`), instead of JSON-serializing the reply.

In that case the handler calls `ctx.Blob(200, http.BodyContentType(reply), reply.GetData())`, using the body's declared content type and raw bytes. All other replies keep the existing `ctx.Result(200, ...)` behavior.

This complements the existing request-side `HttpBody` support (`http.BodyContentType` is already used for inbound bodies).

## Changes

- `cmd/protoc-gen-go-http/httpTemplate.tpl`: branch on `.ReplyHTTPBody` / `.ResponseBodyHTTPBody` to emit a `ctx.Blob` response for HttpBody replies.

## Testing

- `go build ./...`
- `go test ./...` (passes)