### PR TITLE
fix(http): pass bind errors through middleware chain instead of short-circuiting

### DIFF
--- a/cmd/protoc-gen-go-http/httpTemplate.tpl
+++ b/cmd/protoc-gen-go-http/httpTemplate.tpl
@@ -78,56 +78,64 @@ func _{{$svrType}}_{{.Name}}{{.Num}}_HTTP_Handler(srv {{$svrType}}HTTPServer) fu
 		return stream.Close(err)
 		{{- else if .ServerStreaming}}
 		var in {{.Request}}
+		var bindErr error
 		{{- if .HasBody}}
-		if err := ctx.Bind(&in{{.Body}}); err != nil {
-			return err
+		if err := ctx.Bind(&in{{.Body}}); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		{{- if not .HasBody}}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
+		if err := ctx.BindQuery(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- else if ne .BodyField "*"}}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
+		if err := ctx.BindQuery(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		{{- if .HasVars}}
-		if err := ctx.BindVars(&in); err != nil {
-			return err
+		if err := ctx.BindVars(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		stream := http.NewServerSentEventServerStream(ctx)
 		http.SetOperation(ctx,Operation{{$svrType}}{{.OriginalName}})
 		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
 			stream.SetContext(ctx)
+			if bindErr != nil {
+				return nil, bindErr
+			}
 			return nil, srv.{{.Name}}(req.(*{{.Request}}), &{{$svrType}}_{{.Name}}HTTPServer{ServerStream: stream})
 		})
 		_, err := h(ctx, &in)
 		return stream.Close(err)
 		{{- else}}
 		var in {{.Request}}
+		var bindErr error
 		{{- if .HasBody}}
-		if err := ctx.Bind(&in{{.Body}}); err != nil {
-			return err
+		if err := ctx.Bind(&in{{.Body}}); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		{{- if not .HasBody}}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
+		if err := ctx.BindQuery(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- else if ne .BodyField "*"}}
-		if err := ctx.BindQuery(&in); err != nil {
-			return err
+		if err := ctx.BindQuery(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		{{- if .HasVars}}
-		if err := ctx.BindVars(&in); err != nil {
-			return err
+		if err := ctx.BindVars(&in); err != nil && bindErr == nil {
+			bindErr = err
 		}
 		{{- end}}
 		http.SetOperation(ctx,Operation{{$svrType}}{{.OriginalName}})
 		h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
+			if bindErr != nil {
+				return nil, bindErr
+			}
 			return srv.{{.Name}}(ctx, req.(*{{.Request}}))
 		})
 		out, err := h(ctx, &in)


### PR DESCRIPTION
**Issue:** #3815

**Problem:** When HTTP request binding fails (malformed JSON, missing fields, invalid query parameters), the generated handler returns the error directly before the middleware chain is invoked. Logging, tracing, metrics, and recovery middlewares are silently skipped, creating observability blind spots.

**Root cause:** In `httpTemplate.tpl`, the generated handler code calls `ctx.Bind()`, `ctx.BindQuery()`, and `ctx.BindVars()` before `ctx.Middleware()`. A binding error causes an early `return err` that bypasses the middleware chain entirely.

**Fix:** Collect binding errors into a `bindErr` variable instead of returning early. The middleware handler checks `bindErr` and returns it through the middleware chain, so logging/tracing/recovery middleware always executes regardless of binding success.

**Changes:**
- `cmd/protoc-gen-go-http/httpTemplate.tpl`: Both unary and server-streaming code paths are fixed.

**Before:**
```go
var in GreeterSayHelloRequest
if err := ctx.Bind(&in); err != nil {
    return err         // ← middleware bypassed
}
http.SetOperation(ctx, ...)
h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
    return srv.SayHello(ctx, req.(*GreeterSayHelloRequest))
})
```

**After:**
```go
var in GreeterSayHelloRequest
var bindErr error
if err := ctx.Bind(&in); err != nil && bindErr == nil {
    bindErr = err      // ← collected, no early return
}
http.SetOperation(ctx, ...)
h := ctx.Middleware(func(ctx context.Context, req interface{}) (interface{}, error) {
    if bindErr != nil {
        return nil, bindErr  // ← returned through middleware
    }
    return srv.SayHello(ctx, req.(*GreeterSayHelloRequest))
})
```