### PR TITLE
fix: resolve relative paths in kratos run command

### DIFF
--- a/cmd/kratos/internal/run/run.go
+++ b/cmd/kratos/internal/run/run.go
@@ -68,6 +68,14 @@ func Run(cmd *cobra.Command, args []string) {
 			dir = cmdPath[dir]
 		}
 	}
+	if !filepath.IsAbs(dir) {
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "\033[31mERROR: %s\033[m\n", err)
+			return
+		}
+		dir = abs
+	}
 	fd := exec.Command("go", append([]string{"run", dir}, programArgs...)...)
 	fd.Stdout = os.Stdout
 	fd.Stderr = os.Stderr

--- a/cmd/kratos/internal/run/run_test.go
+++ b/cmd/kratos/internal/run/run_test.go
@@ -1,0 +1,54 @@
+package run
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAbsPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantAbs bool
+	}{
+		{
+			name:    "absolute path",
+			input:   "/absolute/path",
+			wantAbs: true,
+		},
+		{
+			name:    "relative path",
+			input:   "relative/path",
+			wantAbs: false,
+		},
+		{
+			name:    "relative path with dot",
+			input:   "./cmd/foo",
+			wantAbs: false,
+		},
+		{
+			name:    "relative path with parent",
+			input:   "../cmd/foo",
+			wantAbs: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isAbs := filepath.IsAbs(tt.input)
+			if isAbs != tt.wantAbs {
+				t.Errorf("filepath.IsAbs(%q) = %v, want %v", tt.input, isAbs, tt.wantAbs)
+			}
+
+			if !isAbs {
+				abs, err := filepath.Abs(tt.input)
+				if err != nil {
+					t.Fatalf("filepath.Abs(%q) error = %v", tt.input, err)
+				}
+				if !filepath.IsAbs(abs) {
+					t.Errorf("filepath.Abs(%q) = %q, not absolute", tt.input, abs)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Convert relative paths to absolute paths before using them as both command arguments and working directory. This prevents the path from being resolved twice, which caused 'package is not in std' errors.

Fixes #3850

