### PR TITLE
fix(transport/http): decode proto.Message with json codec falls back to protojson (#3855)

### DIFF
--- a/transport/http/codec.go
+++ b/transport/http/codec.go
@@ -181,6 +181,16 @@ func decodeWithCodec(codec encoding.Codec, data []byte, v any) error {
 	switch codec.Name() {
 	case "proto", "protojson":
 	default:
+		// When the codec is "json" and the target is a proto.Message,
+		// delegate to protojson to handle protobuf-specific JSON semantics
+		// (e.g., string-encoded int64 fields as per proto3 specification).
+		if codec.Name() == "json" {
+			if msg, ok := v.(proto.Message); ok {
+				if protoCodec := encoding.GetCodec("protojson"); protoCodec != nil {
+					return protoCodec.Unmarshal(data, msg)
+				}
+			}
+		}
 		return codec.Unmarshal(data, v)
 	}
 

--- a/transport/http/codec_test.go
+++ b/transport/http/codec_test.go
@@ -102,6 +102,26 @@ func TestDefaultRequestDecoderProtoJSONRejectsScalarField(t *testing.T) {
 	}
 }
 
+func TestDefaultRequestDecoderJSONWithProtoMessage(t *testing.T) {
+	// When a request uses Content-Type: application/json and the target
+	// is a proto.Message with string-encoded int64 fields (proto3 spec),
+	// the decoder should fall back to protojson for correct unmarshaling.
+	r, _ := http.NewRequest(http.MethodPost, "",
+		io.NopCloser(bytes.NewBufferString(`{"opt_int64":"42"}`)))
+	r.Header.Set("Content-Type", "application/json")
+
+	req := &binding.HelloRequest{}
+	if err := DefaultRequestDecoder(r, &req); err != nil {
+		t.Fatal(err)
+	}
+	if req.OptInt64 == nil {
+		t.Fatal("expected OptInt64 to be allocated")
+	}
+	if *req.OptInt64 != 42 {
+		t.Errorf("expected OptInt64=42, got %d", *req.OptInt64)
+	}
+}
+
 func TestDefaultResponseEncoderProtoJSONRejectsScalarField(t *testing.T) {
 	w := &mockResponseWriter{StatusCode: http.StatusOK, header: make(http.Header)}
 	r, _ := http.NewRequest(http.MethodGet, "", nil)


### PR DESCRIPTION
## Description

Fixes #3855

When a request uses `Content-Type: application/json` and the target type is a `proto.Message` with string-encoded int64 fields (as allowed by the proto3 JSON specification), the standard `encoding/json` codec fails to unmarshal the string values into int64 fields.

### Root Cause

In Kratos v3, the JSON codec was split into two:
- `encoding/json` — standard library JSON codec (registered as `"json"`)
- `encoding/protojson` — protobuf JSON codec (registered as `"protojson"`)

When `CodecForRequest` receives `Content-Type: application/json`, it selects the `"json"` codec, which uses Go's standard `encoding/json`. This codec cannot handle protobuf-specific JSON semantics like string-encoded int64 fields.

### Fix

In `decodeWithCodec`, when the selected codec is `"json"` and the target value implements `proto.Message`, the decoder now delegates to the `protojson` codec for correct protobuf JSON unmarshaling.

### Test

Added `TestDefaultRequestDecoderJSONWithProtoMessage` which verifies that a JSON payload with a string-encoded int64 field (`{"opt_int64":"42"}`) is correctly unmarshaled into a `*binding.HelloRequest` proto message.
