### PR TITLE
fix(config): coerce string env values to destination types on Scan

### DIFF
--- a/config/coerce.go
+++ b/config/coerce.go
@@ -1,0 +1,295 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strconv"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// coerceScalarTypes converts string leaf values in the serialized config to the
+// scalar types declared by the destination (v), so that string-only sources
+// (e.g. env) can populate bool/int/float fields during Scan.
+//
+// The coercion is driven exclusively by the destination's declared type — never
+// by guessing the type from the value's text shape — so string fields whose
+// values happen to look numeric ("1234", "0.5", "8000") are left untouched.
+//
+// If no string leaf needed conversion the original bytes are returned unchanged
+// (the common case, so scanning is a pure round-trip of the source JSON).
+func coerceScalarTypes(data []byte, v any) ([]byte, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	var root any
+	if err := dec.Decode(&root); err != nil {
+		return data, err
+	}
+
+	var changed bool
+	if pb, ok := v.(proto.Message); ok {
+		root, changed = coerceProtoTree(root, pb.ProtoReflect().Descriptor())
+	} else {
+		root, changed = coerceStructTree(root, reflect.TypeOf(v))
+	}
+	if !changed {
+		return data, nil
+	}
+	out, err := json.Marshal(root)
+	if err != nil {
+		return data, err
+	}
+	return out, nil
+}
+
+// coerceStructTree walks a JSON tree (decoded with UseNumber) alongside the
+// destination's reflect.Type, converting string leaves to the declared scalar
+// kind. Returns the (possibly rewritten) tree and whether any leaf changed.
+func coerceStructTree(v any, t reflect.Type) (any, bool) {
+	for t != nil && t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t == nil {
+		return v, false
+	}
+	switch t.Kind() {
+	case reflect.Struct:
+		m, ok := v.(map[string]any)
+		if !ok {
+			return v, false
+		}
+		changed := false
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			if f.PkgPath != "" { // unexported
+				continue
+			}
+			for _, name := range jsonFieldNames(f) {
+				sub, ok := m[name]
+				if !ok {
+					continue
+				}
+				nv, ch := coerceStructTree(sub, f.Type)
+				if ch {
+					m[name] = nv
+					changed = true
+				}
+				break
+			}
+		}
+		return m, changed
+	case reflect.Slice, reflect.Array:
+		arr, ok := v.([]any)
+		if !ok {
+			return v, false
+		}
+		changed := false
+		for i := range arr {
+			nv, ch := coerceStructTree(arr[i], t.Elem())
+			if ch {
+				arr[i] = nv
+				changed = true
+			}
+		}
+		return arr, changed
+	case reflect.Map:
+		m, ok := v.(map[string]any)
+		if !ok {
+			return v, false
+		}
+		changed := false
+		for k, sub := range m {
+			nv, ch := coerceStructTree(sub, t.Elem())
+			if ch {
+				m[k] = nv
+				changed = true
+			}
+		}
+		return m, changed
+	default:
+		return convertStringLeaf(v, t)
+	}
+}
+
+// convertStringLeaf converts a string leaf to the destination scalar kind.
+// Returns (converted, true) only when the leaf is a string AND the destination
+// kind is bool or numeric AND the string parses. It is a no-op for string
+// destinations, so numeric-looking strings stay strings.
+func convertStringLeaf(v any, t reflect.Type) (any, bool) {
+	s, ok := v.(string)
+	if !ok {
+		return v, false
+	}
+	switch t.Kind() {
+	case reflect.Bool:
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return v, false
+		}
+		return b, true
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i, err := strconv.ParseInt(s, 10, t.Bits())
+		if err != nil {
+			return v, false
+		}
+		return i, true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		u, err := strconv.ParseUint(s, 10, t.Bits())
+		if err != nil {
+			return v, false
+		}
+		return u, true
+	case reflect.Float32, reflect.Float64:
+		f, err := strconv.ParseFloat(s, t.Bits())
+		if err != nil {
+			return v, false
+		}
+		return f, true
+	default:
+		return v, false
+	}
+}
+
+// coerceProtoTree walks a JSON tree alongside a protobuf message descriptor,
+// converting string leaves to the field's declared kind.
+func coerceProtoTree(v any, md protoreflect.MessageDescriptor) (any, bool) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return v, false
+	}
+	changed := false
+	fields := md.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		for _, name := range protoFieldNames(fd) {
+			sub, ok := m[name]
+			if !ok {
+				continue
+			}
+			nv, ch := coerceProtoField(sub, fd)
+			if ch {
+				m[name] = nv
+				changed = true
+			}
+			break
+		}
+	}
+	return m, changed
+}
+
+func coerceProtoField(v any, fd protoreflect.FieldDescriptor) (any, bool) {
+	if fd.IsMap() {
+		m, ok := v.(map[string]any)
+		if !ok {
+			return v, false
+		}
+		changed := false
+		for k, sub := range m {
+			valDesc := fd.MapValue()
+			if valDesc.Kind() == protoreflect.MessageKind || valDesc.Kind() == protoreflect.GroupKind {
+				nv, ch := coerceProtoTree(sub, valDesc.Message())
+				if ch {
+					m[k] = nv
+					changed = true
+				}
+				continue
+			}
+			nv, ch := convertStringLeaf(sub, kindToType(valDesc.Kind()))
+			if ch {
+				m[k] = nv
+				changed = true
+			}
+		}
+		return m, changed
+	}
+	if fd.IsList() {
+		arr, ok := v.([]any)
+		if !ok {
+			return v, false
+		}
+		changed := false
+		for i := range arr {
+			nv, ch := coerceProtoField(arr[i], fd)
+			if ch {
+				arr[i] = nv
+				changed = true
+			}
+		}
+		return arr, changed
+	}
+	if fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind {
+		return coerceProtoTree(v, fd.Message())
+	}
+	return convertStringLeaf(v, kindToType(fd.Kind()))
+}
+
+// kindToType maps a protobuf scalar kind onto a Go reflect.Type usable by
+// convertStringLeaf. Message/group kinds are not expected here.
+func kindToType(k protoreflect.Kind) reflect.Type {
+	switch k {
+	case protoreflect.BoolKind:
+		return reflect.TypeOf(false)
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return reflect.TypeOf(int32(0))
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		return reflect.TypeOf(int64(0))
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return reflect.TypeOf(uint32(0))
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return reflect.TypeOf(uint64(0))
+	case protoreflect.FloatKind:
+		return reflect.TypeOf(float32(0))
+	case protoreflect.DoubleKind:
+		return reflect.TypeOf(float64(0))
+	default:
+		return reflect.TypeOf("")
+	}
+}
+
+// jsonFieldNames returns the JSON key candidates for a struct field: the json
+// tag name if present, otherwise the field name (encoding/json matches field
+// names case-insensitively).
+func jsonFieldNames(f reflect.StructField) []string {
+	tag := f.Tag.Get("json")
+	if tag != "" {
+		// "name,omitempty" or "name"
+		if i := indexByte(tag, ','); i >= 0 {
+			tag = tag[:i]
+		}
+		if tag == "-" {
+			return nil
+		}
+		if tag != "" {
+			return []string{tag}
+		}
+	}
+	return []string{f.Name, toLowerFirst(f.Name)}
+}
+
+// protoFieldNames returns the JSON key candidates for a protobuf field:
+// protojson accepts both the json_name and the original proto field name.
+func protoFieldNames(fd protoreflect.FieldDescriptor) []string {
+	return []string{fd.JSONName(), string(fd.Name())}
+}
+
+func indexByte(s string, b byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func toLowerFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	b := []byte(s)
+	if b[0] >= 'A' && b[0] <= 'Z' {
+		b[0] = b[0] + ('a' - 'A')
+	}
+	return string(b)
+}

