### PR TITLE
fix(middleware/metadata): percent-encode non-ASCII metadata values for transport

### DIFF
--- a/middleware/metadata/metadata.go
+++ b/middleware/metadata/metadata.go
@@ -2,12 +2,39 @@ package metadata
 
 import (
 	"context"
+	"net/url"
 	"strings"
+	"unicode"
 
 	"github.com/go-kratos/kratos/v3/metadata"
 	"github.com/go-kratos/kratos/v3/middleware"
 	"github.com/go-kratos/kratos/v3/transport"
 )
+
+// encodeValue percent-encodes v only when necessary: non-ASCII bytes or '%'.
+// Printable ASCII values without '%' are written unchanged for backward
+// compatibility with older peers that do not percent-decode on read.
+func encodeValue(v string) string {
+	for _, r := range v {
+		if r > unicode.MaxASCII || r == '%' {
+			return url.PathEscape(v)
+		}
+	}
+	return v
+}
+
+// decodeValue percent-decodes v. Values without '%' are returned as-is.
+// Malformed percent-sequences (e.g. a legacy value containing a bare '%')
+// fall back to the original string.
+func decodeValue(v string) string {
+	if !strings.ContainsRune(v, '%') {
+		return v
+	}
+	if decoded, err := url.PathUnescape(v); err == nil {
+		return decoded
+	}
+	return v
+}
 
 // Option is metadata option.
 type Option func(*options)
@@ -61,7 +88,7 @@ func Server(opts ...Option) middleware.Middleware {
 			for _, k := range header.Keys() {
 				if options.hasPrefix(k) {
 					for _, v := range header.Values(k) {
-						md.Add(k, v)
+						md.Add(k, decodeValue(v))
 					}
 				}
 			}
@@ -90,13 +117,13 @@ func Client(opts ...Option) middleware.Middleware {
 			// x-md-local-
 			for k, vList := range options.md {
 				for _, v := range vList {
-					header.Add(k, v)
+					header.Add(k, encodeValue(v))
 				}
 			}
 			if md, ok := metadata.FromClientContext(ctx); ok {
 				for k, vList := range md {
 					for _, v := range vList {
-						header.Add(k, v)
+						header.Add(k, encodeValue(v))
 					}
 				}
 			}
@@ -105,7 +132,7 @@ func Client(opts ...Option) middleware.Middleware {
 				for k, vList := range md {
 					if options.hasPrefix(k) {
 						for _, v := range vList {
-							header.Add(k, v)
+							header.Add(k, encodeValue(v))
 						}
 					}
 				}

--- a/middleware/metadata/metadata_test.go
+++ b/middleware/metadata/metadata_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -175,5 +176,98 @@ func TestOptions_hasPrefix(t *testing.T) {
 				t.Errorf("key: '%sr', not exists prefixs: %v", test.key, test.options.prefix)
 			}
 		})
+	}
+}
+
+func TestEncodeValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "global-value", "global-value"},
+		{"chinese", "张三", "%E5%BC%A0%E4%B8%89"},
+		{"emoji", "🙂", "%F0%9F%99%82"},
+		{"percent", "100% off", "100%25%20off"},
+		{"plus preserved", "+861234567890", "+861234567890"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encodeValue(tt.in); got != tt.want {
+				t.Errorf("encodeValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "global-value", "global-value"},
+		{"chinese", "%E5%BC%A0%E4%B8%89", "张三"},
+		{"emoji", "%F0%9F%99%82", "🙂"},
+		{"percent escaped", "100%25%20off", "100% off"},
+		{"plus preserved", "+861234567890", "+861234567890"},
+		{"bare percent error fallback", "100% off", "100% off"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := decodeValue(tt.in); got != tt.want {
+				t.Errorf("decodeValue(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNonASCIIRoundTripThroughClientServer(t *testing.T) {
+	// Simulate a client sending a non-ASCII value through the middleware chain:
+	// Client encodes it into the header, then Server reads and decodes it back.
+	want := "张三" // any non-ASCII value
+	key := "x-md-global-name"
+
+	// Client side: put the value into client metadata, let Client middleware encode it.
+	hs := func(ctx context.Context, in any) (any, error) {
+		// This handler runs "server-side"; read the value from server context.
+		md, ok := metadata.FromServerContext(ctx)
+		if !ok {
+			return nil, errors.New("no server md")
+		}
+		if got := md.Get(key); got != want {
+			return nil, errors.New("server md value mismatch")
+		}
+		return in, nil
+	}
+
+	// Build the encoded header by running the Client middleware against a carrier.
+	clientMD := metadata.New()
+	clientMD.Set(key, want)
+	clientCtx := metadata.NewClientContext(context.Background(), clientMD)
+	carrier := headerCarrier{}
+	clientCtx = transport.NewClientContext(clientCtx, &testTransport{carrier})
+	_, err := Client()(func(ctx context.Context, in any) (any, error) { return in, nil })(clientCtx, "req")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The header value on the wire must be percent-encoded, not raw UTF-8.
+	wire := carrier.Get(key)
+	if wire == want {
+		t.Fatalf("expected percent-encoded value on the wire, got raw %q", wire)
+	}
+	if wire != url.PathEscape(want) {
+		t.Fatalf("wire value = %q, want %q", wire, url.PathEscape(want))
+	}
+
+	// Server side: feed the encoded header into the Server middleware.
+	serverCarrier := headerCarrier{}
+	serverCarrier.Set(key, wire)
+	serverCtx := transport.NewServerContext(context.Background(), &testTransport{serverCarrier})
+	_, err = Server()(hs)(serverCtx, "req")
+	if err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What type of PR is this?
fix

## What this PR does / why we need it?

`middleware/metadata` writes metadata values into the transport header verbatim and reads them back verbatim. When a value contains non-ASCII (multi-byte) characters (e.g. Chinese `张三`), the gRPC call fails with:

```
rpc error: code = Internal desc = header key "x-md-global-name" contains value with non-printable ASCII characters
```

grpc-go rejects any non-`-bin` header value that is not printable ASCII (`%x20-%x7E`). On HTTP the value is passed through raw, which proxies/gateways/non-Go servers mangle into mojibake (RFC 9110 header values are opaque octets).

### Fix
- **Client** middleware percent-encodes values when writing them into the transport header (using `url.PathEscape`).
- **Server** middleware percent-decodes them when reading back (using `url.PathUnescape`).

Backward compatibility:
1. **Only escape when necessary** — printable-ASCII values without `%` are written unchanged, so existing ASCII traffic stays byte-identical and older peers are unaffected.
2. **`url.Path*` pair, not `Query*`** — `QueryEscape` encodes space as `+` and `QueryUnescape` decodes `+` back to space, which would corrupt existing `+` values (base64, phone numbers). `PathEscape`/`PathUnescape` only handle `%XX` and leave `+` alone.
3. On decode, values without `%` are returned as-is and malformed sequences (e.g. legacy `100% off`) fall back to the raw string.

The user-visible `metadata.Metadata` value is now identical on client and server for non-ASCII values.

## Which issue(s) this PR fixes
Fixes #3867

## Special notes for your reviewer
Tests cover the round-trip through the Client -> Header -> Server chain for Chinese / emoji / values containing `%` and `+` / plain ASCII, plus unit tests for `encodeValue`/`decodeValue`.

## Does this PR introduce a user-facing change?
Need to upgrade the client and server together for non-ASCII values to work end-to-end. Values that already work today (printable ASCII) are unaffected.