### PR TITLE
fix(transport/grpc): support array values in gRPC header forwarding (#3857)

### DIFF
--- a/transport/grpc/client.go
+++ b/transport/grpc/client.go
@@ -216,7 +216,10 @@ func unaryClientInterceptor(ms []middleware.Middleware, timeout time.Duration, f
 				keys := header.Keys()
 				keyvals := make([]string, 0, len(keys))
 				for _, k := range keys {
-					keyvals = append(keyvals, k, header.Get(k))
+					vals := header.Values(k)
+					for _, v := range vals {
+						keyvals = append(keyvals, k, v)
+					}
 				}
 				ctx = grpcmd.AppendToOutgoingContext(ctx, keyvals...)
 			}


### PR DESCRIPTION
fix(transport/grpc): support array values in gRPC header forwarding (#3857)

Fixes #3857

## Problem
When forwarding headers from a gRPC client interceptor to the outgoing context, `header.Get(k)` is used which only returns the first value for a header key. This causes array headers (multiple values for the same key) to be silently discarded.

## Root Cause
In `transport/grpc/client.go`, the `unaryClientInterceptor` iterates over header keys and uses `header.Get(k)` to retrieve the value:

```go
for _, k := range keys {
    keyvals = append(keyvals, k, header.Get(k))
}
```

The `header.Get()` method returns only the first value (`vals[0]`), ignoring any additional values.

## Fix
Use `header.Values(k)` to retrieve all values for the key, then iterate over them:

```go
for _, k := range keys {
    vals := header.Values(k)
    for _, v := range vals {
        keyvals = append(keyvals, k, v)
    }
}
```

The `headerCarrier.Values()` method already exists and returns `[]string` (backed by `metadata.MD.Get(key)`), so no new methods are needed.

## Impact
- Single-value headers: unchanged behavior (the same key-value pair is appended as before)
- Multi-value headers: now correctly forwarded as multiple key-value pairs in the gRPC outgoing context
- Backward compatible: all existing tests pass without modification