--- a/config/coerce_test.go
+++ b/config/coerce_test.go
@@ -1,0 +1,232 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	testcomplex "github.com/go-kratos/kratos/v3/internal/testdata/complex"
+)
+
+// bootstrap mirrors the struct used in the issue repro (go-kratos/kratos#3881).
+type bootstrapStruct struct {
+	Debug   bool   `json:"debug"`
+	Port    int    `json:"port"`
+	Level   string `json:"level"`
+	Version string `json:"version"`
+}
+
+// envLikeSource emits format-less KeyValues exactly like the env source does.
+type envLikeSource struct {
+	keys map[string]string
+}
+
+func (e *envLikeSource) Load() ([]*KeyValue, error) {
+	var kvs []*KeyValue
+	for k, v := range e.keys {
+		kvs = append(kvs, &KeyValue{Key: k, Value: []byte(v)})
+	}
+	return kvs, nil
+}
+
+func (e *envLikeSource) Watch() (Watcher, error) {
+	return newTestWatcher(make(chan struct{}), make(chan struct{})), nil
+}
+
+// TestScan_EnvBoolOverride reproduces the issue: a bool field overridden from
+// the environment must be accepted by Scan instead of failing with
+// "json: cannot unmarshal string into Go struct field ... of type bool".
+func TestScan_EnvBoolOverride(t *testing.T) {
+	fileSrc := newTestJSONSource(`{
+		"debug": false,
+		"port": 8000,
+		"level": "info",
+		"version": "1234"
+	}`)
+	envSrc := &envLikeSource{keys: map[string]string{
+		"debug":   "true",
+		"level":   "debug",
+		"version": "1234",
+	}}
+
+	c := New(WithSource(fileSrc, envSrc))
+	defer c.Close()
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+	var bc bootstrapStruct
+	if err := c.Scan(&bc); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if !bc.Debug {
+		t.Errorf("expect Debug=true, got %v", bc.Debug)
+	}
+	if bc.Port != 8000 {
+		t.Errorf("expect Port=8000, got %v", bc.Port)
+	}
+	if bc.Level != "debug" {
+		t.Errorf("expect Level=debug, got %q", bc.Level)
+	}
+	// numeric-looking string must stay a string, not become a number.
+	if bc.Version != "1234" {
+		t.Errorf("expect Version=\"1234\" (string), got %T(%v)", bc.Version, bc.Version)
+	}
+}
+
+// TestScan_EnvIntOverride checks int fields are coerced from env strings too.
+func TestScan_EnvIntOverride(t *testing.T) {
+	fileSrc := newTestJSONSource(`{"port": 8000}`)
+	envSrc := &envLikeSource{keys: map[string]string{"port": "9000"}}
+
+	c := New(WithSource(fileSrc, envSrc))
+	defer c.Close()
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+	var bc struct {
+		Port int `json:"port"`
+	}
+	if err := c.Scan(&bc); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if bc.Port != 9000 {
+		t.Errorf("expect Port=9000, got %v", bc.Port)
+	}
+}
+
+// TestScan_EnvNestedStruct checks coercion inside nested structs.
+func TestScan_EnvNestedStruct(t *testing.T) {
+	fileSrc := newTestJSONSource(`{
+		"server": {
+			"http": {"addr": "0.0.0.0", "port": 8080, "enable_ssl": false, "timeout": 0.5}
+		}
+	}`)
+	envSrc := &envLikeSource{keys: map[string]string{
+		"server.http.enable_ssl": "true",
+		"server.http.timeout":    "1.5",
+	}}
+
+	c := New(WithSource(fileSrc, envSrc))
+	defer c.Close()
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+	var sc struct {
+		Server struct {
+			HTTP struct {
+				Addr      string  `json:"addr"`
+				Port      int     `json:"port"`
+				EnableSSL bool    `json:"enable_ssl"`
+				Timeout   float64 `json:"timeout"`
+			} `json:"http"`
+		} `json:"server"`
+	}
+	if err := c.Scan(&sc); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if !sc.Server.HTTP.EnableSSL {
+		t.Error("expect EnableSSL=true")
+	}
+	if sc.Server.HTTP.Timeout != 1.5 {
+		t.Errorf("expect Timeout=1.5, got %v", sc.Server.HTTP.Timeout)
+	}
+	if sc.Server.HTTP.Port != 8080 {
+		t.Errorf("expect Port=8080, got %v", sc.Server.HTTP.Port)
+	}
+}
+
+// TestScan_ProtoBoolOverride reproduces the proto path from the issue:
+// protojson accepts a quoted string for every scalar kind except bool.
+func TestScan_ProtoBoolOverride(t *testing.T) {
+	fileSrc := newTestJSONSource(`{"b": false, "age": 30, "count": 100}`)
+	envSrc := &envLikeSource{keys: map[string]string{
+		"b":     "true",
+		"age":   "42",
+		"count": "7",
+	}}
+
+	c := New(WithSource(fileSrc, envSrc))
+	defer c.Close()
+	if err := c.Load(); err != nil {
+		t.Fatal(err)
+	}
+	var msg testcomplex.Complex
+	if err := c.Scan(&msg); err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	if !msg.GetB() {
+		t.Error("expect B=true")
+	}
+	if msg.GetAge() != 42 {
+		t.Errorf("expect Age=42, got %d", msg.GetAge())
+	}
+	if msg.GetCount() != 7 {
+		t.Errorf("expect Count=7, got %d", msg.GetCount())
+	}
+}
+
+// TestConvertStringLeaf covers the no-text-guessing contract: numeric-looking
+// strings targeting string fields must never be converted.
+func TestConvertStringLeaf(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  any
+		typ    reflect.Type
+		want   any
+		wantOk bool
+	}{
+		{name: "bool true", value: "true", typ: reflect.TypeOf(false), want: true, wantOk: true},
+		{name: "bool false", value: "false", typ: reflect.TypeOf(false), want: false, wantOk: true},
+		{name: "bool invalid", value: "yes", typ: reflect.TypeOf(false), want: "yes", wantOk: false},
+		{name: "int", value: "42", typ: reflect.TypeOf(int(0)), want: int64(42), wantOk: true},
+		{name: "int invalid", value: "abc", typ: reflect.TypeOf(int(0)), want: "abc", wantOk: false},
+		{name: "uint32", value: "7", typ: reflect.TypeOf(uint32(0)), want: uint64(7), wantOk: true},
+		{name: "float", value: "1.5", typ: reflect.TypeOf(0.0), want: 1.5, wantOk: true},
+		{name: "string numeric stays", value: "1234", typ: reflect.TypeOf(""), want: "1234", wantOk: false},
+		{name: "string normal stays", value: "info", typ: reflect.TypeOf(""), want: "info", wantOk: false},
+		{name: "non-string leaf", value: 42, typ: reflect.TypeOf(int(0)), want: 42, wantOk: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := convertStringLeaf(tt.value, tt.typ)
+			if ok != tt.wantOk {
+				t.Fatalf("convertStringLeaf(%v, %v) ok = %v, want %v", tt.value, tt.typ, ok, tt.wantOk)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertStringLeaf(%v, %v) = %v, want %v", tt.value, tt.typ, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCoerceScalarTypes_NoChange verifies that a config with no string leaves
+// needing conversion round-trips byte-identically (no spurious rewrite).
+func TestCoerceScalarTypes_NoChange(t *testing.T) {
+	data := []byte(`{"debug":false,"port":8000,"level":"info"}`)
+	got, err := coerceScalarTypes(data, &bootstrapStruct{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("no-change config was rewritten: got %s", got)
+	}
+}
+
+// TestCoerceScalarTypes_ProtoSnakeNames checks protojson accepts the proto field
+// name (snake_case or json_name) when the source emits dotted env keys.
+func TestCoerceScalarTypes_ProtoSnakeNames(t *testing.T) {
+	var msg testcomplex.Complex
+	data := []byte(`{"no_one":"x","b":"true"}`)
+	got, err := coerceScalarTypes(data, &msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `"b":true`) {
+		t.Errorf("expect b coerced to true, got %s", got)
+	}
+	if strings.Contains(string(got), `"no_one"`) == false {
+		t.Errorf("string field no_one should be untouched, got %s", got)
+	}
+	_ = json.Valid(got)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -133,6 +133,13 @@ func (c *config) Scan(v any) error {
 	if err != nil {
 		return err
 	}
+	// Sources that deliver every value as a string (e.g. env) would make
+	// unmarshalling reject typed fields (bool/int/float). Coerce string leaves
+	// to the types declared by the destination before decoding.
+	data, err = coerceScalarTypes(data, v)
+	if err != nil {
+		return err
+	}
 	return unmarshalJSON(data, v)
 }
 


### PR DESCRIPTION
## What

`Config.Scan` now coerces string leaf values (typically delivered by the `env` source) to the scalar types declared by the destination, so environment overrides of `bool`/`int`/`float` fields load successfully instead of failing with:

```
json: cannot unmarshal string into Go struct field Bootstrap.debug of type bool
```

with a protobuf destination the failure was:

```
proto: invalid value for bool field debug: "true"
```

## Why

`config/env` emits every value as a string. The existing `convertToType` machinery is only reachable through `${...}` placeholder syntax, so a plain `APP_debug=true` override is never converted. Guessing the type from the value text (`"true"` → bool, `"1234"` → number) was explicitly ruled out in #3881 because it mistypes credentials/ports/versions that happen to look numeric.

This PR follows the reporter's proposed design: coerce at **scan time**, driven by the destination's declared type — struct field types via reflection, protobuf field kinds via the message descriptor. Coercion only fires when a leaf is a string AND the destination kind is bool/numeric AND the string parses; string fields are never touched.

## Tests

- `TestScan_EnvBoolOverride` — issue repro (bool+string+int fields, numeric-looking string stays a string)
- `TestScan_EnvIntOverride` — int coercion
- `TestScan_EnvNestedStruct` — nested struct coercion incl. bool + float64
- `TestScan_ProtoBoolOverride` — protobuf path (`complex.Complex`: bool, int32, uint64)
- `TestConvertStringLeaf` — unit table incl. no-text-guessing contract
- `TestCoerceScalarTypes_NoChange` — unchanged config is byte-identical round-trip

Fixes #3881
