### PR TITLE
fix: auto-match layout template tag to CLI version in kratos new

### DIFF
--- a/cmd/kratos/internal/base/repo.go
+++ b/cmd/kratos/internal/base/repo.go
@@ -69,16 +69,33 @@ func (r *Repo) Pull(ctx context.Context) error {
 	cmd.Dir = r.Path()
 	_, err := cmd.CombinedOutput()
 	if err != nil {
+		// HEAD is detached (e.g. the cache was checked out at a tag via
+		// `-b vX.Y.Z`). `git pull` cannot update a detached HEAD, so fetch
+		// the requested ref and re-checkout it instead.
+		if r.branch != "" {
+			cmd = exec.CommandContext(ctx, "git", "fetch", "origin", r.branch)
+			cmd.Dir = r.Path()
+			out, ferr := cmd.CombinedOutput()
+			fmt.Println(string(out))
+			if ferr != nil {
+				return ferr
+			}
+			cmd = exec.CommandContext(ctx, "git", "checkout", r.branch)
+			cmd.Dir = r.Path()
+			out, ferr = cmd.CombinedOutput()
+			fmt.Println(string(out))
+			return ferr
+		}
 		return err
 	}
 	cmd = exec.CommandContext(ctx, "git", "pull")
 	cmd.Dir = r.Path()
-	out, err := cmd.CombinedOutput()
+	out, perr := cmd.CombinedOutput()
 	fmt.Println(string(out))
-	if err != nil {
-		return err
+	if perr != nil {
+		return perr
 	}
-	return err
+	return nil
 }
 
 // Clone clones the repository to cache path.
@@ -124,3 +141,4 @@ func (r *Repo) CopyToV2(ctx context.Context, to string, modPath string, ignores,
 	replaces = append([]string{mod, modPath}, replaces...)
 	return copyDir(r.Path(), to, replaces, ignores)
 }
+

--- a/cmd/kratos/internal/project/project.go
+++ b/cmd/kratos/internal/project/project.go
@@ -36,6 +36,11 @@ var (
 	timeout = "60s"
 )
 
+// CLIVersion is the kratos CLI version, injected from the main package.
+// It is used to match the layout template tag to the CLI version, so that
+// a v2.x CLI pulls the v2.x template instead of the main (v3) branch.
+var CLIVersion string
+
 func init() {
 	CmdNew.Flags().StringVarP(&repo, "repo", "r", repo, "custom repo url")
 	CmdNew.Flags().StringVarP(&branch, "branch", "b", branch, "repo branch")
@@ -79,6 +84,12 @@ func run(_ *cobra.Command, args []string) {
 			fmt.Fprintf(os.Stderr, "\033[31mERROR: failed to select repo(%s)\033[m\n", err.Error())
 			return
 		}
+	}
+	// When using the default service layout and no explicit branch was
+	// given, match the layout tag to the CLI version (e.g. CLI v2.9.2
+	// pulls the v2.9.2 template instead of the main branch which is v3).
+	if branch == "" && repoURL == projects["service"] && CLIVersion != "" {
+		branch = CLIVersion
 	}
 	go func() {
 		if !nomod {

--- a/cmd/kratos/main.go
+++ b/cmd/kratos/main.go
@@ -20,6 +20,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	project.CLIVersion = release
 	rootCmd.AddCommand(project.CmdNew)
 	rootCmd.AddCommand(proto.CmdProto)
 	rootCmd.AddCommand(upgrade.CmdUpgrade)


### PR DESCRIPTION
## Description

Fixes #3868

**Bug 1: Template version doesn't match CLI version**

When using `kratos new` (e.g. v2.9.2 CLI), the command always clones the `main` branch of `kratos-layout`, which currently contains the v3 template. This causes a mismatch: a v2.x CLI generates a v3 project template.

**Fix**: Inject the CLI version (`release`) into the `project` package via `project.CLIVersion`. When no explicit `-b` flag is given and the default service layout is used, the layout tag is automatically matched to the CLI version (e.g. CLI v2.9.2 → tag `v2.9.2`).

**Bug 2: `-b v2.9.2` (tag) fails on repeated runs**

When `-b` is a tag, `git clone -b <tag>` checks out a detached HEAD. The `Pull()` method in `repo.go` calls `git symbolic-ref HEAD` which fails on detached HEAD, causing `kratos new` to fail on the second project creation.

**Fix**: In `Pull()`, when `git symbolic-ref HEAD` fails (detached HEAD), fall back to `git fetch origin <ref>` + `git checkout <ref>` instead of returning an error.