### PR TITLE
fix(run): skip dependency and VCS directories in findCMD to avoid scanning node_modules

### DIFF
--- a/cmd/kratos/internal/run/run.go
+++ b/cmd/kratos/internal/run/run.go
@@ -99,6 +99,14 @@ func findCMD(base string) (map[string]string, error) {
 	next := func(dir string) (map[string]string, error) {
 		cmdPath := make(map[string]string)
 		err := filepath.Walk(dir, func(walkPath string, info os.FileInfo, _ error) error {
+			// Skip dependency and VCS directories that contain no project cmd/*.
+			// Fixes https://github.com/go-kratos/kratos/issues/3859
+			if info.IsDir() {
+				switch info.Name() {
+				case "node_modules", ".git", "vendor", ".idea":
+					return filepath.SkipDir
+				}
+			}
 			// multi level directory is not allowed under the cmdPath directory, so it is judged that the path ends with cmdPath.
 			if strings.HasSuffix(walkPath, "cmd") {
 				paths, err := os.ReadDir(walkPath)


### PR DESCRIPTION
## Description

The `findCMD` function uses `filepath.Walk` to find `cmd/*` directories, but it descends into dependency directories like `web/node_modules`, which contain thousands of third-party `cmd` directories. This causes:

1. `kratos run` to be extremely slow while walking `node_modules`
2. The directory selection prompt to show many irrelevant `cmd` paths
3. In some cases, the command fails entirely

## Fix

Skip `node_modules`, `.git`, `vendor`, and `.idea` directories during the walk by returning `filepath.SkipDir`. These directories contain no project `cmd/*` and should not be scanned.

Fixes #3859

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Code compiles correctly
- [x] I have read the [Contributing Guide](https://github.com/go-kratos/kratos/blob/main/CONTRIBUTING.md)