### PR TITLE
feat(errors): add standard library errors wrappers

### DIFF
--- a/errors/wrap.go
+++ b/errors/wrap.go
@@ -4,6 +4,21 @@ import (
 	stderrors "errors"
 )
 
+// ErrUnsupported indicates that a requested operation cannot be performed,
+// because it is unsupported. For example, a call to os.Link when using a
+// file system that does not support hard links.
+//
+// Functions and methods should not return this error but should instead
+// return an error including appropriate context that satisfies
+//
+//	errors.Is(err, errors.ErrUnsupported)
+//
+// either by directly wrapping ErrUnsupported or by implementing an Is method.
+//
+// Functions and methods should document the cases in which an error
+// wrapping this will be returned.
+var ErrUnsupported = stderrors.ErrUnsupported
+
 // Is reports whether any error in err's chain matches target.
 //
 // The chain consists of err itself followed by the sequence of errors obtained by
@@ -33,4 +48,16 @@ func As(err error, target any) bool { return stderrors.As(err, target) }
 // Otherwise, Unwrap returns nil.
 func Unwrap(err error) error {
 	return stderrors.Unwrap(err)
+}
+
+// Join returns an error that wraps the given errors. The returned error has a method Unwrap() []error that returns the
+// given errors in order.
+//
+// Join returns nil if errs contains no non-nil error values. If errs contains
+// a single non-nil error value, Join returns that error. If errs contains multiple non-nil error values, Join returns an error that formats as the concatenation of the
+// format of the non-nil error values, separated by "; ". The returned error's Unwrap method returns a slice of the non-nil error values.
+//
+// Join is designed for use in situations where multiple errors may be returned, such as when processing a list of items and collecting errors from each item. It allows you to combine those errors into a single error value that can be returned to the caller.
+func Join(errs ...error) error {
+	return stderrors.Join(errs...)
 }

--- a/errors/wrap.go
+++ b/errors/wrap.go
@@ -50,14 +50,19 @@ func Unwrap(err error) error {
 	return stderrors.Unwrap(err)
 }
 
-// Join returns an error that wraps the given errors. The returned error has a method Unwrap() []error that returns the
-// given errors in order.
+// Join returns an error that wraps the given errors. The returned error has a
+// method Unwrap() []error that returns the given errors in order.
 //
-// Join returns nil if errs contains no non-nil error values. If errs contains
-// a single non-nil error value, Join returns that error. If errs contains multiple non-nil error values, Join returns an error that formats as the concatenation of the
-// format of the non-nil error values, separated by "; ". The returned error's Unwrap method returns a slice of the non-nil error values.
+// Join returns nil if errs contains no non-nil error values. If errs contains a
+// single non-nil error value, Join returns that error. If errs contains multiple
+// non-nil error values, Join returns an error that formats as the concatenation
+// of the format of the non-nil error values, separated by "; ". The returned
+// error's Unwrap method returns a slice of the non-nil error values.
 //
-// Join is designed for use in situations where multiple errors may be returned, such as when processing a list of items and collecting errors from each item. It allows you to combine those errors into a single error value that can be returned to the caller.
+// Join is designed for use in situations where multiple errors may be returned,
+// such as when processing a list of items and collecting errors from each item.
+// It allows you to combine those errors into a single error value that can be
+// returned to the caller.
 func Join(errs ...error) error {
 	return stderrors.Join(errs...)
 }


### PR DESCRIPTION
#### Description (what this PR does / why we need it):

Adds two standard library `errors` symbols to the kratos `errors` package so callers can use them without importing the standard `errors` package alongside it:

- `ErrUnsupported` — the sentinel added in Go 1.21, re-exported as `errors.ErrUnsupported`.
- `Join` — wraps multiple errors into one, mirroring `stderrors.Join`.

This rounds out the existing wrappers (`Is`, `As`, `Unwrap`) already provided by the package. The stdlib `New` is intentionally not wrapped, since the package already defines its own `New(code int, reason, message string)` with a different signature.

#### Which issue(s) this PR fixes (resolves / be part of):

N/A

#### Other special notes for the reviewers:

- Doc comments are copied from the standard library for consistency.
- Verified with `go build`, `go vet`, `gofmt`, and `go test ./errors/` — all pass.