### PR TITLE
fix(config/nacos): upgrade nacos-sdk-go from v1 to v2 to match registry module

### DIFF
--- a/contrib/config/nacos/config.go
+++ b/contrib/config/nacos/config.go
@@ -5,8 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nacos-group/nacos-sdk-go/clients/config_client"
-	"github.com/nacos-group/nacos-sdk-go/vo"
+	"github.com/nacos-group/nacos-sdk-go/v2/clients/config_client"
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 
 	"github.com/go-kratos/kratos/v3/config"
 )

--- a/contrib/config/nacos/config_test.go
+++ b/contrib/config/nacos/config_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nacos-group/nacos-sdk-go/clients"
-	"github.com/nacos-group/nacos-sdk-go/common/constant"
-	"github.com/nacos-group/nacos-sdk-go/vo"
+	"github.com/nacos-group/nacos-sdk-go/v2/clients"
+	"github.com/nacos-group/nacos-sdk-go/v2/common/constant"
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 
 	"github.com/go-kratos/kratos/v3/config"
 )

--- a/contrib/config/nacos/go.mod
+++ b/contrib/config/nacos/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-kratos/kratos/v3 v3.0.0
-	github.com/nacos-group/nacos-sdk-go v1.1.6
+	github.com/nacos-group/nacos-sdk-go/v2 v2.3.5
 )
 
 require (

--- a/contrib/config/nacos/watcher.go
+++ b/contrib/config/nacos/watcher.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nacos-group/nacos-sdk-go/vo"
+	"github.com/nacos-group/nacos-sdk-go/v2/vo"
 
 	"github.com/go-kratos/kratos/v3/config"
 )


### PR DESCRIPTION
## Summary

Fixes #3861

The `contrib/registry/nacos` module was upgraded to `nacos-sdk-go/v2` (v2.3.5), but `contrib/config/nacos` was left behind on `nacos-sdk-go v1.1.6`. This causes an inconsistent dependency tree across the two nacos modules.

This PR upgrades `contrib/config/nacos` to use `nacos-sdk-go/v2 v2.3.5`, matching the version used by the registry module.

## Changes

- `go.mod`: upgrade `github.com/nacos-group/nacos-sdk-go v1.1.6` → `github.com/nacos-group/nacos-sdk-go/v2 v2.3.5`
- `config.go`: update import paths to `nacos-sdk-go/v2`
- `watcher.go`: update import paths to `nacos-sdk-go/v2`
- `config_test.go`: update import paths to `nacos-sdk-go/v2`

## Verification

The v2 SDK API for the config client (`IConfigClient`, `vo.ConfigParam`, `clients.NewConfigClient`) is backward-compatible with v1 for the methods used here (`GetConfig`, `ListenConfig`, `CancelListenConfig`). The registry module already uses v2.3.5 successfully, confirming the API surface is compatible.

Note: `go.sum` will need to be regenerated via `go mod tidy` after merge.