### PR TITLE
fix(middleware/metadata): percent-encode non-ASCII values in transport headers (#3867)

### DIFF
--- a/middleware/metadata/metadata.go
+++ b/middleware/metadata/metadata.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/go-kratos/kratos/v3/metadata"
@@ -61,7 +62,7 @@ func Server(opts ...Option) middleware.Middleware {
 			for _, k := range header.Keys() {
 				if options.hasPrefix(k) {
 					for _, v := range header.Values(k) {
-						md.Add(k, v)
+						md.Add(k, decodeValue(v))
 					}
 				}
 			}
@@ -90,13 +91,13 @@ func Client(opts ...Option) middleware.Middleware {
 			// x-md-local-
 			for k, vList := range options.md {
 				for _, v := range vList {
-					header.Add(k, v)
+					header.Add(k, encodeValue(v))
 				}
 			}
 			if md, ok := metadata.FromClientContext(ctx); ok {
 				for k, vList := range md {
 					for _, v := range vList {
-						header.Add(k, v)
+						header.Add(k, encodeValue(v))
 					}
 				}
 			}
@@ -105,7 +106,7 @@ func Client(opts ...Option) middleware.Middleware {
 				for k, vList := range md {
 					if options.hasPrefix(k) {
 						for _, v := range vList {
-							header.Add(k, v)
+							header.Add(k, encodeValue(v))
 						}
 					}
 				}
@@ -113,4 +114,61 @@ func Client(opts ...Option) middleware.Middleware {
 			return handler(ctx, req)
 		}
 	}
+}
+
+// encodeValue percent-encodes bytes outside the printable ASCII range
+// (0x20-0x7E) to make metadata values safe for transport headers.
+// gRPC and HTTP require header values to be printable ASCII.
+// Pure-ASCII values are returned unchanged for backward compatibility.
+func encodeValue(v string) string {
+	for i := 0; i < len(v); i++ {
+		if v[i] < 0x20 || v[i] > 0x7E {
+			var b strings.Builder
+			b.Grow(len(v) * 3 / 2)
+			for i := 0; i < len(v); i++ {
+				c := v[i]
+				if c >= 0x20 && c <= 0x7E {
+					b.WriteByte(c)
+				} else {
+					b.WriteString(fmt.Sprintf("%%%02X", c))
+				}
+			}
+			return b.String()
+		}
+	}
+	return v
+}
+
+// decodeValue reverses encodeValue, percent-decoding %XX sequences.
+func decodeValue(v string) string {
+	if !strings.Contains(v, "%") {
+		return v
+	}
+	var b strings.Builder
+	b.Grow(len(v))
+	for i := 0; i < len(v); i++ {
+		if v[i] == '%' && i+2 < len(v) {
+			if hi := unhex(v[i+1]); hi >= 0 {
+				if lo := unhex(v[i+2]); lo >= 0 {
+					b.WriteByte(byte(hi<<4 | lo))
+					i += 2
+					continue
+				}
+			}
+		}
+		b.WriteByte(v[i])
+	}
+	return b.String()
+}
+
+func unhex(c byte) int {
+	switch {
+	case '0' <= c && c <= '9':
+		return int(c - '0')
+	case 'a' <= c && c <= 'f':
+		return int(c - 'a' + 10)
+	case 'A' <= c && c <= 'F':
+		return int(c - 'A' + 10)
+	}
+	return -1
 }

--- a/middleware/metadata/metadata_test.go
+++ b/middleware/metadata/metadata_test.go
@@ -156,6 +156,84 @@ func TestOptions_WithPropagatedPrefix(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeValue(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"ascii", "global-value"},
+		{"empty", ""},
+		{"chinese", "你好世界"},
+		{"emoji", "hello 🌍"},
+		{"accented", "café"},
+		{"percent", "100% done"},
+		{"mixed", "foo-中-文-bar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enc := encodeValue(tt.in)
+			// encoded value must be printable ASCII
+			for i := 0; i < len(enc); i++ {
+				if enc[i] < 0x20 || enc[i] > 0x7E {
+					t.Fatalf("encoded value %q contains non-printable byte 0x%02X", enc, enc[i])
+				}
+			}
+			dec := decodeValue(enc)
+			if dec != tt.in {
+				t.Errorf("round-trip mismatch: got %q want %q (encoded %q)", dec, tt.in, enc)
+			}
+		})
+	}
+}
+
+func TestMetadataRoundTripNonASCII(t *testing.T) {
+	// A client with a non-ASCII metadata value must produce a header value
+	// that a server can correctly decode back to the original value.
+	const cnKey = "x-md-global-name"
+	const cnValue = "张三"
+
+	var sentHeader = headerCarrier{}
+	clientMD := metadata.New()
+	clientMD.Set(cnKey, cnValue)
+	ctx := metadata.NewClientContext(context.Background(), clientMD)
+	ctx = transport.NewClientContext(ctx, &testTransport{sentHeader})
+
+	_, err := Client()(func(ctx context.Context, in any) (any, error) {
+		return in, nil
+	})(ctx, "req")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The value written to the transport header must be printable ASCII.
+	gotWire := sentHeader.Get(cnKey)
+	for i := 0; i < len(gotWire); i++ {
+		if gotWire[i] < 0x20 || gotWire[i] > 0x7E {
+			t.Fatalf("wire header value %q contains non-printable byte 0x%02X", gotWire, gotWire[i])
+		}
+	}
+
+	// A server reading that header must reconstruct the original value.
+	recvHeader := headerCarrier{}
+	recvHeader.Set(cnKey, gotWire)
+	serverCtx := transport.NewServerContext(context.Background(), &testTransport{recvHeader})
+	var gotMD metadata.Metadata
+	_, err = Server()(func(ctx context.Context, in any) (any, error) {
+		var ok bool
+		gotMD, ok = metadata.FromServerContext(ctx)
+		if !ok {
+			return nil, errors.New("no md")
+		}
+		return in, nil
+	})(serverCtx, "req")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gotMD.Get(cnKey); got != cnValue {
+		t.Errorf("server decoded metadata %q, want %q (wire %q)", got, cnValue, gotWire)
+	}
+}
+
 func TestOptions_hasPrefix(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### Problem

When `middleware/metadata` passes a non-ASCII value (e.g. Chinese characters, emoji, accented letters) to the transport header, the RPC call fails:

- **gRPC**: `grpc-go` rejects non-printable ASCII header values via `internal/metadata.ValidatePair` with `codes.Internal`
- **HTTP**: Go's `httpguts.ValidHeaderFieldValue` rejects non-ASCII header values

### Root Cause

The `Client` middleware writes metadata values verbatim into the transport header via `header.Add(k, v)`, and the `Server` middleware reads them back verbatim. Neither side performs any encoding/decoding for non-ASCII bytes.

### Solution

Two new helper functions and their integration into the middleware:

- **`encodeValue(v string) string`**: When a value contains bytes outside the printable ASCII range (0x20-0x7E), percent-encodes those bytes. Pure-ASCII values are returned unchanged for full backward compatibility.
- **`decodeValue(v string) string`**: Reverses `encodeValue` by percent-decoding `%XX` sequences.

These are applied in:

1. **`Client` middleware** — all three value sources (options.md, client metadata, and server-context metadata) are encoded before writing to `header.Add`
2. **`Server` middleware** — values read from `header.Values` are decoded before adding to the metadata context

### Testing

- All 5 existing tests pass unchanged (backward compatible)
- `TestEncodeDecodeValue`: table-driven test covering ASCII, empty, Chinese, emoji, accented, percent-sign, and mixed values
- `TestMetadataRoundTripNonASCII`: end-to-end Client → Server round-trip with Chinese characters, verifying the wire format is printable ASCII and the server reconstructs the original value

Fixes #3867