### PR TITLE
fix: match template version to installed kratos CLI version, fix detached HEAD cache for tag refs

### DIFF
--- a/cmd/kratos/internal/base/repo.go
+++ b/cmd/kratos/internal/base/repo.go
@@ -84,7 +84,18 @@ func (r *Repo) Pull(ctx context.Context) error {
 // Clone clones the repository to cache path.
 func (r *Repo) Clone(ctx context.Context) error {
 	if _, err := os.Stat(r.Path()); !os.IsNotExist(err) {
-		return r.Pull(ctx)
+		// If the cached copy is checked out at a tag it is in a detached HEAD
+		// state, and git pull cannot update it. Detect this and remove the cache
+		// so the tag can be re-cloned cleanly.
+		cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "HEAD")
+		cmd.Dir = r.Path()
+		if err := cmd.Run(); err != nil {
+			if err := os.RemoveAll(r.Path()); err != nil {
+				return err
+			}
+		} else {
+			return r.Pull(ctx)
+		}
 	}
 	var cmd *exec.Cmd
 	if r.branch == "" {

--- a/cmd/kratos/internal/project/project.go
+++ b/cmd/kratos/internal/project/project.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -19,6 +20,46 @@ import (
 var projects = map[string]string{
 	"service": "https://github.com/go-kratos/kratos-layout.git",
 	"admin":   "https://github.com/go-kratos/kratos-admin.git",
+}
+
+// KratosVersion is the version of the running kratos CLI. It is set from the
+// main package so that kratos new can generate a project that matches the
+// installed kratos version.
+var KratosVersion string
+
+// resolveTemplateVersion returns the template repository ref to use when
+// creating a new project. When the user provides an explicit ref via -b it is
+// used as-is. Otherwise, if the running kratos CLI has a version and the
+// template repository exposes a tag matching that version, that tag is used.
+func resolveTemplateVersion(ctx context.Context, repoURL string) (string, error) {
+	if branch != "" {
+		return branch, nil
+	}
+	if KratosVersion == "" {
+		return "", nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", "--tags", repoURL)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Fall back to the default branch when the tag list cannot be fetched.
+		return "", nil
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		ref := fields[1]
+		if !strings.HasPrefix(ref, "refs/tags/") {
+			continue
+		}
+		tag := strings.TrimPrefix(ref, "refs/tags/")
+		tag = strings.TrimSuffix(tag, "^{}")
+		if tag == KratosVersion {
+			return tag, nil
+		}
+	}
+	return "", nil
 }
 
 // CmdNew represents the new command.
@@ -80,9 +121,16 @@ func run(_ *cobra.Command, args []string) {
 			return
 		}
 	}
+	// When no -b flag is provided, try to match the template version to the
+	// installed kratos version so the generated project is compatible.
+	resolvedBranch, err := resolveTemplateVersion(ctx, repoURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\033[31mERROR: failed to resolve template version(%s)\033[m\n", err.Error())
+		return
+	}
 	go func() {
 		if !nomod {
-			done <- p.New(ctx, workingDir, repoURL, branch)
+			done <- p.New(ctx, workingDir, repoURL, resolvedBranch)
 			return
 		}
 		projectRoot := getgomodProjectRoot(workingDir)
@@ -105,7 +153,7 @@ func run(_ *cobra.Command, args []string) {
 		}
 		// Get the relative path for adding a project based on Go modules
 		p.Path = filepath.Join(strings.TrimPrefix(workingDir, projectRoot+"/"), p.Name)
-		done <- p.Add(ctx, workingDir, repoURL, branch, mod, packagePath)
+		done <- p.Add(ctx, workingDir, repoURL, resolvedBranch, mod, packagePath)
 	}()
 	select {
 	case <-ctx.Done():

--- a/cmd/kratos/main.go
+++ b/cmd/kratos/main.go
@@ -20,6 +20,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	project.KratosVersion = release
 	rootCmd.AddCommand(project.CmdNew)
 	rootCmd.AddCommand(proto.CmdProto)
 	rootCmd.AddCommand(upgrade.CmdUpgrade)


### PR DESCRIPTION
Fixes #3868

## Problem

When using `kratos new` to create a project, two issues arise:

1. **Template version mismatch**: The CLI always clones the default branch (`main`) of the template repository, even when the installed kratos version is older. For example, kratos v2.9.2 generates a v3 template, causing import path mismatches.

2. **Tag-based cache failure**: When the user specifies a tag via `-b` (e.g., `kratos new myapp -b v2.9.2`), the first clone succeeds but the second attempt fails because the cached repo is in a detached HEAD state and `git pull` cannot update it.

## Changes

### `cmd/kratos/internal/base/repo.go`
- **`Clone()`**: Detect detached HEAD state (tag checkout) before calling `Pull()`. When the cached copy is detached, remove it and re-clone cleanly.

### `cmd/kratos/internal/project/project.go`
- Add `KratosVersion` variable, set from the main package.
- Add `resolveTemplateVersion()`: when no `-b` flag is given, use `git ls-remote --tags` to check if the template repository has a tag matching the installed kratos version. If found, that tag is used so the generated project matches the CLI version.

### `cmd/kratos/main.go`
- Set `project.KratosVersion = release` before registering commands.

## Testing

- `kratos new myapp` (no `-b`): clones the template at the tag matching the CLI version
- `kratos new myapp -b v2.9.2`: first run clones the tag, second run re-clones instead of failing on detached HEAD
- `kratos new myapp -b main`: normal branch behaviour, cache is pulled on subsequent runs
